### PR TITLE
Bump to version 0.1.2

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -15,7 +15,7 @@ from pyro.params import _MODULE_NAMESPACE_DIVIDER, _PYRO_PARAM_STORE, param_with
 from pyro.poutine import _PYRO_STACK, condition, do  # noqa: F401
 from pyro.util import apply_stack, deep_getattr, get_tensor_data, ones, set_rng_seed, zeros  # noqa: F401
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 def get_param_store():


### PR DESCRIPTION
This minor patch release contains:
- #533 fix for bug in gradient scaling of subsampled non-reparameterized sites
- misc improvements in documentation
- #530 split LambdaPoutine into ScalePoutine + IndepPoutine
  (this is not strictly backward compatible, but we assume nobody is using `pyro.LambdaPoutine` directly)