### PR TITLE
Show master build status on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ----------------------------------------------------------------
 
-[![Build Status](https://travis-ci.org/uber/pyro.svg?branch=dev)](https://travis-ci.org/uber/pyro)
+[![Build Status](https://travis-ci.org/uber/pyro.svg?branch=master)](https://travis-ci.org/uber/pyro)
 [![Latest Version](https://badge.fury.io/py/pyro-ppl.svg)](https://pypi.python.org/pypi/pyro-ppl)
 
 


### PR DESCRIPTION
This switches the travis badge from the dev branch to the master branch.

## Why?

The dev badge is mostly red due to unresolved issues from migrating from travis-ci.org to travis-ci.com #514 . This PR switches the build badge to point to the branch that users would get when they `git clone` Pyro, i.e. the `master` branch. We may add an additional `dev` badge once we resolve CI issues.

Tests cancelled.