### PR TITLE
Make pyro.distributions.util.log_gamma compatible with Tensors

### DIFF
--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -6,10 +6,9 @@ from torch.autograd import Variable
 
 
 def log_gamma(xx):
-    if isinstance(xx, Variable):
-        ttype = xx.data.type()
-    elif isinstance(xx, torch.Tensor):
-        ttype = xx.type()
+    if isinstance(xx, torch.Tensor):
+        xx = Variable(xx)
+    ttype = xx.data.type()
     gamma_coeff = [
         76.18009172947146,
         -86.50532032941677,


### PR DESCRIPTION
Current implementation of log_gamma is not compatible with Tensors i.e. `log_gamma(torch.ones(1))` throws:

```
RuntimeError: add() received an invalid combination of arguments - got (torch.FloatTensor), but expected one of:
 * (float other, float alpha)
 * (Variable other, float alpha)
```