### PR TITLE
Warn about NANs in log_pdf and loss

### DIFF
--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 import numbers
+import warnings
+
+import numpy as np
 
 import pyro
 import pyro.poutine as poutine
@@ -118,6 +121,8 @@ class Trace_ELBO(object):
             elbo += torch_data_sum(weight * elbo_particle)
 
         loss = -elbo
+        if np.isnan(loss):
+            warnings.warn('Encountered NAN loss')
         return loss
 
     def loss_and_grads(self, model, guide, *args, **kwargs):
@@ -176,5 +181,6 @@ class Trace_ELBO(object):
                 pyro.get_param_store().mark_params_active(trainable_params)
 
         loss = -elbo
-
+        if np.isnan(loss):
+            warnings.warn('Encountered NAN loss')
         return loss

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -238,7 +238,7 @@ class TraceGraph_ELBO(object):
                         elbo_particle += model_trace.nodes[name]["log_pdf"]
                         elbo_particle -= guide_trace.nodes[name]["log_pdf"]
 
-            elbo += weight * elbo_particle.data[0]
+            elbo += torch_data_sum(weight * elbo_particle)
 
         loss = -elbo
         if np.isnan(loss):

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -4,6 +4,7 @@ import warnings
 from collections import namedtuple
 
 import networkx
+import numpy as np
 import torch
 
 import pyro
@@ -240,6 +241,8 @@ class TraceGraph_ELBO(object):
             elbo += weight * elbo_particle.data[0]
 
         loss = -elbo
+        if np.isnan(loss):
+            warnings.warn('Encountered NAN loss')
         return loss
 
     def loss_and_grads(self, model, guide, *args, **kwargs):
@@ -304,4 +307,6 @@ class TraceGraph_ELBO(object):
             pyro.get_param_store().mark_params_active(trainable_params)
 
         loss = -elbo
+        if np.isnan(loss):
+            warnings.warn('Encountered NAN loss')
         return weight * loss

--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -1,8 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
 import collections
+import warnings
 
 import networkx
+import numpy as np
+
+
+def _warn_if_nan(name, variable):
+    if np.isnan(variable.data[0]):
+        warnings.warn("Encountered NAN log_pdf at site '{}'".format(name))
 
 
 class Trace(networkx.DiGraph):
@@ -70,6 +77,7 @@ class Trace(networkx.DiGraph):
                     site_log_p = site["fn"].log_pdf(
                         site["value"], *args, **kwargs) * site["scale"]
                     site["log_pdf"] = site_log_p
+                    _warn_if_nan(name, site_log_p)
                 log_p += site_log_p
         return log_p
 
@@ -91,6 +99,7 @@ class Trace(networkx.DiGraph):
                         site["value"], *args, **kwargs) * site["scale"]
                     site["batch_log_pdf"] = site_log_p
                     site["log_pdf"] = site_log_p.sum()
+                    _warn_if_nan(name, site["log_pdf"])
                 # Here log_p may be broadcast to a larger tensor:
                 log_p = log_p + site_log_p
         return log_p
@@ -111,6 +120,7 @@ class Trace(networkx.DiGraph):
                         site["value"], *args, **kwargs) * site["scale"]
                     site["batch_log_pdf"] = site_log_p
                     site["log_pdf"] = site_log_p.sum()
+                    _warn_if_nan(name, site["log_pdf"])
 
     @property
     def observation_nodes(self):

--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -8,8 +8,12 @@ import numpy as np
 
 
 def _warn_if_nan(name, variable):
-    if np.isnan(variable.data[0]):
+    value = variable.data[0]
+    if np.isnan(value):
         warnings.warn("Encountered NAN log_pdf at site '{}'".format(name))
+    if np.isinf(value) and value > 0:
+        warnings.warn("Encountered +inf log_pdf at site '{}'".format(name))
+    # Note that -inf log_pdf is fine: it is merely a zero-probability event.
 
 
 class Trace(networkx.DiGraph):


### PR DESCRIPTION
Fixes #571 

This adds warnings for:
- NAN and +INF `Trace.*log_pdf()` methods (at each site)
- NAN `.loss()` and `.loss_and_grads()` of in ELBO implementations

Note that this does not print whether errors occurred in the model vs guide, but that information can be seen from the stack trace if a user promotes warnings to errors via
```py
import warnings
warnings.simplefilter("error")
```
or by running a script via `python -W error my_script.py`.

## Tested

I have not added any death tests.