### PR TITLE
Minor changes to travis to make build faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 language: python
 
-sudo: required
+sudo: false
 
 env:
     global:
         - PYTHONPATH=$PWD:$PYTHONPATH
-
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
 
 install:
     # install pytorch and its dependencies
@@ -44,13 +40,13 @@ jobs:
               - make docs
         - python: 2.7
           env: STAGE=unit
-          script: pytest -vs --cov=pyro --stage unit
+          script: pytest -vs -n auto --cov=pyro --stage unit
         - python: 2.7
           env: STAGE=examples
           script: pytest -vs --cov=pyro --stage test_examples
         - python: 3.5
           env: STAGE=unit
-          script: pytest -vs --cov=pyro --stage unit
+          script: pytest -vs -n auto --cov=pyro --stage unit
         - python: 3.5
           env: STAGE=examples
           script: pytest -vs --cov=pyro --stage test_examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,26 +40,26 @@ jobs:
               - make docs
         - python: 2.7
           env: STAGE=unit
-          script: pytest -vs -n 4 --cov=pyro --stage unit
+          script: pytest -vs -n 2 --cov=pyro --stage unit
         - python: 2.7
           env: STAGE=examples
           script: pytest -vs --cov=pyro --stage test_examples
         - python: 3.5
           env: STAGE=unit
-          script: pytest -vs -n 4 --cov=pyro --stage unit
+          script: pytest -vs -n 2 --cov=pyro --stage unit
         - python: 3.5
           env: STAGE=examples
           script: pytest -vs --cov=pyro --stage test_examples
         - stage: integration test
           python: 2.7
           env: STAGE=integration_batch_1
-          script: pytest -vs -n 4 --cov=pyro --stage integration_batch_1
+          script: pytest -vs -n 2 --cov=pyro --stage integration_batch_1
         - python: 2.7
           env: STAGE=integration_batch_2
-          script: pytest -vs -n 4 --cov=pyro --stage integration_batch_2
+          script: pytest -vs -n 2 --cov=pyro --stage integration_batch_2
         - python: 3.5
           env: STAGE=integration_batch_1
-          script: pytest -vs -n 4 --cov=pyro --stage integration_batch_1
+          script: pytest -vs -n 2 --cov=pyro --stage integration_batch_1
         - python: 3.5
           env: STAGE=integration_batch_2
-          script: pytest -vs -n 4 --cov=pyro --stage integration_batch_2
+          script: pytest -vs -n 2 --cov=pyro --stage integration_batch_2

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,33 +40,26 @@ jobs:
               - make docs
         - python: 2.7
           env: STAGE=unit
-          script: pytest -vs -n auto --cov=pyro --stage unit
+          script: pytest -vs -n 4 --cov=pyro --stage unit
         - python: 2.7
           env: STAGE=examples
           script: pytest -vs --cov=pyro --stage test_examples
         - python: 3.5
           env: STAGE=unit
-          script: pytest -vs -n auto --cov=pyro --stage unit
+          script: pytest -vs -n 4 --cov=pyro --stage unit
         - python: 3.5
           env: STAGE=examples
           script: pytest -vs --cov=pyro --stage test_examples
-        - python: 2.7
-          env: STAGE=tutorials
-          script: pytest -v --nbval-lax tutorial/
         - stage: integration test
           python: 2.7
           env: STAGE=integration_batch_1
-          script: pytest -vs --cov=pyro --stage integration_batch_1
+          script: pytest -vs -n 4 --cov=pyro --stage integration_batch_1
         - python: 2.7
           env: STAGE=integration_batch_2
-          script: pytest -vs --cov=pyro --stage integration_batch_2
+          script: pytest -vs -n 4 --cov=pyro --stage integration_batch_2
         - python: 3.5
           env: STAGE=integration_batch_1
-          script: pytest -vs --cov=pyro --stage integration_batch_1
+          script: pytest -vs -n 4 --cov=pyro --stage integration_batch_1
         - python: 3.5
           env: STAGE=integration_batch_2
-          script: pytest -vs --cov=pyro --stage integration_batch_2
-    allow_failures:
-        - python: 2.7
-          env: STAGE=tutorials
-          script: pytest -v --nbval-lax tutorial/
+          script: pytest -vs -n 4 --cov=pyro --stage integration_batch_2

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'test': [
             'pytest',
             'pytest-cov',
+            'pytest-xdist',
             'nbval',
             # examples/tutorials
             'visdom',


### PR DESCRIPTION
Makes the following changes to the test utilities:
 - sets `sudo: false`. This allows us to use dockerized instances that have 2 cores available (invoking pytest-xdist with `n=2`), and have reportedly faster build start times. 
 - Removes the tutorials stage (currently failing) - should be reinstated soon #525.

I see a definite, though small improvement in test time. We can merge this and continue to fine-tune travis.yml as needed.