### PR TITLE
Refactor TraceGraph_ELBO

### DIFF
--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -31,6 +31,141 @@ def _get_baseline_options(site):
     return options_tuple
 
 
+def _compute_downstream_costs(model_trace, guide_trace,  #
+                              model_vec_md_nodes, guide_vec_md_nodes,  #
+                              non_reparam_nodes):
+    # recursively compute downstream cost nodes for all sample sites in model and guide
+    # (even though ultimately just need for non-reparameterizable sample sites)
+    # 1. downstream costs used for rao-blackwellization
+    # 2. model observe sites (as well as terms that arise from the model and guide having different
+    # dependency structures) are taken care of via 'children_in_model' below
+    topo_sort_guide_nodes = list(reversed(list(networkx.topological_sort(guide_trace))))
+    topo_sort_guide_nodes = [x for x in topo_sort_guide_nodes
+                             if guide_trace.nodes[x]["type"] == "sample"]
+    downstream_guide_cost_nodes = {}
+    downstream_costs = {}
+
+    for node in topo_sort_guide_nodes:
+        node_log_pdf_key = 'batch_log_pdf' if node in guide_vec_md_nodes else 'log_pdf'
+        downstream_costs[node] = model_trace.nodes[node][node_log_pdf_key] - \
+            guide_trace.nodes[node][node_log_pdf_key]
+        nodes_included_in_sum = set([node])
+        downstream_guide_cost_nodes[node] = set([node])
+        for child in guide_trace.successors(node):
+            child_cost_nodes = downstream_guide_cost_nodes[child]
+            downstream_guide_cost_nodes[node].update(child_cost_nodes)
+            if nodes_included_in_sum.isdisjoint(child_cost_nodes):  # avoid duplicates
+                if node_log_pdf_key == 'log_pdf':
+                    downstream_costs[node] += downstream_costs[child].sum()
+                else:
+                    downstream_costs[node] += downstream_costs[child]
+                nodes_included_in_sum.update(child_cost_nodes)
+        missing_downstream_costs = downstream_guide_cost_nodes[node] - nodes_included_in_sum
+        # include terms we missed because we had to avoid duplicates
+        for missing_node in missing_downstream_costs:
+            mn_log_pdf_key = 'batch_log_pdf' if missing_node in guide_vec_md_nodes else 'log_pdf'
+            if node_log_pdf_key == 'log_pdf':
+                downstream_costs[node] += (model_trace.nodes[missing_node][mn_log_pdf_key] -
+                                           guide_trace.nodes[missing_node][mn_log_pdf_key]).sum()
+            else:
+                downstream_costs[node] += model_trace.nodes[missing_node][mn_log_pdf_key] - \
+                                          guide_trace.nodes[missing_node][mn_log_pdf_key]
+
+    # finish assembling complete downstream costs
+    # (the above computation may be missing terms from model)
+    # XXX can we cache some of the sums over children_in_model to make things more efficient?
+    for site in non_reparam_nodes:
+        children_in_model = set()
+        for node in downstream_guide_cost_nodes[site]:
+            children_in_model.update(model_trace.successors(node))
+        # remove terms accounted for above
+        children_in_model.difference_update(downstream_guide_cost_nodes[site])
+        for child in children_in_model:
+            child_log_pdf_key = 'batch_log_pdf' if child in model_vec_md_nodes else 'log_pdf'
+            site_log_pdf_key = 'batch_log_pdf' if site in guide_vec_md_nodes else 'log_pdf'
+            assert (model_trace.nodes[child]["type"] == "sample")
+            if site_log_pdf_key == 'log_pdf':
+                downstream_costs[site] += model_trace.nodes[child][child_log_pdf_key].sum()
+            else:
+                downstream_costs[site] += model_trace.nodes[child][child_log_pdf_key]
+
+    return downstream_costs
+
+
+def _compute_elbo_reparam(model_trace, guide_trace, non_reparam_nodes):
+    # prepare a list of all the cost nodes, each of which is +- log_pdf
+    cost_nodes = []
+    for name, model_site in model_trace.nodes.items():
+        if model_site["type"] == "sample":
+            if model_site["is_observed"]:
+                cost_nodes.append(CostNode(model_site["log_pdf"], True))
+            else:
+                # cost node from model sample
+                cost_nodes.append(CostNode(model_site["log_pdf"], True))
+                # cost node from guide sample
+                guide_site = guide_trace.nodes[name]
+                zero_expectation = name in non_reparam_nodes
+                cost_nodes.append(CostNode(-guide_site["log_pdf"], not zero_expectation))
+
+    # compute the elbo; if all stochastic nodes are reparameterizable, we're done
+    # this bit is never differentiated: it's here for getting an estimate of the elbo itself
+    elbo = torch_data_sum(sum(c.cost for c in cost_nodes))
+
+    # compute the surrogate elbo, removing terms whose gradient is zero
+    # this is the bit that's actually differentiated
+    # XXX should the user be able to control if these terms are included?
+    surrogate_elbo = sum(c.cost for c in cost_nodes if c.nonzero_expectation)
+
+    return elbo, surrogate_elbo
+
+
+def _compute_elbo_non_reparam(guide_trace, guide_vec_md_nodes,  #
+                              non_reparam_nodes, downstream_costs):
+    # construct all the reinforce-like terms.
+    # we include only downstream costs to reduce variance
+    # optionally include baselines to further reduce variance
+    # XXX should the average baseline be in the param store as below?
+    surrogate_elbo = 0.0
+    baseline_loss = 0.0
+    for node in non_reparam_nodes:
+        guide_site = guide_trace.nodes[node]
+        log_pdf_key = 'batch_log_pdf' if node in guide_vec_md_nodes else 'log_pdf'
+        downstream_cost = downstream_costs[node]
+        baseline = 0.0
+        (nn_baseline, nn_baseline_input, use_decaying_avg_baseline, baseline_beta,
+            baseline_value) = _get_baseline_options(guide_site)
+        use_nn_baseline = nn_baseline is not None
+        use_baseline_value = baseline_value is not None
+        assert(not (use_nn_baseline and use_baseline_value)), \
+            "cannot use baseline_value and nn_baseline simultaneously"
+        if use_decaying_avg_baseline:
+            avg_downstream_cost_old = pyro.param("__baseline_avg_downstream_cost_" + node,
+                                                 ng_zeros(1), tags="__tracegraph_elbo_internal_tag")
+            avg_downstream_cost_new = (1 - baseline_beta) * downstream_cost + \
+                baseline_beta * avg_downstream_cost_old
+            avg_downstream_cost_old.data = avg_downstream_cost_new.data  # XXX copy_() ?
+            baseline += avg_downstream_cost_old
+        if use_nn_baseline:
+            # block nn_baseline_input gradients except in baseline loss
+            baseline += nn_baseline(detach_iterable(nn_baseline_input))
+        elif use_baseline_value:
+            # it's on the user to make sure baseline_value tape only points to baseline params
+            baseline += baseline_value
+        if use_nn_baseline or use_baseline_value:
+            # accumulate baseline loss
+            baseline_loss += torch.pow(downstream_cost.detach() - baseline, 2.0).sum()
+
+        guide_log_pdf = guide_site[log_pdf_key] / guide_site["scale"]  # not scaled by subsampling
+        if use_nn_baseline or use_decaying_avg_baseline or use_baseline_value:
+            if downstream_cost.size() != baseline.size():
+                raise ValueError("Expected baseline at site {} to be {} instead got {}".format(
+                    node, downstream_cost.size(), baseline.size()))
+            downstream_cost = downstream_cost - baseline
+        surrogate_elbo += (guide_log_pdf * downstream_cost.detach()).sum()
+
+    return surrogate_elbo, baseline_loss
+
+
 class TraceGraph_ELBO(object):
     """
     A TraceGraph implementation of ELBO-based SVI. The gradient estimator
@@ -144,131 +279,18 @@ class TraceGraph_ELBO(object):
         model_trace.compute_batch_log_pdf(site_filter=lambda name, site: name in model_vec_md_nodes)
         model_trace.log_pdf()
 
-        # prepare a list of all the cost nodes, each of which is +- log_pdf
-        cost_nodes = []
+        # compute elbo for reparameterized nodes
         non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
-        for name, model_site in model_trace.nodes.items():
-            if model_site["type"] == "sample":
-                if model_site["is_observed"]:
-                    cost_nodes.append(CostNode(model_site["log_pdf"], True))
-                else:
-                    # cost node from model sample
-                    cost_nodes.append(CostNode(model_site["log_pdf"], True))
-                    # cost node from guide sample
-                    guide_site = guide_trace.nodes[name]
-                    zero_expectation = name in non_reparam_nodes
-                    cost_nodes.append(CostNode(-guide_site["log_pdf"], not zero_expectation))
-
-        # compute the elbo; if all stochastic nodes are reparameterizable, we're done
-        # this bit is never differentiated: it's here for getting an estimate of the elbo itself
-        elbo = torch_data_sum(sum(c.cost for c in cost_nodes))
-
-        # compute the surrogate elbo, removing terms whose gradient is zero
-        # this is the bit that's actually differentiated
-        # XXX should the user be able to control if these terms are included?
-        surrogate_elbo = sum(c.cost for c in cost_nodes if c.nonzero_expectation)
+        elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace, non_reparam_nodes)
 
         # the following computations are only necessary if we have non-reparameterizable nodes
         baseline_loss = 0.0
         if non_reparam_nodes:
-
-            # recursively compute downstream cost nodes for all sample sites in model and guide
-            # (even though ultimately just need for non-reparameterizable sample sites)
-            # 1. downstream costs used for rao-blackwellization
-            # 2. model observe sites (as well as terms that arise from the model and guide having different
-            # dependency structures) are taken care of via 'children_in_model' below
-            topo_sort_guide_nodes = list(reversed(list(networkx.topological_sort(guide_trace))))
-            topo_sort_guide_nodes = [x for x in topo_sort_guide_nodes
-                                     if guide_trace.nodes[x]["type"] == "sample"]
-            downstream_guide_cost_nodes = {}
-            downstream_costs = {}
-
-            for node in topo_sort_guide_nodes:
-                node_log_pdf_key = 'batch_log_pdf' if node in guide_vec_md_nodes else 'log_pdf'
-                downstream_costs[node] = model_trace.nodes[node][node_log_pdf_key] - \
-                    guide_trace.nodes[node][node_log_pdf_key]
-                nodes_included_in_sum = set([node])
-                downstream_guide_cost_nodes[node] = set([node])
-                for child in guide_trace.successors(node):
-                    child_cost_nodes = downstream_guide_cost_nodes[child]
-                    downstream_guide_cost_nodes[node].update(child_cost_nodes)
-                    if nodes_included_in_sum.isdisjoint(child_cost_nodes):  # avoid duplicates
-                        if node_log_pdf_key == 'log_pdf':
-                            downstream_costs[node] += downstream_costs[child].sum()
-                        else:
-                            downstream_costs[node] += downstream_costs[child]
-                        nodes_included_in_sum.update(child_cost_nodes)
-                missing_downstream_costs = downstream_guide_cost_nodes[node] - nodes_included_in_sum
-                # include terms we missed because we had to avoid duplicates
-                for missing_node in missing_downstream_costs:
-                    mn_log_pdf_key = 'batch_log_pdf' if missing_node in guide_vec_md_nodes else 'log_pdf'
-                    if node_log_pdf_key == 'log_pdf':
-                        downstream_costs[node] += (model_trace.nodes[missing_node][mn_log_pdf_key] -
-                                                   guide_trace.nodes[missing_node][mn_log_pdf_key]).sum()
-                    else:
-                        downstream_costs[node] += model_trace.nodes[missing_node][mn_log_pdf_key] - \
-                                                  guide_trace.nodes[missing_node][mn_log_pdf_key]
-
-            # finish assembling complete downstream costs
-            # (the above computation may be missing terms from model)
-            # XXX can we cache some of the sums over children_in_model to make things more efficient?
-            for site in non_reparam_nodes:
-                children_in_model = set()
-                for node in downstream_guide_cost_nodes[site]:
-                    children_in_model.update(model_trace.successors(node))
-                # remove terms accounted for above
-                children_in_model.difference_update(downstream_guide_cost_nodes[site])
-                for child in children_in_model:
-                    child_log_pdf_key = 'batch_log_pdf' if child in model_vec_md_nodes else 'log_pdf'
-                    site_log_pdf_key = 'batch_log_pdf' if site in guide_vec_md_nodes else 'log_pdf'
-                    assert (model_trace.nodes[child]["type"] == "sample")
-                    if site_log_pdf_key == 'log_pdf':
-                        downstream_costs[site] += model_trace.nodes[child][child_log_pdf_key].sum()
-                    else:
-                        downstream_costs[site] += model_trace.nodes[child][child_log_pdf_key]
-
-            # construct all the reinforce-like terms.
-            # we include only downstream costs to reduce variance
-            # optionally include baselines to further reduce variance
-            # XXX should the average baseline be in the param store as below?
-            elbo_reinforce_terms = 0.0
-            for node in non_reparam_nodes:
-                guide_site = guide_trace.nodes[node]
-                log_pdf_key = 'batch_log_pdf' if node in guide_vec_md_nodes else 'log_pdf'
-                downstream_cost = downstream_costs[node]
-                baseline = 0.0
-                (nn_baseline, nn_baseline_input, use_decaying_avg_baseline, baseline_beta,
-                    baseline_value) = _get_baseline_options(guide_site)
-                use_nn_baseline = nn_baseline is not None
-                use_baseline_value = baseline_value is not None
-                assert(not (use_nn_baseline and use_baseline_value)), \
-                    "cannot use baseline_value and nn_baseline simultaneously"
-                if use_decaying_avg_baseline:
-                    avg_downstream_cost_old = pyro.param("__baseline_avg_downstream_cost_" + node,
-                                                         ng_zeros(1), tags="__tracegraph_elbo_internal_tag")
-                    avg_downstream_cost_new = (1 - baseline_beta) * downstream_cost + \
-                        baseline_beta * avg_downstream_cost_old
-                    avg_downstream_cost_old.data = avg_downstream_cost_new.data  # XXX copy_() ?
-                    baseline += avg_downstream_cost_old
-                if use_nn_baseline:
-                    # block nn_baseline_input gradients except in baseline loss
-                    baseline += nn_baseline(detach_iterable(nn_baseline_input))
-                elif use_baseline_value:
-                    # it's on the user to make sure baseline_value tape only points to baseline params
-                    baseline += baseline_value
-                if use_nn_baseline or use_baseline_value:
-                    # accumulate baseline loss
-                    baseline_loss += torch.pow(downstream_cost.detach() - baseline, 2.0).sum()
-
-                guide_log_pdf = guide_site[log_pdf_key] / guide_site["scale"]  # not scaled by subsampling
-                if use_nn_baseline or use_decaying_avg_baseline or use_baseline_value:
-                    if downstream_cost.size() != baseline.size():
-                        raise ValueError("Expected baseline at site {} to be {} instead got {}".format(
-                            node, downstream_cost.size(), baseline.size()))
-                    downstream_cost = downstream_cost - baseline
-                elbo_reinforce_terms += (guide_log_pdf * downstream_cost.detach()).sum()
-
-            surrogate_elbo += elbo_reinforce_terms
+            downstream_costs = _compute_downstream_costs(
+                    model_trace, guide_trace,  model_vec_md_nodes, guide_vec_md_nodes, non_reparam_nodes)
+            surrogate_elbo_term, baseline_loss = _compute_elbo_non_reparam(
+                    guide_trace, guide_vec_md_nodes, non_reparam_nodes, downstream_costs)
+            surrogate_elbo += surrogate_elbo_term
 
         # collect parameters to train from model and guide
         trainable_params = set(site["value"]


### PR DESCRIPTION
This just moves code around inside `TraceGraph_ELBO` so as to split up the largest method into smaller helper functions.