### PR TITLE
Simplify TraceGraph_ELBO.loss_and_grads()

### DIFF
--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -97,202 +97,203 @@ class TraceGraph_ELBO(object):
         Performs backward on the latter. Num_particle many samples are used to form the estimators.
         If baselines are present, a baseline loss is also constructed and differentiated.
         """
-        elbo = 0.0
-
+        loss = 0.0
         for weight, model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+            loss += self._loss_and_grads_particle(weight, model_trace, guide_trace)
+        return loss
 
-            # get info regarding rao-blackwellization of vectorized map_data
-            guide_vec_md_info = guide_trace.graph["vectorized_map_data_info"]
-            model_vec_md_info = model_trace.graph["vectorized_map_data_info"]
-            guide_vec_md_condition = guide_vec_md_info['rao-blackwellization-condition']
-            model_vec_md_condition = model_vec_md_info['rao-blackwellization-condition']
-            do_vec_rb = guide_vec_md_condition and model_vec_md_condition
-            if not do_vec_rb:
-                warnings.warn(
-                    "Unable to do fully-vectorized Rao-Blackwellization in TraceGraph_ELBO. "
-                    "Falling back to higher-variance gradient estimator. "
-                    "Try to avoid these issues in your model and guide:\n{}".format("\n".join(
-                        guide_vec_md_info["warnings"] | model_vec_md_info["warnings"])))
-            guide_vec_md_nodes = guide_vec_md_info['nodes'] if do_vec_rb else set()
-            model_vec_md_nodes = model_vec_md_info['nodes'] if do_vec_rb else set()
+    def _loss_and_grads_particle(self, weight, model_trace, guide_trace):
+        # get info regarding rao-blackwellization of vectorized map_data
+        guide_vec_md_info = guide_trace.graph["vectorized_map_data_info"]
+        model_vec_md_info = model_trace.graph["vectorized_map_data_info"]
+        guide_vec_md_condition = guide_vec_md_info['rao-blackwellization-condition']
+        model_vec_md_condition = model_vec_md_info['rao-blackwellization-condition']
+        do_vec_rb = guide_vec_md_condition and model_vec_md_condition
+        if not do_vec_rb:
+            warnings.warn(
+                "Unable to do fully-vectorized Rao-Blackwellization in TraceGraph_ELBO. "
+                "Falling back to higher-variance gradient estimator. "
+                "Try to avoid these issues in your model and guide:\n{}".format("\n".join(
+                    guide_vec_md_info["warnings"] | model_vec_md_info["warnings"])))
+        guide_vec_md_nodes = guide_vec_md_info['nodes'] if do_vec_rb else set()
+        model_vec_md_nodes = model_vec_md_info['nodes'] if do_vec_rb else set()
 
-            # have the trace compute all the individual (batch) log pdf terms
-            # so that they are available below
-            guide_trace.compute_batch_log_pdf(site_filter=lambda name, site: name in guide_vec_md_nodes)
-            guide_trace.log_pdf()
-            model_trace.compute_batch_log_pdf(site_filter=lambda name, site: name in model_vec_md_nodes)
-            model_trace.log_pdf()
+        # have the trace compute all the individual (batch) log pdf terms
+        # so that they are available below
+        guide_trace.compute_batch_log_pdf(site_filter=lambda name, site: name in guide_vec_md_nodes)
+        guide_trace.log_pdf()
+        model_trace.compute_batch_log_pdf(site_filter=lambda name, site: name in model_vec_md_nodes)
+        model_trace.log_pdf()
 
-            # prepare a list of all the cost nodes, each of which is +- log_pdf
-            cost_nodes = []
-            non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
-            for site in model_trace.nodes.keys():
-                model_trace_site = model_trace.nodes[site]
-                log_pdf_key = 'batch_log_pdf' if site in model_vec_md_nodes else 'log_pdf'
-                if model_trace_site["type"] == "sample":
-                    if model_trace_site["is_observed"]:
-                        cost_node = (model_trace_site[log_pdf_key], True)
-                        cost_nodes.append(cost_node)
-                    else:
-                        # cost node from model sample
-                        cost_node1 = (model_trace_site[log_pdf_key], True)
-                        # cost node from guide sample
-                        zero_expectation = site in non_reparam_nodes
-                        cost_node2 = (-guide_trace.nodes[site][log_pdf_key],
-                                      not zero_expectation)
-                        cost_nodes.extend([cost_node1, cost_node2])
+        # prepare a list of all the cost nodes, each of which is +- log_pdf
+        cost_nodes = []
+        non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
+        for site in model_trace.nodes.keys():
+            model_trace_site = model_trace.nodes[site]
+            log_pdf_key = 'batch_log_pdf' if site in model_vec_md_nodes else 'log_pdf'
+            if model_trace_site["type"] == "sample":
+                if model_trace_site["is_observed"]:
+                    cost_node = (model_trace_site[log_pdf_key], True)
+                    cost_nodes.append(cost_node)
+                else:
+                    # cost node from model sample
+                    cost_node1 = (model_trace_site[log_pdf_key], True)
+                    # cost node from guide sample
+                    zero_expectation = site in non_reparam_nodes
+                    cost_node2 = (-guide_trace.nodes[site][log_pdf_key],
+                                  not zero_expectation)
+                    cost_nodes.extend([cost_node1, cost_node2])
 
-            elbo_particle = 0.0
-            surrogate_elbo_particle = 0.0
-            baseline_loss_particle = 0.0
-            elbo_reinforce_terms_particle = 0.0
-            elbo_no_zero_expectation_terms_particle = 0.0
+        elbo_particle = 0.0
+        surrogate_elbo_particle = 0.0
+        baseline_loss_particle = 0.0
+        elbo_reinforce_terms_particle = 0.0
+        elbo_no_zero_expectation_terms_particle = 0.0
 
-            # compute the elbo; if all stochastic nodes are reparameterizable, we're done
-            # this bit is never differentiated: it's here for getting an estimate of the elbo itself
-            for cost_node in cost_nodes:
-                elbo_particle += cost_node[0].sum()
-            elbo += weight * torch_data_sum(elbo_particle)
+        # compute the elbo; if all stochastic nodes are reparameterizable, we're done
+        # this bit is never differentiated: it's here for getting an estimate of the elbo itself
+        for cost_node in cost_nodes:
+            elbo_particle += cost_node[0].sum()
+        elbo = weight * torch_data_sum(elbo_particle)
 
-            # compute the elbo, removing terms whose gradient is zero
-            # this is the bit that's actually differentiated
-            # XXX should the user be able to control if these terms are included?
-            for cost_node in cost_nodes:
-                if cost_node[1]:
-                    elbo_no_zero_expectation_terms_particle += cost_node[0].sum()
-            surrogate_elbo_particle += weight * elbo_no_zero_expectation_terms_particle
+        # compute the elbo, removing terms whose gradient is zero
+        # this is the bit that's actually differentiated
+        # XXX should the user be able to control if these terms are included?
+        for cost_node in cost_nodes:
+            if cost_node[1]:
+                elbo_no_zero_expectation_terms_particle += cost_node[0].sum()
+        surrogate_elbo_particle += weight * elbo_no_zero_expectation_terms_particle
 
-            # the following computations are only necessary if we have non-reparameterizable nodes
-            if len(non_reparam_nodes) > 0:
+        # the following computations are only necessary if we have non-reparameterizable nodes
+        if len(non_reparam_nodes) > 0:
 
-                # recursively compute downstream cost nodes for all sample sites in model and guide
-                # (even though ultimately just need for non-reparameterizable sample sites)
-                # 1. downstream costs used for rao-blackwellization
-                # 2. model observe sites (as well as terms that arise from the model and guide having different
-                # dependency structures) are taken care of via 'children_in_model' below
-                topo_sort_guide_nodes = list(reversed(list(networkx.topological_sort(guide_trace))))
-                topo_sort_guide_nodes = [x for x in topo_sort_guide_nodes
-                                         if guide_trace.nodes[x]["type"] == "sample"]
-                downstream_guide_cost_nodes = {}
-                downstream_costs = {}
+            # recursively compute downstream cost nodes for all sample sites in model and guide
+            # (even though ultimately just need for non-reparameterizable sample sites)
+            # 1. downstream costs used for rao-blackwellization
+            # 2. model observe sites (as well as terms that arise from the model and guide having different
+            # dependency structures) are taken care of via 'children_in_model' below
+            topo_sort_guide_nodes = list(reversed(list(networkx.topological_sort(guide_trace))))
+            topo_sort_guide_nodes = [x for x in topo_sort_guide_nodes
+                                     if guide_trace.nodes[x]["type"] == "sample"]
+            downstream_guide_cost_nodes = {}
+            downstream_costs = {}
 
-                for node in topo_sort_guide_nodes:
-                    node_log_pdf_key = 'batch_log_pdf' if node in guide_vec_md_nodes else 'log_pdf'
-                    downstream_costs[node] = model_trace.nodes[node][node_log_pdf_key] - \
-                        guide_trace.nodes[node][node_log_pdf_key]
-                    nodes_included_in_sum = set([node])
-                    downstream_guide_cost_nodes[node] = set([node])
-                    for child in guide_trace.successors(node):
-                        child_cost_nodes = downstream_guide_cost_nodes[child]
-                        downstream_guide_cost_nodes[node].update(child_cost_nodes)
-                        if nodes_included_in_sum.isdisjoint(child_cost_nodes):  # avoid duplicates
-                            if node_log_pdf_key == 'log_pdf':
-                                downstream_costs[node] += downstream_costs[child].sum()
-                            else:
-                                downstream_costs[node] += downstream_costs[child]
-                            nodes_included_in_sum.update(child_cost_nodes)
-                    missing_downstream_costs = downstream_guide_cost_nodes[node] - nodes_included_in_sum
-                    # include terms we missed because we had to avoid duplicates
-                    for missing_node in missing_downstream_costs:
-                        mn_log_pdf_key = 'batch_log_pdf' if missing_node in guide_vec_md_nodes else 'log_pdf'
+            for node in topo_sort_guide_nodes:
+                node_log_pdf_key = 'batch_log_pdf' if node in guide_vec_md_nodes else 'log_pdf'
+                downstream_costs[node] = model_trace.nodes[node][node_log_pdf_key] - \
+                    guide_trace.nodes[node][node_log_pdf_key]
+                nodes_included_in_sum = set([node])
+                downstream_guide_cost_nodes[node] = set([node])
+                for child in guide_trace.successors(node):
+                    child_cost_nodes = downstream_guide_cost_nodes[child]
+                    downstream_guide_cost_nodes[node].update(child_cost_nodes)
+                    if nodes_included_in_sum.isdisjoint(child_cost_nodes):  # avoid duplicates
                         if node_log_pdf_key == 'log_pdf':
-                            downstream_costs[node] += (model_trace.nodes[missing_node][mn_log_pdf_key] -
-                                                       guide_trace.nodes[missing_node][mn_log_pdf_key]).sum()
+                            downstream_costs[node] += downstream_costs[child].sum()
                         else:
-                            downstream_costs[node] += model_trace.nodes[missing_node][mn_log_pdf_key] - \
-                                                      guide_trace.nodes[missing_node][mn_log_pdf_key]
-
-                # finish assembling complete downstream costs
-                # (the above computation may be missing terms from model)
-                # XXX can we cache some of the sums over children_in_model to make things more efficient?
-                for site in non_reparam_nodes:
-                    children_in_model = set()
-                    for node in downstream_guide_cost_nodes[site]:
-                        children_in_model.update(model_trace.successors(node))
-                    # remove terms accounted for above
-                    children_in_model.difference_update(downstream_guide_cost_nodes[site])
-                    for child in children_in_model:
-                        child_log_pdf_key = 'batch_log_pdf' if child in model_vec_md_nodes else 'log_pdf'
-                        site_log_pdf_key = 'batch_log_pdf' if site in guide_vec_md_nodes else 'log_pdf'
-                        assert (model_trace.nodes[child]["type"] == "sample")
-                        if site_log_pdf_key == 'log_pdf':
-                            downstream_costs[site] += model_trace.nodes[child][child_log_pdf_key].sum()
-                        else:
-                            downstream_costs[site] += model_trace.nodes[child][child_log_pdf_key]
-
-                # construct all the reinforce-like terms.
-                # we include only downstream costs to reduce variance
-                # optionally include baselines to further reduce variance
-                # XXX should the average baseline be in the param store as below?
-
-                # for extracting baseline options from site["baseline"]
-                # XXX default for baseline_beta currently set here
-                def get_baseline_options(site_baseline):
-                    options_dict = site_baseline.copy()
-                    options_tuple = (options_dict.pop('nn_baseline', None),
-                                     options_dict.pop('nn_baseline_input', None),
-                                     options_dict.pop('use_decaying_avg_baseline', False),
-                                     options_dict.pop('baseline_beta', 0.90),
-                                     options_dict.pop('baseline_value', None))
-                    if options_dict:
-                        raise ValueError("Unrecognized baseline options: {}".format(options_dict.keys()))
-                    return options_tuple
-
-                baseline_loss_particle = 0.0
-                for node in non_reparam_nodes:
-                    log_pdf_key = 'batch_log_pdf' if node in guide_vec_md_nodes else 'log_pdf'
-                    downstream_cost = downstream_costs[node]
-                    baseline = 0.0
-                    (nn_baseline, nn_baseline_input, use_decaying_avg_baseline, baseline_beta,
-                        baseline_value) = get_baseline_options(guide_trace.nodes[node]["baseline"])
-                    use_nn_baseline = nn_baseline is not None
-                    use_baseline_value = baseline_value is not None
-                    assert(not (use_nn_baseline and use_baseline_value)), \
-                        "cannot use baseline_value and nn_baseline simultaneously"
-                    if use_decaying_avg_baseline:
-                        avg_downstream_cost_old = pyro.param("__baseline_avg_downstream_cost_" + node,
-                                                             ng_zeros(1), tags="__tracegraph_elbo_internal_tag")
-                        avg_downstream_cost_new = (1 - baseline_beta) * downstream_cost + \
-                            baseline_beta * avg_downstream_cost_old
-                        avg_downstream_cost_old.data = avg_downstream_cost_new.data  # XXX copy_() ?
-                        baseline += avg_downstream_cost_old
-                    if use_nn_baseline:
-                        # block nn_baseline_input gradients except in baseline loss
-                        baseline += nn_baseline(detach_iterable(nn_baseline_input))
-                    elif use_baseline_value:
-                        # it's on the user to make sure baseline_value tape only points to baseline params
-                        baseline += baseline_value
-                    if use_nn_baseline or use_baseline_value:
-                        # construct baseline loss
-                        baseline_loss = torch.pow(downstream_cost.detach() - baseline, 2.0).sum()
-                        baseline_loss_particle += weight * baseline_loss
-
-                    guide_site = guide_trace.nodes[node]
-                    guide_log_pdf = guide_site[log_pdf_key] / guide_site["scale"]  # not scaled by subsampling
-                    if use_nn_baseline or use_decaying_avg_baseline or use_baseline_value:
-                        if downstream_cost.size() != baseline.size():
-                            raise ValueError("Expected baseline at site {} to be {} instead got {}".format(
-                                node, downstream_cost.size(), baseline.size()))
-                        elbo_reinforce_terms_particle += (guide_log_pdf * (downstream_cost - baseline).detach()).sum()
+                            downstream_costs[node] += downstream_costs[child]
+                        nodes_included_in_sum.update(child_cost_nodes)
+                missing_downstream_costs = downstream_guide_cost_nodes[node] - nodes_included_in_sum
+                # include terms we missed because we had to avoid duplicates
+                for missing_node in missing_downstream_costs:
+                    mn_log_pdf_key = 'batch_log_pdf' if missing_node in guide_vec_md_nodes else 'log_pdf'
+                    if node_log_pdf_key == 'log_pdf':
+                        downstream_costs[node] += (model_trace.nodes[missing_node][mn_log_pdf_key] -
+                                                   guide_trace.nodes[missing_node][mn_log_pdf_key]).sum()
                     else:
-                        elbo_reinforce_terms_particle += (guide_log_pdf * downstream_cost.detach()).sum()
+                        downstream_costs[node] += model_trace.nodes[missing_node][mn_log_pdf_key] - \
+                                                  guide_trace.nodes[missing_node][mn_log_pdf_key]
 
-                surrogate_elbo_particle += weight * elbo_reinforce_terms_particle
-                torch_backward(baseline_loss_particle)
+            # finish assembling complete downstream costs
+            # (the above computation may be missing terms from model)
+            # XXX can we cache some of the sums over children_in_model to make things more efficient?
+            for site in non_reparam_nodes:
+                children_in_model = set()
+                for node in downstream_guide_cost_nodes[site]:
+                    children_in_model.update(model_trace.successors(node))
+                # remove terms accounted for above
+                children_in_model.difference_update(downstream_guide_cost_nodes[site])
+                for child in children_in_model:
+                    child_log_pdf_key = 'batch_log_pdf' if child in model_vec_md_nodes else 'log_pdf'
+                    site_log_pdf_key = 'batch_log_pdf' if site in guide_vec_md_nodes else 'log_pdf'
+                    assert (model_trace.nodes[child]["type"] == "sample")
+                    if site_log_pdf_key == 'log_pdf':
+                        downstream_costs[site] += model_trace.nodes[child][child_log_pdf_key].sum()
+                    else:
+                        downstream_costs[site] += model_trace.nodes[child][child_log_pdf_key]
 
-            # collect parameters to train from model and guide
-            trainable_params = set(site["value"]
-                                   for trace in (model_trace, guide_trace)
-                                   for site in trace.nodes.values()
-                                   if site["type"] == "param")
+            # construct all the reinforce-like terms.
+            # we include only downstream costs to reduce variance
+            # optionally include baselines to further reduce variance
+            # XXX should the average baseline be in the param store as below?
 
-            surrogate_loss_particle = -surrogate_elbo_particle
-            if trainable_params:
-                torch_backward(surrogate_loss_particle)
+            # for extracting baseline options from site["baseline"]
+            # XXX default for baseline_beta currently set here
+            def get_baseline_options(site_baseline):
+                options_dict = site_baseline.copy()
+                options_tuple = (options_dict.pop('nn_baseline', None),
+                                 options_dict.pop('nn_baseline_input', None),
+                                 options_dict.pop('use_decaying_avg_baseline', False),
+                                 options_dict.pop('baseline_beta', 0.90),
+                                 options_dict.pop('baseline_value', None))
+                if options_dict:
+                    raise ValueError("Unrecognized baseline options: {}".format(options_dict.keys()))
+                return options_tuple
 
-                # mark all params seen in trace as active so that gradient steps are taken downstream
-                pyro.get_param_store().mark_params_active(trainable_params)
+            baseline_loss_particle = 0.0
+            for node in non_reparam_nodes:
+                log_pdf_key = 'batch_log_pdf' if node in guide_vec_md_nodes else 'log_pdf'
+                downstream_cost = downstream_costs[node]
+                baseline = 0.0
+                (nn_baseline, nn_baseline_input, use_decaying_avg_baseline, baseline_beta,
+                    baseline_value) = get_baseline_options(guide_trace.nodes[node]["baseline"])
+                use_nn_baseline = nn_baseline is not None
+                use_baseline_value = baseline_value is not None
+                assert(not (use_nn_baseline and use_baseline_value)), \
+                    "cannot use baseline_value and nn_baseline simultaneously"
+                if use_decaying_avg_baseline:
+                    avg_downstream_cost_old = pyro.param("__baseline_avg_downstream_cost_" + node,
+                                                         ng_zeros(1), tags="__tracegraph_elbo_internal_tag")
+                    avg_downstream_cost_new = (1 - baseline_beta) * downstream_cost + \
+                        baseline_beta * avg_downstream_cost_old
+                    avg_downstream_cost_old.data = avg_downstream_cost_new.data  # XXX copy_() ?
+                    baseline += avg_downstream_cost_old
+                if use_nn_baseline:
+                    # block nn_baseline_input gradients except in baseline loss
+                    baseline += nn_baseline(detach_iterable(nn_baseline_input))
+                elif use_baseline_value:
+                    # it's on the user to make sure baseline_value tape only points to baseline params
+                    baseline += baseline_value
+                if use_nn_baseline or use_baseline_value:
+                    # construct baseline loss
+                    baseline_loss = torch.pow(downstream_cost.detach() - baseline, 2.0).sum()
+                    baseline_loss_particle += weight * baseline_loss
+
+                guide_site = guide_trace.nodes[node]
+                guide_log_pdf = guide_site[log_pdf_key] / guide_site["scale"]  # not scaled by subsampling
+                if use_nn_baseline or use_decaying_avg_baseline or use_baseline_value:
+                    if downstream_cost.size() != baseline.size():
+                        raise ValueError("Expected baseline at site {} to be {} instead got {}".format(
+                            node, downstream_cost.size(), baseline.size()))
+                    elbo_reinforce_terms_particle += (guide_log_pdf * (downstream_cost - baseline).detach()).sum()
+                else:
+                    elbo_reinforce_terms_particle += (guide_log_pdf * downstream_cost.detach()).sum()
+
+            surrogate_elbo_particle += weight * elbo_reinforce_terms_particle
+            torch_backward(baseline_loss_particle)
+
+        # collect parameters to train from model and guide
+        trainable_params = set(site["value"]
+                               for trace in (model_trace, guide_trace)
+                               for site in trace.nodes.values()
+                               if site["type"] == "param")
+
+        surrogate_loss_particle = -surrogate_elbo_particle
+        if trainable_params:
+            torch_backward(surrogate_loss_particle)
+
+            # mark all params seen in trace as active so that gradient steps are taken downstream
+            pyro.get_param_store().mark_params_active(trainable_params)
 
         loss = -elbo
-
         return loss


### PR DESCRIPTION
This is a pure-refactoring PR.

This is the first step in refactoring `TraceGraph_ELBO.loss_and_grads()` to be more flexible and easier to test. This PR just tries to simplify code before we split things up: it reduces the largest function in Pyro from 208 lines to 162 lines. The refactorings in this PR include:
- Factoring out a helper `_loss_and_grads_particle( weight, model_trace, guide_trace )`.
- Moving `_get_baseline_options()` out of `.loss_and_grads()`.
- Simplifying the `cost_nodes` calculation and adding a `CostNode` named tuple.
- Moving application of `weight` to the end of the function.
- Calling `torch_backward` on a combination of `surrogate_loss` and `baseline_loss`, rather than invoking `torch_backward` twice.
- Miscellaneous simplifications.

@martinjankowiak Let me know if you want to discuss these superficial changes. Github's diff engine is having trouble, so I recommend reviewing the commits individually
1. [almost pure copy-and-outdent](https://github.com/uber/pyro/pull/536/commits/4378f069725f33089c7207ab95ef77ee5c3afc96)
2. [remove `_particle` suffixes, simplify sums](https://github.com/uber/pyro/pull/536/commits/74a177ceee9f46871530311cc1f0014a3d394682)
3. [simplify `cost_node` computation](https://github.com/uber/pyro/pull/536/commits/3d17e72bf0826a8ae94ed845fdd3bd5e55dacd69)

Or just use a better diff viewer like [Meld](http://meldmerge.org/).