### PR TITLE
Fix figures in AIR tutorial.

### DIFF
--- a/tutorial/source/air.ipynb
+++ b/tutorial/source/air.ipynb
@@ -73,10 +73,29 @@
     "\n",
     "AIR decomposes the process of generating an image into discrete steps, each of which generates only part of the image. More specifically, at each step the model will generate a small image (`y_att`) by passing a latent \"code\" variable (`z_what`) through a neural network. We'll refer to these small images as \"objects\". In the case of AIR applied to the multi-mnist dataset we expect each of these objects to represent a single digit. The model also includes uncertainty about the location and size of each object. We'll describe an object's location and size as its \"pose\" (`z_where`). To produce the final image, each object will first be located within a larger image (`y`) using the pose infomation `z_where`. Finally, the `y`s from all time steps will be combined additively to produce the final image `x`.\n",
     "\n",
-    "Here's a picture (reproduced from [1]) that shows two steps of this process:\n",
-    "\n",
-    "<img src='_static/img/model-generative.png' style='width: 35%;' />\n",
-    "\n",
+    "Here's a picture (reproduced from [1]) that shows two steps of this process:"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/html"
+   },
+   "source": [
+    "<center>\n",
+    "<figure style='padding: 0 0 1em'>\n",
+    "<img src='_static/img/model-generative.png' style='width: 35%;'>\n",
+    "<figcaption style='font-size: 90%; padding: 0.5em 0 0'>\n",
+    "<b>Figure 1:</b> Two steps of the generative process.\n",
+    "</figcaption>\n",
+    "</figure>\n",
+    "</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Inference is performed in this model using [amortized stochastic variational inference](svi_part_i.html) (SVI). The parameters of the neural network are also optimized during inference. Performing inference in such rich models is always difficult, but the presence of discrete choices (the number of steps in this case) makes inference in this model particularly tricky. For this reason the authors use a technique called data dependent baselines to achieve good performance. This technique can be implemented in Pyro, and we'll see how later in the tutorial.\n",
     "\n",
     "## Model\n",
@@ -613,10 +632,29 @@
     "\n",
     "So far we've considered the model and the guide in isolation, but we gain an interesting perspective if we zoom out and look at the model and guide computation as a whole. Doing so, we see that at each step AIR includes a sub-computation that has the same structure as a [Variational Auto-encoder](vae.html) (VAE).\n",
     "\n",
-    "To see this, notice that the guide passes the window through a neural network (the encoder) to generate the parameters of the distribution over a latent code, and the model passes samples from this latent code distribution through another neural network (the decoder) to generate an output window. This structure is highlighted in the following figure, reproduced from [1]:\n",
-    "\n",
-    "<img src='_static/img/model-micro.png' style='width: 35%; padding: 1em 0 1em' />\n",
-    "\n",
+    "To see this, notice that the guide passes the window through a neural network (the encoder) to generate the parameters of the distribution over a latent code, and the model passes samples from this latent code distribution through another neural network (the decoder) to generate an output window. This structure is highlighted in the following figure, reproduced from [1]:"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/html"
+   },
+   "source": [
+    "<center>\n",
+    "<figure style='padding: 0 0 1em'>\n",
+    "<img src='_static/img/model-micro.png' style='width: 35%;'>\n",
+    "<figcaption style='font-size: 90%; padding: 0.5em 0 0'>\n",
+    "<b>Figure 2:</b> Interaction between the guide and model at each step.\n",
+    "</figcaption>\n",
+    "</figure>\n",
+    "</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "From this perspective AIR is seen as a sequential variant of the VAE. The act of cropping a small window from the input image serves to restrict the attention of a VAE to a small region of the input image at each step; hence \"Attend, Infer, Repeat\".\n",
     "\n",
     "## Inference\n",
@@ -777,12 +815,28 @@
     "This section will be updated with more results.\n",
     "</div>\n",
     "\n",
-    "The following images show the progress made by our [standalone implementation](https://github.com/uber/pyro/tree/dev/examples/air) during an inference run. The top image shows four data points from the training set. The bottom image is a visualization of a sample from the guide (for these data points) that shows the values sampled for `z_pres` and `z_where`. It also shows reconstructions of the input obtained by passing the sample from the guide back through the model to generate an output image.\n",
-    "\n",
-    "<img src='_static/img/air_inputs.jpg' />\n",
-    "\n",
-    "<img src='_static/img/air_reconstructions.jpg' />\n",
-    "\n",
+    "The following images show the progress made by our [standalone implementation](https://github.com/uber/pyro/tree/dev/examples/air) during an inference run. The top image shows four data points from the training set. The bottom image is a visualization of a sample from the guide (for these data points) that shows the values sampled for `z_pres` and `z_where`. It also shows reconstructions of the input obtained by passing the sample from the guide back through the model to generate an output image."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/html"
+   },
+   "source": [
+    "<center>\n",
+    "<figure style='padding: 0 0 1em'>\n",
+    "<div style='padding: 0 0 0.5em'><img src=\"_static/img/air_inputs.jpg\" /></div>\n",
+    "<div><img src=\"_static/img/air_reconstructions.jpg\" /></div>\n",
+    "<figcaption style='font-size: 90%; padding: 0.5em 0 0'><b>Figure 3:</b> <i>Top:</i> Multi-mnist data points. <i>Bottom:</i> Visualization of a sample from the guide and the model's reconstruction of the input.</figcaption>\n",
+    "</figure>\n",
+    "</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Note that at this stage of inference the locations of most of the digits are inferred accurately but object counts are not.\n",
     "\n",
     "## References\n",


### PR DESCRIPTION
This makes the figures in the AIR tutorial show up in the HTML build. (Following the lead of e.g. #488.)