### PR TITLE
Parse pyro.__version__ and README.md in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 [![Latest Version](https://badge.fury.io/py/pyro-ppl.svg)](https://pypi.python.org/pypi/pyro-ppl)
 
 
-[Getting Started](http://pyro.ai/examples) | [Documentation](http://docs.pyro.ai/) | [Contributing](CONTRIBUTING.md)
+[Getting Started](http://pyro.ai/examples) |
+[Documentation](http://docs.pyro.ai/) |
+[Contributing](https://github.com/uber/pyro/blob/master/CONTRIBUTING.md)
 
 Please also refer to the [Pyro homepage](http://pyro.ai/).
 

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -15,6 +15,8 @@ from pyro.params import _MODULE_NAMESPACE_DIVIDER, _PYRO_PARAM_STORE, param_with
 from pyro.poutine import _PYRO_STACK, condition, do  # noqa: F401
 from pyro.util import apply_stack, deep_getattr, get_tensor_data, ones, set_rng_seed, zeros  # noqa: F401
 
+__version__ = '0.1.1'
+
 
 def get_param_store():
     """

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,28 @@
 from __future__ import absolute_import, division, print_function
 
+import sys
+
 from setuptools import find_packages, setup
+
+# Find pyro version.
+for line in open('pyro/__init__.py'):
+    if line.startswith('__version__ = '):
+        version = line.strip().split()[2][1:-1]
+
+# Convert README.md to rst for display at https://pypi.python.org/pypi/pyro-ppl
+try:
+    import pypandoc
+    long_description = pypandoc.convert('README.md', 'rst')
+except (IOError, ImportError, OSError) as e:
+    sys.stderr.write('Failed to convert README.md to rst:\n  {}\n'.format(e))
+    sys.stderr.flush()
+    long_description = open('README.md').read()
 
 setup(
     name='pyro-ppl',
-    version='0.1.1',
+    version=version,
     description='A Python library for probabilistic modeling and inference',
+    long_description=long_description,
     packages=find_packages(exclude=('tests*',)),
     url='http://pyro.ai',
     author='Uber AI Labs',
@@ -44,6 +61,7 @@ setup(
             'pytest-xdist',
             'nbval',
             'nbstripout',
+            'pypandoc',
             'sphinx',
             'sphinx_rtd_theme',
         ],

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ for line in open('pyro/__init__.py'):
         version = line.strip().split()[2][1:-1]
 
 # Convert README.md to rst for display at https://pypi.python.org/pypi/pyro-ppl
+# When releasing on pypi, make sure pandoc is on your system:
+# $ brew install pandoc          # OS X
+# $ sudo apt-get install pandoc  # Ubuntu Linux
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
@@ -17,6 +20,13 @@ except (IOError, ImportError, OSError) as e:
     sys.stderr.write('Failed to convert README.md to rst:\n  {}\n'.format(e))
     sys.stderr.flush()
     long_description = open('README.md').read()
+
+# Remove badges since they will always be obsolete.
+blacklist = ['Build Status', 'Latest Version', 'travis-ci.org', 'pypi.python.org']
+long_description = '\n'.join([
+    line for line in long_description.split('\n')
+    if not any(patt in line for patt in blacklist)
+])
 
 setup(
     name='pyro-ppl',


### PR DESCRIPTION
1. Move pyro version string from `setup.py` to `pyro.__init__.py` so it is available as `pyro.__version__`. (This is common practice.)
2. Parse `README.md` in `setup.py` so it can display on https://pypi.python.org/pypi/pyro-ppl (Also common practice)

Tests cancelled after linting.