### PR TITLE
Fix tests to pass on PyTorch v0.3.0 III

### DIFF
--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -225,11 +225,14 @@ def test_bern_elbo_gradient(enum_discrete, trace_graph):
 
     print("Computing gradients using finite difference")
     elbo = Trace_ELBO(num_particles=num_particles)
-    expected_grads = finite_difference(lambda: elbo.loss(model, guide))
+    expected_grads = finite_difference(lambda: elbo.loss(model, guide), delta=0.2)
 
     for name in params:
-        print("{} {}{}{}".format(name, "-" * 30, actual_grads[name].data,
-                                 expected_grads[name].data))
+        print("\n".join([
+            "{} {}".format(name, "-" * 30),
+            "expected = {}".format(expected_grads[name].data.cpu().numpy()),
+            "  actual = {}".format(actual_grads[name].data.cpu().numpy()),
+        ]))
     assert_equal(actual_grads, expected_grads, prec=0.1)
 
 
@@ -263,6 +266,9 @@ def test_gmm_elbo_gradient(model, guide, enum_discrete, trace_graph):
     expected_grads = finite_difference(lambda: elbo.loss(model, guide, data))
 
     for name in params:
-        print("{} {}{}{}".format(name, "-" * 30, actual_grads[name].data,
-                                 expected_grads[name].data))
+        print("\n".join([
+            "{} {}".format(name, "-" * 30),
+            "expected = {}".format(expected_grads[name].data.cpu().numpy()),
+            "  actual = {}".format(actual_grads[name].data.cpu().numpy()),
+        ]))
     assert_equal(actual_grads, expected_grads, prec=0.5)


### PR DESCRIPTION
Addresses #554 

This fixes some flaky tests that were failing due to difference in randomness in PyTorch 0.2.0 vs 0.3.0.

- Splits `test_subsample_gradient` up to test subsample-vs-truth and full-vs-truth, rather than subsample-vs-full. This allows us to use tighter bounds and run more tests in parallel.
- Change the finite difference grid on `test_bern_elbo_gradient` and tidy up its pretty printing.

I'll run `unit` tests on travis but will cancel `example` and `integration` tests.