### PR TITLE
Fix sum variable with dim = -1 torch error

### DIFF
--- a/pyro/distributions/normal.py
+++ b/pyro/distributions/normal.py
@@ -88,7 +88,7 @@ class Normal(Distribution):
         # will likely be done in a better/cleaner way in the future
         if self.log_pdf_mask is not None:
             log_pxs = log_pxs * self.log_pdf_mask
-        batch_log_pdf = torch.sum(log_pxs, -1)
+        batch_log_pdf = torch.sum(log_pxs, log_pxs.dim() - 1)
         batch_log_pdf_shape = self.batch_shape(x) + (1,)
         return batch_log_pdf.contiguous().view(batch_log_pdf_shape)
 


### PR DESCRIPTION
From the dev branch:
Using the following code snippet from the tuturial,
```
mu = Variable(torch.zeros(1))   # mean zero
sigma = Variable(torch.ones(1)) # unit variance
x = dist.normal(mu, sigma)      # x is a sample from N(0,1)
log_p_x = dist.normal.log_pdf(x, mu, sigma)
```
We observe a PyTorch error:
`RuntimeError: dimension -1 out of range at pytorch/torch/lib/TH/generic/THTensorMath.c:1622`