### PR TITLE
Fix event_shape in TransformedDistribution

### DIFF
--- a/pyro/distributions/transformed_distribution.py
+++ b/pyro/distributions/transformed_distribution.py
@@ -59,7 +59,7 @@ class TransformedDistribution(Distribution):
         """
         Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
         """
-        return self.base_dist.batch_shape(*args, **kwargs)
+        return self.base_dist.event_shape(*args, **kwargs)
 
     def log_pdf(self, y, *args, **kwargs):
         """


### PR DESCRIPTION
The `event_shape` for TransformedDistribution was incorrectly calling `batch_shape` of the base class distribution.

Added a test case to ensure that the sample size drawn from the distribution is consistent with the batch/event shape properties.

Fixes #574. 