### PR TITLE
Fix flaky test in test_enum.py

### DIFF
--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -186,7 +186,7 @@ def finite_difference(eval_loss, delta=0.1):
     params = pyro.get_param_store().get_all_param_names()
     assert params, "no params found"
     grads = {name: Variable(torch.zeros(pyro.param(name).size())) for name in params}
-    for name in params:
+    for name in sorted(params):
         value = pyro.param(name).data
         for index in itertools.product(*map(range, value.size())):
             center = value[index]


### PR DESCRIPTION
Fixes #514 

The only issue that I have noticed so far that results in non-determinism is the order in which the parameters are considered for computing the gradient using finite difference. Once the order is fixed, this should yield the same result each time (checked this locally). If the order is not fixed, then the model may sample different values for each ordering, resulting in fluctuating results for the expected values.