### PR TITLE
Do not run distributed tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,26 +40,26 @@ jobs:
               - make docs
         - python: 2.7
           env: STAGE=unit
-          script: pytest -vs -n 2 --cov=pyro --stage unit
+          script: pytest -vs --cov=pyro --stage unit
         - python: 2.7
           env: STAGE=examples
           script: pytest -vs --cov=pyro --stage test_examples
         - python: 3.5
           env: STAGE=unit
-          script: pytest -vs -n 2 --cov=pyro --stage unit
+          script: pytest -vs --cov=pyro --stage unit
         - python: 3.5
           env: STAGE=examples
           script: pytest -vs --cov=pyro --stage test_examples
         - stage: integration test
           python: 2.7
           env: STAGE=integration_batch_1
-          script: pytest -vs -n 2 --cov=pyro --stage integration_batch_1
+          script: pytest -vs --cov=pyro --stage integration_batch_1
         - python: 2.7
           env: STAGE=integration_batch_2
-          script: pytest -vs -n 2 --cov=pyro --stage integration_batch_2
+          script: pytest -vs --cov=pyro --stage integration_batch_2
         - python: 3.5
           env: STAGE=integration_batch_1
-          script: pytest -vs -n 2 --cov=pyro --stage integration_batch_1
+          script: pytest -vs --cov=pyro --stage integration_batch_1
         - python: 3.5
           env: STAGE=integration_batch_2
-          script: pytest -vs -n 2 --cov=pyro --stage integration_batch_2
+          script: pytest -vs --cov=pyro --stage integration_batch_2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-sudo: false
+sudo: true
 
 env:
     global:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'test': [
             'pytest',
             'pytest-cov',
-            'pytest-xdist',
             'nbval',
             # examples/tutorials
             'visdom',


### PR DESCRIPTION
- Removes xdist in travis. It seems like parallelizing on 1.5 cores (with sudo - true on the old VM based workers) leads to more issues than any potential benefits.
- Sets `sudo: true`. Refer to the discussion in #549. 