### PR TITLE
Rename map_data_stack -> cond_indep_stack and reverse it

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -68,7 +68,7 @@ def sample(name, fn, *args, **kwargs):
             "value": None,
             "baseline": baseline,
             "scale": 1.0,
-            "map_data_stack": [],
+            "cond_indep_stack": [],
             "done": False,
             "stop": False,
         }
@@ -291,7 +291,7 @@ def param(name, *args, **kwargs):
             "args": args,
             "kwargs": kwargs,
             "scale": 1.0,
-            "map_data_stack": [],
+            "cond_indep_stack": [],
             "value": None,
             "done": False,
             "stop": False,

--- a/pyro/poutine/indep_poutine.py
+++ b/pyro/poutine/indep_poutine.py
@@ -11,7 +11,7 @@ class IndepPoutine(Poutine):
     """
     This poutine keeps track of stack of independence information declared by
     nested ``irange`` and ``iarange`` contexts. This information is stored in
-    a ``map_data_stack`` at each sample/observe site for consumption by
+    a ``cond_indep_stack`` at each sample/observe site for consumption by
     ``TracePoutine``.
     """
     def __init__(self, fn, name, vectorized):
@@ -34,8 +34,8 @@ class IndepPoutine(Poutine):
     def _prepare_site(self, msg):
         """
         Construct the message that is consumed by ``TracePoutine``;
-        ``map_data_stack`` encodes the nested sequence of ``irange`` branches
+        ``cond_indep_stack`` encodes the nested sequence of ``irange`` branches
         that the site at name is within.
         """
-        msg["map_data_stack"].insert(0, CondIndepStackFrame(self.name, self.counter, self.vectorized))
+        msg["cond_indep_stack"].append(CondIndepStackFrame(self.name, self.counter, self.vectorized))
         return msg

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -220,7 +220,7 @@ def enum_extend(trace, msg, num_samples=None):
     # Batched .enumerate_support() assumes batched values are independent.
     batch_shape = msg["fn"].batch_shape(msg["value"], *msg["args"], **msg["kwargs"])
     is_batched = any(size > 1 for size in batch_shape)
-    inside_iarange = any(frame.vectorized for frame in msg["map_data_stack"])
+    inside_iarange = any(frame.vectorized for frame in msg["cond_indep_stack"])
     if is_batched and not inside_iarange:
         raise ValueError(
                 "Tried to enumerate a batched pyro.sample site '{}' outside of a pyro.iarange. "

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -224,11 +224,11 @@ def map_data_iter_model(subsample_size):
     map_data_vector_model,
     map_data_iter_model,
 ], ids=['iarange', 'irange', 'nested_irange', 'map_data_vector', 'map_data_iter'])
-def test_map_data_stack(model, subsample_size):
+def test_cond_indep_stack(model, subsample_size):
     tr = poutine.trace(model).get_trace(subsample_size)
     for name, node in tr.nodes.items():
         if name.startswith("x"):
-            assert node["map_data_stack"], "missing map_data_stack at node {}".format(name)
+            assert node["cond_indep_stack"], "missing cond_indep_stack at node {}".format(name)
 
 
 @pytest.mark.parametrize('subsample_size', [5, 20])


### PR DESCRIPTION
This renames `site["map_data_stack"]` to `site["cond_indep_stack"]` and reverses its order.

## Why?

- `map_data()` is deprecated in favor of `iarange` and `irange`
- we were reversing `map_data_stack` on each access
- `list.append()` is more pythonic than `list.insert(0, -)`