### PR TITLE
Basic profiling tools for distributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,46 @@ To run a single test from the command line
 pytest -vs {path_to_test}::{test_name}
 ```
 
+# Profiling
+
+The profiler module contains scripts to support profiling different 
+Pyro modules, as well as test for performance regression.
+
+To run the profiling utilities, ensure that all dependencies for profiling are satisfied, 
+by running `make install`, or more specifically, `pip install -e .[profile]`.
+
+There are some generic test cases available in the `profiler` module. Currently, this supports 
+only the `distributions` library, but we will be adding test cases for inference methods
+soon.
+
+#### Some useful invocations
+
+To get help on the parameters that the profiling script takes, run: 
+
+```sh
+python -m profiler.distributions --help
+```
+
+To run the profiler on all the distributions, simply run:
+
+```sh
+python -m profiler.distributions
+```
+
+To run the profiler on a few distributions by varying the batch size, run:
+
+```sh
+python -m profiler.distributions --dist bernoulli normal --batch_sizes 1000 100000 
+```
+
+To get more details on the potential sources of slowdown, use the `cProfile` tool
+ as follows:
+
+```sh
+python -m profiler.distributions --dist bernoulli --tool cprofile
+
+```
+
 # Submitting
 
 For larger changes, please open an issue for discussion before submitting a pull request.

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ scrub: FORCE
 	find tutorial -name "*.ipynb" | xargs python -m nbstripout --keep-output
 
 format: FORCE
-	yapf -i *.py pyro/distributions/*.py docs/source/conf.py
-	isort --recursive *.py pyro/ tests/ docs/source/conf.py
+	yapf -i *.py pyro/distributions/*.py profiler/*.py docs/source/conf.py
+	isort --recursive *.py pyro/ tests/ profiler/*.py docs/source/conf.py
 
 test: lint docs FORCE
 	pytest -vx -n auto --stage unit

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: docs test
 
 install: FORCE
-	pip install -e .[notebooks,visualization,dev]
+	pip install -e .[notebooks,visualization,dev,profile]
 
 docs: FORCE
 	$(MAKE) -C docs html

--- a/profiler/distributions.py
+++ b/profiler/distributions.py
@@ -1,0 +1,134 @@
+from __future__ import absolute_import, division, print_function
+
+import argparse
+
+import torch
+from torch.autograd import Variable
+
+from profiler.profiling_utils import Profile, profile_print
+from pyro.distributions import (bernoulli, beta, categorical, cauchy, delta, dirichlet, exponential, gamma, halfcauchy,
+                                lognormal, normal, poisson, uniform)
+
+
+def T(arr):
+    return Variable(torch.Tensor(arr))
+
+
+TOOL = 'timeit'
+TOOL_CFG = {}
+DISTRIBUTIONS = {
+    'bernoulli': (bernoulli, {
+        'ps': T([0.3, 0.3, 0.3, 0.3])
+    }),
+    'beta': (beta, {
+        'alpha': T([2.4, 2.4, 2.4, 2.4]),
+        'beta': T([3.2, 3.2, 3.2, 3.2])
+    }),
+    'categorical': (categorical, {
+        'ps': T([0.1, 0.3, 0.4, 0.2])
+    }),
+    'dirichlet': (dirichlet, {
+        'alpha': T([2.4, 3, 6, 6])
+    }),
+    'normal': (normal, {
+        'mu': T([0.5, 0.5, 0.5, 0.5]),
+        'sigma': T([1.2, 1.2, 1.2, 1.2])
+    }),
+    'lognormal': (lognormal, {
+        'mu': T([0.5, 0.5, 0.5, 0.5]),
+        'sigma': T([1.2, 1.2, 1.2, 1.2])
+    }),
+    'halfcauchy': (halfcauchy, {
+        'mu': T([0.5, 0.5, 0.5, 0.5]),
+        'gamma': T([1.2, 1.2, 1.2, 1.2])
+    }),
+    'cauchy': (cauchy, {
+        'mu': T([0.5, 0.5, 0.5, 0.5]),
+        'gamma': T([1.2, 1.2, 1.2, 1.2])
+    }),
+    'exponential': (exponential, {
+        'lam': T([5.5, 3.2, 4.1, 5.6])
+    }),
+    'poisson': (poisson, {
+        'lam': T([5.5, 3.2, 4.1, 5.6])
+    }),
+    'gamma': (gamma, {
+        'alpha': T([2.4, 2.4, 2.4, 2.4]),
+        'beta': T([3.2, 3.2, 3.2, 3.2])
+    }),
+    'uniform': (uniform, {
+        'a': T([0, 0, 0, 0]),
+        'b': T([4, 4, 4, 4])
+    })
+}
+
+
+def get_tool():
+    return TOOL
+
+
+def get_tool_cfg():
+    return TOOL_CFG
+
+
+@Profile(
+    tool=get_tool,
+    tool_cfg=get_tool_cfg,
+    fn_id=lambda dist, batch_size, *args, **kwargs: 'sample_' + dist.dist_class.__name__)
+def sample(dist, batch_size, *args, **kwargs):
+    return dist.sample(batch_size=batch_size, *args, **kwargs)
+
+
+@Profile(
+    tool=get_tool,
+    tool_cfg=get_tool_cfg,
+    fn_id=lambda dist, batch_size, *args, **kwargs: 'batch_log_pdf_' + dist.dist_class.__name__)
+def batch_log_pdf(dist, batch, *args, **kwargs):
+    return dist.batch_log_pdf(batch, *args, **kwargs)
+
+
+def run_with_tool(tool, dists, batch_size):
+    column_widths, field_format, template = None, None, None
+    if tool == 'timeit':
+        field_format = (None, '{:.6f}', '{:.6f}')
+        template = 'column'
+    elif tool == 'cprofile':
+        column_widths = [16, 80]
+        template = 'row'
+    with profile_print(column_widths, field_format, template) as out:
+        out.header('DISTRIBUTION', 'SAMPLE', 'BATCH_LOG_PDF')
+        for dist_name in dists:
+            dist, params = DISTRIBUTIONS[dist_name]
+            sample_prof, sample_result = sample(dist, batch_size=batch_size, **params)
+            logpdf_prof, _ = batch_log_pdf(dist, sample_result, **params)
+            out.push(dist_name, sample_prof, logpdf_prof)
+
+
+def set_tool_cfg(args):
+    global TOOL, TOOL_CFG
+    TOOL = args.tool
+    tool_cfg = {}
+    if args.tool == 'timeit':
+        repeat = 5
+        if args.repeat is not None:
+            repeat = args.repeat
+        tool_cfg = {'repeat': repeat}
+    TOOL_CFG = tool_cfg
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Profiling distributions library')
+    parser.add_argument('--tool', nargs='?', default='timeit')
+    parser.add_argument('--batch_size', nargs='?', default=100000, type=int)
+    parser.add_argument('--dists', nargs='*')
+    parser.add_argument('--repeat', nargs='?', default=5, type=int)
+    args = parser.parse_args()
+    set_tool_cfg(args)
+    dists = args.dists
+    if not dists:
+        dists = sorted(DISTRIBUTIONS.keys())
+    run_with_tool(args.tool, dists, args.batch_size)
+
+
+if __name__ == '__main__':
+    main()

--- a/profiler/profiling_utils.py
+++ b/profiler/profiling_utils.py
@@ -76,13 +76,6 @@ def profile_print(column_widths=None, field_format=None, template='column'):
         out_buffer.print()
 
 
-def get_fn_id(fn, *args, **params):
-    fn_id = fn.__name__
-    args_str = '_'.join([str(arg) for arg in args])
-    kwargs_str = '_'.join([k + '=' + str(params[k]) for k in params])
-    return fn_id + '_' + args_str + '_' + kwargs_str
-
-
 def profile_timeit(fn_callable, repeat=1):
     ret = fn_callable()
     return min(timeit.repeat(fn_callable, repeat=repeat, number=1)), ret

--- a/profiler/profiling_utils.py
+++ b/profiler/profiling_utils.py
@@ -1,0 +1,127 @@
+from __future__ import absolute_import, division, print_function
+
+import cProfile
+import functools
+import os
+import pstats
+import timeit
+from contextlib import contextmanager
+from cStringIO import StringIO
+
+from prettytable import ALL, PrettyTable
+
+FILE = os.path.abspath(__file__)
+PROF_DIR = os.path.join(os.path.dirname(FILE), 'data')
+if not os.path.exists(PROF_DIR):
+    os.makedirs(PROF_DIR)
+
+
+class ProfilePrinter(object):
+
+    def __init__(self, column_widths=None, field_format=None, template='column'):
+        assert template in ('column', 'row')
+        self._template = template
+        self._column_widths = column_widths
+        self._field_format = field_format
+        self._header = None
+        if template == 'column':
+            self.table = PrettyTable(header=True, max_width=50, hrules=ALL)
+        else:
+            self.table = PrettyTable(header=False, max_width=50, hrules=ALL)
+
+    def _formatted_values(self, values):
+        if self._field_format is not None:
+            assert len(self._field_format) == len(values)
+            return [f.format(val) if f else str(val) for f, val in zip(self._field_format, values)]
+        return values
+
+    def _add_using_row_format(self, values):
+        assert len(self._header) == len(values)
+        formatted_vals = self._formatted_values(values)
+        for i in range(len(self._header)):
+            self.table.add_row([self._header[i], formatted_vals[i]])
+
+    def _add_using_column_format(self, values):
+        formatted_vals = self._formatted_values(values)
+        self.table.add_row(formatted_vals)
+
+    def push(self, *values):
+        if self._template == 'column':
+            self._add_using_column_format(values)
+        else:
+            self._add_using_row_format(values)
+
+    def header(self, *values):
+        self._header = values
+        if self._template == 'column':
+            field_names = values
+        else:
+            field_names = ['KEY', 'VALUE']
+        self.table.field_names = field_names
+        for i in range(len(field_names)):
+            self.table.align[field_names[i]] = 'l'
+            if self._column_widths:
+                self.table.max_width[field_names[i]] = self._column_widths[i]
+
+    def print(self):
+        print(self.table)
+
+
+@contextmanager
+def profile_print(column_widths=None, field_format=None, template='column'):
+    out_buffer = ProfilePrinter(column_widths, field_format, template)
+    try:
+        yield out_buffer
+    finally:
+        out_buffer.print()
+
+
+def get_fn_id(fn, *args, **params):
+    fn_id = fn.__name__
+    args_str = '_'.join([str(arg) for arg in args])
+    kwargs_str = '_'.join([k + '=' + str(params[k]) for k in params])
+    return fn_id + '_' + args_str + '_' + kwargs_str
+
+
+def profile_timeit(fn_callable, repeat=1):
+    ret = fn_callable()
+    return min(timeit.repeat(fn_callable, repeat=repeat, number=1)), ret
+
+
+def profile_cprofile(fn_callable, prof_file):
+    prof = cProfile.Profile()
+    ret = prof.runcall(fn_callable)
+    prof.dump_stats(prof_file)
+    prof_stats = StringIO()
+    p = pstats.Stats(prof_file, stream=prof_stats)
+    p.strip_dirs().sort_stats('cumulative').print_stats(0.5)
+    return prof_stats.getvalue(), ret
+
+
+class Profile(object):
+
+    def __init__(self, tool, tool_cfg, fn_id):
+        self.tool = tool
+        self.tool_cfg = tool_cfg
+        self.fn_id = fn_id
+
+    def _set_decorator_params(self):
+        if callable(self.tool):
+            self.tool = self.tool()
+        if callable(self.tool_cfg):
+            self.tool_cfg = self.tool_cfg()
+
+    def __call__(self, fn):
+
+        def wrapped_fn(*args, **kwargs):
+            self._set_decorator_params()
+            fn_callable = functools.partial(fn, *args, **kwargs)
+            if self.tool == 'timeit':
+                return profile_timeit(fn_callable, **self.tool_cfg)
+            elif self.tool == 'cprofile':
+                prof_file = os.path.join(PROF_DIR, self.fn_id(*args, **kwargs))
+                return profile_cprofile(fn_callable, prof_file=prof_file)
+            else:
+                raise ValueError('Invalid profiling tool specified: {}.'.format(self.tool))
+
+        return wrapped_fn

--- a/profiler/profiling_utils.py
+++ b/profiler/profiling_utils.py
@@ -25,9 +25,9 @@ class ProfilePrinter(object):
         self._field_format = field_format
         self._header = None
         if template == 'column':
-            self.table = PrettyTable(header=True, max_width=50, hrules=ALL)
+            self.table = PrettyTable(header=False, hrules=ALL)
         else:
-            self.table = PrettyTable(header=False, max_width=50, hrules=ALL)
+            self.table = PrettyTable(header=False, hrules=ALL)
 
     def _formatted_values(self, values):
         if self._field_format is not None:
@@ -45,16 +45,17 @@ class ProfilePrinter(object):
         formatted_vals = self._formatted_values(values)
         self.table.add_row(formatted_vals)
 
-    def push(self, *values):
+    def push(self, values):
         if self._template == 'column':
             self._add_using_column_format(values)
         else:
             self._add_using_row_format(values)
 
-    def header(self, *values):
+    def header(self, values):
         self._header = values
         if self._template == 'column':
             field_names = values
+            self.table.add_row(values)
         else:
             field_names = ['KEY', 'VALUE']
         self.table.field_names = field_names
@@ -78,7 +79,7 @@ def profile_print(column_widths=None, field_format=None, template='column'):
 
 def profile_timeit(fn_callable, repeat=1):
     ret = fn_callable()
-    return min(timeit.repeat(fn_callable, repeat=repeat, number=1)), ret
+    return ret, min(timeit.repeat(fn_callable, repeat=repeat, number=1))
 
 
 def profile_cprofile(fn_callable, prof_file):
@@ -88,7 +89,7 @@ def profile_cprofile(fn_callable, prof_file):
     prof_stats = StringIO()
     p = pstats.Stats(prof_file, stream=prof_stats)
     p.strip_dirs().sort_stats('cumulative').print_stats(0.5)
-    return prof_stats.getvalue(), ret
+    return ret, prof_stats.getvalue()
 
 
 class Profile(object):

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ setup(
             'visdom',
             'torchvision',
         ],
+        'profile': [
+            'prettytable'
+        ],
         'dev': [
             'torchvision',
             'flake8',


### PR DESCRIPTION
Adds some basic profiling tools for distributions. See #460.

 - We can add an `infer.py` script which can be invoked in a similar manner. 
 - The common profiling utilities will be in `profiling_utils.py`. For instance the `@Profile` annotation can be applied to any function, which when run returns the function's value along with the side effect from the profiler (mostly terminal output, but can also be the profiler dump in `/data`).

```
@Profile(
    tool='timeit',
    tool_cfg={'repeat': 5},
    fn_id=lambda dist, batch_size, *args, **kwargs: 'sample_' + dist.dist_class.__name__)
def sample(dist, batch_size, *args, **kwargs):
    return dist.sample(batch_size=batch_size, *args, **kwargs)
```
 - There is a context manager which serves as an output buffer for running profiling tasks after which they can all be printed together using a tabular format. See examples below.

*Some example invocations:*

`python -m profiler.distributions --dist bernoulli normal dirichlet --tool timeit` 
<details>
<summary> output </summary>

```
+--------------+----------+---------------+
| DISTRIBUTION | SAMPLE   | BATCH_LOG_PDF |
+--------------+----------+---------------+
| bernoulli    | 0.004779 | 0.004176      |
+--------------+----------+---------------+
| normal       | 0.014364 | 0.012648      |
+--------------+----------+---------------+
| dirichlet    | 0.993340 | 0.062922      |
+--------------+----------+---------------+
```
</details>

`python -m profiler.distributions --dist --tool cprofile` 

<details>
<summary> output </summary>

```
+---------------+----------------------------------------------------------------------------------+
| DISTRIBUTION  | bernoulli                                                                        |
+---------------+----------------------------------------------------------------------------------+
| SAMPLE        | Thu Nov  9 19:10:20 2017                                                         |
|               | /Users/npradhan/workspace/pyro_dev/pyro/profiler/data/sample_Bernoulli           |
|               |                                                                                  |
|               |          73 function calls in 0.006 seconds                                      |
|               |                                                                                  |
|               |    Ordered by: cumulative time                                                   |
|               |    List reduced from 44 to 22 due to restriction <0.5>                           |
|               |                                                                                  |
|               |    ncalls  tottime  percall  cumtime  percall filename:lineno(function)          |
|               |         1    0.000    0.000    0.006    0.006 distributions.py:74(sample)        |
|               |         1    0.000    0.000    0.006    0.006 random_primitive.py:36(sample)     |
|               |         1    0.000    0.000    0.006    0.006 bernoulli.py:72(sample)            |
|               |         1    0.006    0.006    0.006    0.006 {torch._C.bernoulli}               |
|               |         1    0.000    0.000    0.000    0.000 bernoulli.py:33(__init__)          |
|               |         1    0.000    0.000    0.000    0.000 util.py:150(get_probs_and_logits)  |
|               |         7    0.000    0.000    0.000    0.000 {built-in method apply}            |
|               |         1    0.000    0.000    0.000    0.000 variable.py:428(clamp)             |
|               |         1    0.000    0.000    0.000    0.000 pointwise.py:144(forward)          |
|               |         1    0.000    0.000    0.000    0.000 variable.py:819(__sub__)           |
|               |         1    0.000    0.000    0.000    0.000 variable.py:331(sub)               |
|               |         1    0.000    0.000    0.000    0.000 variable.py:324(_sub)              |
|               |         2    0.000    0.000    0.000    0.000 variable.py:721(expand)            |
|               |         1    0.000    0.000    0.000    0.000 basic_ops.py:26(forward)           |
|               |         2    0.000    0.000    0.000    0.000 tensor.py:107(forward)             |
|               |         1    0.000    0.000    0.000    0.000 {torch._C.log}                     |
|               |         1    0.000    0.000    0.000    0.000 tensor.py:308(__mul__)             |
|               |         1    0.000    0.000    0.000    0.000 {method 'mul' of                   |
|               | 'torch._C.ByteTensorBase' objects}                                               |
|               |         1    0.000    0.000    0.000    0.000 {method 'sub' of                   |
|               | 'torch._C.FloatTensorBase' objects}                                              |
|               |         1    0.000    0.000    0.000    0.000 variable.py:374(log)               |
|               |         1    0.000    0.000    0.000    0.000 {method 'ge' of                    |
|               | 'torch._C.FloatTensorBase' objects}                                              |
|               |         1    0.000    0.000    0.000    0.000 {torch._C.log1p}                   |
|               |                                                                                  |
|               |                                                                                  |
|               |                                                                                  |
+---------------+----------------------------------------------------------------------------------+
| BATCH_LOG_PDF | Thu Nov  9 19:10:20 2017                                                         |
|               | /Users/npradhan/workspace/pyro_dev/pyro/profiler/data/batch_log_pdf_Bernoulli    |
|               |                                                                                  |
|               |          173 function calls in 0.006 seconds                                     |
|               |                                                                                  |
|               |    Ordered by: cumulative time                                                   |
|               |    List reduced from 67 to 34 due to restriction <0.5>                           |
|               |                                                                                  |
|               |    ncalls  tottime  percall  cumtime  percall filename:lineno(function)          |
|               |         1    0.000    0.000    0.006    0.006 distributions.py:82(batch_log_pdf) |
|               |         1    0.000    0.000    0.006    0.006                                    |
|               | random_primitive.py:44(batch_log_pdf)                                            |
|               |         1    0.000    0.000    0.006    0.006 bernoulli.py:78(batch_log_pdf)     |
|               |        22    0.000    0.000    0.006    0.000 {built-in method apply}            |
|               |         3    0.000    0.000    0.002    0.001 variable.py:812(__add__)           |
|               |         3    0.000    0.000    0.002    0.001 variable.py:318(add)               |
|               |         3    0.000    0.000    0.002    0.001 variable.py:311(_add)              |
|               |         3    0.000    0.000    0.002    0.001 basic_ops.py:9(forward)            |
|               |         3    0.002    0.001    0.002    0.001 {method 'add' of                   |
|               | 'torch._C.FloatTensorBase' objects}                                              |
|               |         1    0.000    0.000    0.001    0.001 variable.py:828(__mul__)           |
|               |         1    0.000    0.000    0.001    0.001 variable.py:337(mul)               |
|               |         1    0.000    0.000    0.001    0.001 basic_ops.py:43(forward)           |
|               |         1    0.001    0.001    0.001    0.001 {method 'mul' of                   |
|               | 'torch._C.FloatTensorBase' objects}                                              |
|               |         3    0.000    0.000    0.001    0.000 variable.py:819(__sub__)           |
|               |         3    0.000    0.000    0.001    0.000 variable.py:331(sub)               |
|               |         3    0.000    0.000    0.001    0.000 variable.py:324(_sub)              |
|               |         3    0.000    0.000    0.001    0.000 basic_ops.py:26(forward)           |
|               |         3    0.001    0.000    0.001    0.000 {method 'sub' of                   |
|               | 'torch._C.FloatTensorBase' objects}                                              |
|               |         1    0.000    0.000    0.001    0.001 {torch._C.sum}                     |
|               |         1    0.000    0.000    0.001    0.001 variable.py:475(sum)               |
|               |         1    0.000    0.000    0.001    0.001 reduce.py:10(forward)              |
|               |         1    0.001    0.001    0.001    0.001 {method 'sum' of                   |
|               | 'torch._C.FloatTensorBase' objects}                                              |
|               |         5    0.000    0.000    0.000    0.000 variable.py:860(__neg__)           |
|               |         5    0.000    0.000    0.000    0.000 basic_ops.py:218(forward)          |
|               |         5    0.000    0.000    0.000    0.000 {method 'neg' of                   |
|               | 'torch._C.FloatTensorBase' objects}                                              |
|               |         1    0.000    0.000    0.000    0.000 bernoulli.py:33(__init__)          |
|               |         1    0.000    0.000    0.000    0.000 util.py:150(get_probs_and_logits)  |
|               |         2    0.000    0.000    0.000    0.000 variable.py:428(clamp)             |
|               |         1    0.000    0.000    0.000    0.000 bernoulli.py:46(batch_shape)       |
|               |         1    0.000    0.000    0.000    0.000 pointwise.py:144(forward)          |
|               |         1    0.000    0.000    0.000    0.000 variable.py:724(expand_as)         |
|               |         2    0.000    0.000    0.000    0.000 variable.py:368(exp)               |
|               |         1    0.000    0.000    0.000    0.000 pointwise.py:295(forward)          |
|               |         2    0.000    0.000    0.000    0.000 variable.py:374(log)               |
|               |                                                                                  |
|               |                                                                                  |
|               |                                                                                  |
+---------------+----------------------------------------------------------------------------------+
```
</details>

This also dumps the output from the profiler in the `data` directory which can then be visualized using `snakeviz`.

*TODO:*
 - Add support for more tools - particularly for memory profiling.
 - Finetune output of cProfile for better readability.
 - Add some model/guide pairs in `profiler.infer` on which we can run SVI for profiling. Maybe reuse @martinjankowiak 's conjugate gaussian models for this.