### PR TITLE
[Discussion][WIP] HMC implementation for Pyro

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -1,0 +1,197 @@
+import random
+
+import torch
+from torch.autograd import Variable
+
+import pyro
+import pyro.distributions as dist
+import pyro.poutine as poutine
+from pyro.distributions.util import torch_zeros_like, torch_ones_like
+from pyro.infer import TracePosterior
+from pyro.poutine import Trace
+from tests.common import assert_equal
+
+
+def verlet_integrator(z, r, grad_potential, step_size, num_steps):
+    """
+    Velocity Verlet integrator.
+
+    :param z: trace object containing current values for the sample sites
+    :param r: dictionary of sample site names and corresponding momenta
+    :param grad_potential: function that returns gradient of the potential given z
+        for each sample site
+    :return: (z_next, r_next) having same types as (z, r)
+    """
+    # deep copy the current state - (z, r)
+    z_next = clone_trace(z)
+    r_next = {k: v.clone() for k, v in r.items()}
+    grads = grad_potential(z_next)
+    for _ in range(num_steps):
+        for site_name, node in z_next.iter_stochastic_nodes():
+            # r(n+1/2)
+            r_next[site_name] = r_next[site_name] + 0.5 * step_size * (-grads[site_name])
+            # z(n+1)
+            node['value'] = node['value'] + step_size * r_next[site_name]
+            node['value'].retain_grad()
+        grads = grad_potential(z_next)
+        for site_name in r_next:
+            # r(n+1)
+            r_next[site_name] = r_next[site_name] + 0.5 * step_size * (-grads[site_name])
+    return z_next, r_next
+
+
+def clone_trace(trace):
+    # clone the tensors so as not to mutate the old state (q, p)
+    # if it is not accepted
+    new_trace = trace.copy()
+    for name, node in trace.iter_stochastic_nodes():
+        node['value'].retain_grad()
+        node['value'] = node['value'].clone()
+    return new_trace
+
+
+class HMC(TracePosterior):
+    def __init__(self,
+                 model,
+                 step_size=0.5,
+                 num_steps=3,
+                 warmup_steps=20,
+                 num_samples=1000):
+        self.model = model
+        self.step_size = step_size
+        self.num_steps = num_steps
+        self.num_samples = num_samples
+        self.warmup_steps = warmup_steps
+        self.cached_param_grads = {}
+        self.args = None
+        self.kwargs = None
+        super(HMC, self).__init__()
+
+    def log_prob(self, z_trace):
+        """
+        Return log pdf of the model with sample sites replayed from z_trace
+        """
+        model_trace = poutine.trace(poutine.replay(self.model, trace=z_trace)).get_trace(*self.args, **self.kwargs)
+        return model_trace.log_pdf()
+
+    def grad_potential(self, z):
+        log_joint_prob = self.log_prob(z)
+        log_joint_prob.backward()
+        grad_potential = {}
+        for name, node in z.iter_stochastic_nodes():
+            grad_potential[name] = -node['value'].grad.clone()
+            grad_potential[name].volatile = False
+        return grad_potential
+
+    def _setup(self, z):
+        # store the current value of param gradients so that they
+        # can be reset at the end
+        for name, node in z.iter_param_nodes():
+            self.cached_param_grads[name] = node['value'].grad
+
+    def _cleanup(self):
+        # reset the param values to those stored before the hmc run
+        for name, grad in self.cached_param_grads.items():
+            param = pyro.get_param_store().get_param(name)
+            param.grad = grad
+
+    def energy(self, z, r):
+        kinetic_energy = 0.5 * torch.sum(torch.stack([r[name] ** 2 for name in r]))
+        potential_energy = - self.log_prob(z)
+        return kinetic_energy + potential_energy
+
+    def _traces(self, *args, **kwargs):
+        t = 0
+        self.args = args
+        self.kwargs = kwargs
+        # initialize z with model trace
+        z = poutine.trace(self.model).get_trace(*args, **kwargs)
+        self._setup(z)
+        # sample p's from the distribution given by p_dist
+        r_dist = {}
+        for name, node in z.iter_stochastic_nodes():
+            r_mu = torch_zeros_like(node['value'])
+            r_sigma = torch_ones_like(node['value'])
+            r_dist[name] = dist.Normal(mu=r_mu, sigma=r_sigma)
+        self.accept_cnt = 0
+
+        # Run HMC iterations
+        print('Simulating using HMC...')
+        while t < self.warmup_steps + self.num_samples:
+            if t % 100 == 0:
+                print('Iteration: {}'.format(t))
+            # sample momentum
+            r = {name: r_dist[name].sample() for name in z.stochastic_nodes}
+            z_new, r_new = verlet_integrator(z,
+                                             r,
+                                             self.grad_potential,
+                                             self.step_size,
+                                             self.num_steps)
+            energy_proposal = self.energy(z_new, r_new)
+            energy_current = self.energy(z, r)
+            # print("Energy - current: {}".format(energy_current))
+            # print("Energy - proposal: {}".format(energy_proposal))
+            delta_energy = energy_proposal - energy_current
+            t += 1
+            if random.random() < (-delta_energy).exp().data[0]:
+                self.accept_cnt += 1
+                z = z_new
+            if t < self.warmup_steps:
+                continue
+            yield (z, z.log_pdf())
+        self._cleanup()
+
+    def get_acceptance_ratio(self):
+        return self.accept_cnt / float(self.warmup_steps + self.num_samples)
+
+
+def test_normal_normal():
+    def model(data):
+        mu = pyro.param('mu', Variable(torch.zeros(10), requires_grad=True))
+        x = pyro.sample('x', dist.normal, mu=mu, sigma=Variable(torch.ones(10)))
+        pyro.sample('data', dist.normal, obs=data, mu=x, sigma=Variable(torch.ones(10)))
+
+    data = Variable(torch.ones(1, 10))
+    hmc = HMC(model, step_size=0.4, num_steps=3, num_samples=400, warmup_steps=50)
+    traces = []
+    for t, _ in hmc._traces(data):
+        traces.append(t.nodes['x']['value'])
+    print('Acceptance ratio: {}'.format(hmc.get_acceptance_ratio()))
+    print('Posterior mean:')
+    print(torch.mean(torch.stack(traces), 0).data)
+    # gradients should not have been back-propagated.
+    assert pyro.get_param_store().get_param('mu').grad is None
+
+
+def test_verlet_integrator():
+    def energy(q, p):
+        return 0.5 * p['x'] ** 2 + 0.5 * q.nodes['x']['value'] ** 2
+
+    def grad(q):
+        return {'x': q.nodes['x']['value']}
+
+    q = Trace()
+    q.add_node('x',
+               type='sample',
+               is_observed=False,
+               value=Variable(torch.Tensor([0.0])))
+    p = {'x': Variable(torch.Tensor([1.0]))}
+    energy_cur = energy(q, p)
+    print("Energy - current: {}".format(energy_cur.data[0]))
+    q_new, p_new = verlet_integrator(q, p, grad, 0.01, 100)
+    assert q_new.nodes['x']['value'].data[0] != q.nodes['x']['value'].data[0]
+    energy_new = energy(q_new, p_new)
+    assert_equal(energy_new, energy_cur)
+    print("q_old: {}, p_old: {}".format(q.nodes['x']['value'].data[0], p['x'].data[0]))
+    print("q_new: {}, p_new: {}".format(q_new.nodes['x']['value'].data[0], p_new['x'].data[0]))
+    print("Energy - new: {}".format(energy_new.data[0]))
+    print("-------------------------------------")
+
+
+def main():
+    test_verlet_integrator()
+    test_normal_normal()
+
+
+if __name__ == '__main__':
+    main()

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -1,4 +1,4 @@
-import random
+from __future__ import absolute_import, division, print_function
 
 import torch
 from torch.autograd import Variable
@@ -6,9 +6,9 @@ from torch.autograd import Variable
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-from pyro.distributions.util import torch_zeros_like, torch_ones_like
+from pyro.distributions.util import torch_ones_like, torch_zeros_like
 from pyro.infer import TracePosterior
-from pyro.poutine import Trace
+from pyro.util import ng_ones, ng_zeros
 from tests.common import assert_equal
 
 
@@ -16,23 +16,31 @@ def verlet_integrator(z, r, grad_potential, step_size, num_steps):
     """
     Velocity Verlet integrator.
 
-    :param z: trace object containing current values for the sample sites
+    :param z: dictionary of sample site names and their current values
     :param r: dictionary of sample site names and corresponding momenta
     :param grad_potential: function that returns gradient of the potential given z
         for each sample site
     :return: (z_next, r_next) having same types as (z, r)
     """
     # deep copy the current state - (z, r)
-    z_next = clone_trace(z)
-    r_next = {k: v.clone() for k, v in r.items()}
+    z_next = {key: val.clone() for key, val in z.items()}
+    r_next = {key: val.clone() for key, val in r.items()}
+    retain_grads(z_next)
+    retain_grads(r_next)
     grads = grad_potential(z_next)
+
     for _ in range(num_steps):
-        for site_name, node in z_next.iter_stochastic_nodes():
+        # detach graph nodes for next iteration
+        detach_nodes(z_next)
+        detach_nodes(r_next)
+        for site_name in z_next:
             # r(n+1/2)
             r_next[site_name] = r_next[site_name] + 0.5 * step_size * (-grads[site_name])
             # z(n+1)
-            node['value'] = node['value'] + step_size * r_next[site_name]
-            node['value'].retain_grad()
+            z_next[site_name] = z_next[site_name] + step_size * r_next[site_name]
+        # retain gradients for intermediate nodes in backward step
+        retain_grads(z_next)
+        retain_grads(r_next)
         grads = grad_potential(z_next)
         for site_name in r_next:
             # r(n+1)
@@ -40,14 +48,14 @@ def verlet_integrator(z, r, grad_potential, step_size, num_steps):
     return z_next, r_next
 
 
-def clone_trace(trace):
-    # clone the tensors so as not to mutate the old state (q, p)
-    # if it is not accepted
-    new_trace = trace.copy()
-    for name, node in trace.iter_stochastic_nodes():
-        node['value'].retain_grad()
-        node['value'] = node['value'].clone()
-    return new_trace
+def retain_grads(z):
+    for key in z:
+        z[key].retain_grad()
+
+
+def detach_nodes(z):
+    for key in z:
+        z[key] = Variable(z[key].data, requires_grad=True)
 
 
 class HMC(TracePosterior):
@@ -62,31 +70,45 @@ class HMC(TracePosterior):
         self.num_steps = num_steps
         self.num_samples = num_samples
         self.warmup_steps = warmup_steps
+        # simulation run attributes - will be set in self._setup
+        # at start of run
         self.cached_param_grads = {}
         self.args = None
         self.kwargs = None
+        self.accept_cnt = None
+        self.prototype_trace = None
         super(HMC, self).__init__()
 
-    def log_prob(self, z_trace):
+    def log_prob(self, z):
         """
         Return log pdf of the model with sample sites replayed from z_trace
         """
-        model_trace = poutine.trace(poutine.replay(self.model, trace=z_trace)).get_trace(*self.args, **self.kwargs)
+        z_trace = self.prototype_trace.copy()
+        for name, value in z.items():
+            z_trace.nodes[name]['value'] = value
+        model_trace = poutine.trace(poutine.replay(self.model, trace=z_trace)) \
+            .get_trace(*self.args, **self.kwargs)
         return model_trace.log_pdf()
 
     def grad_potential(self, z):
         log_joint_prob = self.log_prob(z)
         log_joint_prob.backward()
         grad_potential = {}
-        for name, node in z.iter_stochastic_nodes():
-            grad_potential[name] = -node['value'].grad.clone()
+        for name, value in z.items():
+            grad_potential[name] = -value.grad.clone().detach()
             grad_potential[name].volatile = False
         return grad_potential
 
-    def _setup(self, z):
+    def _setup(self, *args, **kwargs):
+        self.accept_cnt = 0
+        self.args = args
+        self.kwargs = kwargs
+        # set the trace prototype to inter-convert between trace object
+        # and dict object used by the integrator
+        self.prototype_trace = poutine.trace(self.model).get_trace(*args, **kwargs)
         # store the current value of param gradients so that they
         # can be reset at the end
-        for name, node in z.iter_param_nodes():
+        for name, node in self.prototype_trace.iter_param_nodes():
             self.cached_param_grads[name] = node['value'].grad
 
     def _cleanup(self):
@@ -101,27 +123,23 @@ class HMC(TracePosterior):
         return kinetic_energy + potential_energy
 
     def _traces(self, *args, **kwargs):
-        t = 0
-        self.args = args
-        self.kwargs = kwargs
-        # initialize z with model trace
-        z = poutine.trace(self.model).get_trace(*args, **kwargs)
-        self._setup(z)
+        self._setup(*args, **kwargs)
         # sample p's from the distribution given by p_dist
         r_dist = {}
-        for name, node in z.iter_stochastic_nodes():
-            r_mu = torch_zeros_like(node['value'])
-            r_sigma = torch_ones_like(node['value'])
+        z = {name: node['value'] for name, node in self.prototype_trace.iter_stochastic_nodes()}
+        for name, value in z.items():
+            r_mu = torch_zeros_like(value)
+            r_sigma = torch_ones_like(value)
             r_dist[name] = dist.Normal(mu=r_mu, sigma=r_sigma)
-        self.accept_cnt = 0
 
         # Run HMC iterations
+        t = 0
         print('Simulating using HMC...')
         while t < self.warmup_steps + self.num_samples:
             if t % 100 == 0:
                 print('Iteration: {}'.format(t))
             # sample momentum
-            r = {name: r_dist[name].sample() for name in z.stochastic_nodes}
+            r = {name: pyro.sample('r_{}'.format(name), r_dist[name]) for name in z}
             z_new, r_new = verlet_integrator(z,
                                              r,
                                              self.grad_potential,
@@ -133,16 +151,17 @@ class HMC(TracePosterior):
             # print("Energy - proposal: {}".format(energy_proposal))
             delta_energy = energy_proposal - energy_current
             t += 1
-            if random.random() < (-delta_energy).exp().data[0]:
+            rand = pyro.sample('rand', dist.uniform, a=ng_zeros(1), b=ng_ones(1))
+            if rand.log().data[0] < -delta_energy.data[0]:
                 self.accept_cnt += 1
                 z = z_new
             if t < self.warmup_steps:
                 continue
-            yield (z, z.log_pdf())
+            yield (z, self.log_prob(z))
         self._cleanup()
 
     def get_acceptance_ratio(self):
-        return self.accept_cnt / float(self.warmup_steps + self.num_samples)
+        return self.accept_cnt / (self.warmup_steps + self.num_samples)
 
 
 def test_normal_normal():
@@ -152,10 +171,10 @@ def test_normal_normal():
         pyro.sample('data', dist.normal, obs=data, mu=x, sigma=Variable(torch.ones(10)))
 
     data = Variable(torch.ones(1, 10))
-    hmc = HMC(model, step_size=0.4, num_steps=3, num_samples=400, warmup_steps=50)
+    hmc = HMC(model, step_size=0.6, num_steps=3, num_samples=400, warmup_steps=50)
     traces = []
     for t, _ in hmc._traces(data):
-        traces.append(t.nodes['x']['value'])
+        traces.append(t['x'])
     print('Acceptance ratio: {}'.format(hmc.get_acceptance_ratio()))
     print('Posterior mean:')
     print(torch.mean(torch.stack(traces), 0).data)
@@ -165,25 +184,21 @@ def test_normal_normal():
 
 def test_verlet_integrator():
     def energy(q, p):
-        return 0.5 * p['x'] ** 2 + 0.5 * q.nodes['x']['value'] ** 2
+        return 0.5 * p['x'] ** 2 + 0.5 * q['x'] ** 2
 
     def grad(q):
-        return {'x': q.nodes['x']['value']}
+        return {'x': q['x']}
 
-    q = Trace()
-    q.add_node('x',
-               type='sample',
-               is_observed=False,
-               value=Variable(torch.Tensor([0.0])))
+    q = {'x': Variable(torch.Tensor([0.0]))}
     p = {'x': Variable(torch.Tensor([1.0]))}
     energy_cur = energy(q, p)
     print("Energy - current: {}".format(energy_cur.data[0]))
     q_new, p_new = verlet_integrator(q, p, grad, 0.01, 100)
-    assert q_new.nodes['x']['value'].data[0] != q.nodes['x']['value'].data[0]
+    assert q_new['x'].data[0] != q['x'].data[0]
     energy_new = energy(q_new, p_new)
     assert_equal(energy_new, energy_cur)
-    print("q_old: {}, p_old: {}".format(q.nodes['x']['value'].data[0], p['x'].data[0]))
-    print("q_new: {}, p_new: {}".format(q_new.nodes['x']['value'].data[0], p_new['x'].data[0]))
+    print("q_old: {}, p_old: {}".format(q['x'].data[0], p['x'].data[0]))
+    print("q_new: {}, p_new: {}".format(q_new['x'].data[0], p_new['x'].data[0]))
     print("Energy - new: {}".format(energy_new.data[0]))
     print("-------------------------------------")
 

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -27,7 +27,6 @@ def verlet_integrator(z, r, grad_potential, step_size, num_steps):
     z_next = {key: val.clone().detach() for key, val in z.items()}
     r_next = {key: val.clone().detach() for key, val in r.items()}
     retain_grads(z_next)
-    retain_grads(r_next)
     grads = grad_potential(z_next)
 
     for _ in range(num_steps):
@@ -41,7 +40,6 @@ def verlet_integrator(z, r, grad_potential, step_size, num_steps):
             z_next[site_name] = z_next[site_name] + step_size * r_next[site_name]
         # retain gradients for intermediate nodes in backward step
         retain_grads(z_next)
-        retain_grads(r_next)
         grads = grad_potential(z_next)
         for site_name in r_next:
             # r(n+1)
@@ -50,16 +48,16 @@ def verlet_integrator(z, r, grad_potential, step_size, num_steps):
 
 
 def retain_grads(z):
-    for key in z:
+    for value in z.values():
         # XXX: can be removed with PyTorch 0.3
-        if z[key].is_leaf and not z[key].requires_grad:
-            z[key].requires_grad = True
-        z[key].retain_grad()
+        if value.is_leaf and not value.requires_grad:
+            value.requires_grad = True
+        value.retain_grad()
 
 
 def detach_nodes(z):
-    for key in z:
-        z[key] = Variable(z[key].data, requires_grad=True)
+    for key, value in z.items():
+        z[key] = Variable(value.data, requires_grad=True)
 
 
 class HMC(TracePosterior):

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -48,7 +48,6 @@ class HMC(TraceKernel):
 
     def _grad_potential(self, z):
         log_joint_prob = self._log_prob(z)
-        print(log_joint_prob)
         log_joint_prob.backward()
         grad_potential = {}
         for name, value in z.items():
@@ -121,10 +120,10 @@ def test_normal_normal():
         pyro.sample('data', dist.normal, obs=data, mu=y, sigma=Variable(torch.ones(10)))
 
     data = Variable(torch.ones(1, 10))
-    hmc = MCMC(model, kernel=HMC, num_samples=400, warmup_steps=50, step_size=0.6, num_steps=3)
+    hmc = MCMC(model, kernel=HMC, num_samples=900, warmup_steps=50, step_size=0.6, num_steps=5)
     traces = []
     for t, _ in hmc._traces(data):
-        traces.append(t['x'])
+        traces.append(t.nodes['x']['value'])
     print('Acceptance ratio: {}'.format(hmc.acceptance_ratio))
     print('Posterior mean:')
     print(torch.mean(torch.stack(traces), 0).data)

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -64,10 +64,12 @@ class HMC(TraceKernel):
         # set the trace prototype to inter-convert between trace object
         # and dict object used by the integrator
         self._prototype_trace = poutine.trace(self.model).get_trace(*args, **kwargs)
+        # momenta distribution - currently standard normal
         for name, node in self._prototype_trace.iter_stochastic_nodes():
             r_mu = torch_zeros_like(node['value'])
             r_sigma = torch_ones_like(node['value'])
             self._r_dist[name] = dist.Normal(mu=r_mu, sigma=r_sigma)
+        # validate model
         for name, node in self._prototype_trace.iter_stochastic_nodes():
             if not node['fn'].reparameterized:
                 raise ValueError('Found non-reparameterized node in the model at site: {}'.format(name))

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -13,10 +13,8 @@ from pyro.util import ng_ones, ng_zeros
 
 
 class HMC(TraceKernel):
-    def __init__(self,
-                 model,
-                 step_size=0.5,
-                 num_steps=3):
+
+    def __init__(self, model, step_size=0.5, num_steps=3):
         self.model = model
         self.step_size = step_size
         self.num_steps = num_steps
@@ -53,8 +51,8 @@ class HMC(TraceKernel):
         return grad_potential
 
     def _energy(self, z, r):
-        kinetic_energy = 0.5 * torch.sum(torch.stack([r[name] ** 2 for name in r]))
-        potential_energy = - self._log_prob(z)
+        kinetic_energy = 0.5 * torch.sum(torch.stack([r[name]**2 for name in r]))
+        potential_energy = -self._log_prob(z)
         return kinetic_energy + potential_energy
 
     def setup(self, *args, **kwargs):
@@ -92,11 +90,7 @@ class HMC(TraceKernel):
         # sample p's from the distribution given by p_dist
         # sample momentum
         r = {name: pyro.sample('r_{}_t={}'.format(name, time_step), self._r_dist[name]) for name in z}
-        z_new, r_new = verlet_integrator(z,
-                                         r,
-                                         self._grad_potential,
-                                         self.step_size,
-                                         self.num_steps)
+        z_new, r_new = verlet_integrator(z, r, self._grad_potential, self.step_size, self.num_steps)
         energy_proposal = self._energy(z_new, r_new)
         energy_current = self._energy(z, r)
         delta_energy = energy_proposal - energy_current
@@ -109,101 +103,3 @@ class HMC(TraceKernel):
     @property
     def num_accepts(self):
         return self._accept_cnt
-
-
-def test_normal_normal():
-    def model(data):
-        mu = pyro.param('mu', Variable(torch.zeros(10), requires_grad=True))
-        x = pyro.sample('x', dist.normal, mu=mu, sigma=Variable(torch.ones(10)))
-        pyro.sample('data', dist.normal, obs=data, mu=x, sigma=Variable(torch.ones(10)))
-
-    data = Variable(torch.ones(1, 10))
-    hmc = HMC(model, step_size=0.6, num_steps=3, num_samples=400, warmup_steps=50)
-    traces = []
-    for t, _ in hmc._traces(data):
-        traces.append(t['x'])
-    print('Acceptance ratio: {}'.format(hmc.acceptance_ratio))
-    print('Posterior mean:')
-    print(torch.mean(torch.stack(traces), 0).data)
-    # gradients should not have been back-propagated.
-    assert pyro.get_param_store().get_param('mu').grad is None
-
-
-def test_verlet_integrator():
-    def energy(q, p):
-        return 0.5 * p['x'] ** 2 + 0.5 * q['x'] ** 2
-
-    def grad(q):
-        return {'x': q['x']}
-
-    q = {'x': Variable(torch.Tensor([0.0]), requires_grad=True)}
-    p = {'x': Variable(torch.Tensor([1.0]), requires_grad=True)}
-    energy_cur = energy(q, p)
-    print("Energy - current: {}".format(energy_cur.data[0]))
-    q_new, p_new = verlet_integrator(q, p, grad, 0.01, 100)
-    assert q_new['x'].data[0] != q['x'].data[0]
-    energy_new = energy(q_new, p_new)
-    assert_equal(energy_new, energy_cur)
-    assert_equal(q_new['x'].data[0], np.sin(1.0), prec=1.0e-4)
-    assert_equal(p_new['x'].data[0], np.cos(1.0), prec=1.0e-4)
-    print("q_old: {}, p_old: {}".format(q['x'].data[0], p['x'].data[0]))
-    print("q_new: {}, p_new: {}".format(q_new['x'].data[0], p_new['x'].data[0]))
-    print("Energy - new: {}".format(energy_new.data[0]))
-    print("-------------------------------------")
-
-
-def test_circular_planetary_motion():
-    def energy(q, p):
-        return 0.5 * p['x'] ** 2 + 0.5 * p['y'] ** 2 - \
-            1.0 / torch.pow(q['x'] ** 2 + q['y'] ** 2, 0.5)
-
-    def grad(q):
-        return {'x': q['x'] / torch.pow(q['x'] ** 2 + q['y'] ** 2, 1.5),
-                'y': q['y'] / torch.pow(q['x'] ** 2 + q['y'] ** 2, 1.5)}
-
-    q = {'x': Variable(torch.Tensor([1.0]), requires_grad=True),
-         'y': Variable(torch.Tensor([0.0]), requires_grad=True)}
-    p = {'x': Variable(torch.Tensor([0.0]), requires_grad=True),
-         'y': Variable(torch.Tensor([1.0]), requires_grad=True)}
-    energy_initial = energy(q, p)
-    print("*** circular planetary motion ***")
-    print("initial energy: {}".format(energy_initial.data[0]))
-    q_new, p_new = verlet_integrator(q, p, grad, 0.01, 628)
-    energy_final = energy(q_new, p_new)
-    assert_equal(energy_final, energy_initial)
-    assert_equal(q_new['x'].data[0], 1.0, prec=5.0e-3)
-    assert_equal(q_new['y'].data[0], 0.0, prec=5.0e-3)
-    print("final energy: {}".format(energy_final.data[0]))
-    print("-------------------------------------")
-
-
-def test_quartic_oscillator():
-    def energy(q, p):
-        return 0.5 * p['x'] ** 2 + 0.25 * torch.pow(q['x'], 4.0)
-
-    def grad(q):
-        return {'x': torch.pow(q['x'], 3.0)}
-
-    q = {'x': Variable(torch.Tensor([0.02]), requires_grad=True)}
-    p = {'x': Variable(torch.Tensor([0.0]), requires_grad=True)}
-    energy_initial = energy(q, p)
-    print("*** quartic oscillator ***")
-    print("initial energy: {}".format(energy_initial.data[0]))
-    q_new, p_new = verlet_integrator(q, p, grad, 0.1, 1810)
-    energy_final = energy(q_new, p_new)
-    assert_equal(energy_final, energy_initial)
-    assert_equal(q_new['x'].data[0], -0.02, prec=1.0e-4)
-    assert_equal(p_new['x'].data[0], 0.0, prec=1.0e-4)
-    print("final energy: {}".format(energy_final.data[0]))
-    print("-------------------------------------")
-
-
-def main():
-    test_verlet_integrator()
-    test_circular_planetary_motion()
-    test_quartic_oscillator()
-    test_normal_normal()
-
-
-if __name__ == '__main__':
-    main()

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -142,7 +142,7 @@ class HMC(TracePosterior):
             if t % 100 == 0:
                 print('Iteration: {}'.format(t))
             # sample momentum
-            r = {name: pyro.sample('r_{}'.format(name), r_dist[name]) for name in z}
+            r = {name: pyro.sample('r_{}_t={}'.format(name, t), r_dist[name]) for name in z}
             z_new, r_new = verlet_integrator(z,
                                              r,
                                              self.grad_potential,
@@ -154,7 +154,7 @@ class HMC(TracePosterior):
             # print("Energy - proposal: {}".format(energy_proposal))
             delta_energy = energy_proposal - energy_current
             t += 1
-            rand = pyro.sample('rand', dist.uniform, a=ng_zeros(1), b=ng_ones(1))
+            rand = pyro.sample('rand_t='.format(t), dist.uniform, a=ng_zeros(1), b=ng_ones(1))
             if rand.log().data[0] < -delta_energy.data[0]:
                 self.accept_cnt += 1
                 z = z_new

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -8,72 +8,24 @@ import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.distributions.util import torch_ones_like, torch_zeros_like
-from pyro.infer import TracePosterior
+from pyro.infer.mcmc.mcmc import MCMC
+from pyro.infer.mcmc.trace_kernel import TraceKernel
+from pyro.infer.mcmc.verlet_integrator import verlet_integrator
 from pyro.util import ng_ones, ng_zeros
 from tests.common import assert_equal
 
 
-def verlet_integrator(z, r, grad_potential, step_size, num_steps):
-    """
-    Velocity Verlet integrator.
-
-    :param z: dictionary of sample site names and their current values
-    :param r: dictionary of sample site names and corresponding momenta
-    :param grad_potential: function that returns gradient of the potential given z
-        for each sample site
-    :return: (z_next, r_next) having same types as (z, r)
-    """
-    # deep copy the current state - (z, r)
-    z_next = {key: val.clone().detach() for key, val in z.items()}
-    r_next = {key: val.clone().detach() for key, val in r.items()}
-    retain_grads(z_next)
-    grads = grad_potential(z_next)
-
-    for _ in range(num_steps):
-        # detach graph nodes for next iteration
-        detach_nodes(z_next)
-        detach_nodes(r_next)
-        for site_name in z_next:
-            # r(n+1/2)
-            r_next[site_name] = r_next[site_name] + 0.5 * step_size * (-grads[site_name])
-            # z(n+1)
-            z_next[site_name] = z_next[site_name] + step_size * r_next[site_name]
-        # retain gradients for intermediate nodes in backward step
-        retain_grads(z_next)
-        grads = grad_potential(z_next)
-        for site_name in r_next:
-            # r(n+1)
-            r_next[site_name] = r_next[site_name] + 0.5 * step_size * (-grads[site_name])
-    return z_next, r_next
-
-
-def retain_grads(z):
-    for value in z.values():
-        # XXX: can be removed with PyTorch 0.3
-        if value.is_leaf and not value.requires_grad:
-            value.requires_grad = True
-        value.retain_grad()
-
-
-def detach_nodes(z):
-    for key, value in z.items():
-        z[key] = Variable(value.data, requires_grad=True)
-
-
-class HMC(TracePosterior):
+class HMC(TraceKernel):
     def __init__(self,
                  model,
                  step_size=0.5,
-                 num_steps=3,
-                 warmup_steps=20,
-                 num_samples=1000):
+                 num_steps=3):
         self.model = model
         self.step_size = step_size
         self.num_steps = num_steps
-        self.num_samples = num_samples
-        self.warmup_steps = warmup_steps
         # simulation run attributes - will be set in self._setup
         # at start of run
+        self._r_dist = {}
         self._cached_param_grads = {}
         self._args = None
         self._kwargs = None
@@ -81,19 +33,22 @@ class HMC(TracePosterior):
         self._prototype_trace = None
         super(HMC, self).__init__()
 
+    def _get_trace(self, z):
+        z_trace = self._prototype_trace.copy()
+        for name, value in z.items():
+            z_trace.nodes[name]['value'] = value
+        return poutine.trace(poutine.replay(self.model, trace=z_trace)) \
+            .get_trace(*self._args, **self._kwargs)
+
     def _log_prob(self, z):
         """
         Return log pdf of the model with sample sites replayed from z_trace
         """
-        z_trace = self._prototype_trace.copy()
-        for name, value in z.items():
-            z_trace.nodes[name]['value'] = value
-        model_trace = poutine.trace(poutine.replay(self.model, trace=z_trace)) \
-            .get_trace(*self._args, **self._kwargs)
-        return model_trace.log_pdf()
+        return self._get_trace(z).log_pdf()
 
     def _grad_potential(self, z):
         log_joint_prob = self._log_prob(z)
+        print(log_joint_prob)
         log_joint_prob.backward()
         grad_potential = {}
         for name, value in z.items():
@@ -106,13 +61,17 @@ class HMC(TracePosterior):
         potential_energy = - self._log_prob(z)
         return kinetic_energy + potential_energy
 
-    def _setup(self, *args, **kwargs):
+    def setup(self, *args, **kwargs):
         self._accept_cnt = 0
         self._args = args
         self._kwargs = kwargs
         # set the trace prototype to inter-convert between trace object
         # and dict object used by the integrator
         self._prototype_trace = poutine.trace(self.model).get_trace(*args, **kwargs)
+        for name, node in self._prototype_trace.iter_stochastic_nodes():
+            r_mu = torch_zeros_like(node['value'])
+            r_sigma = torch_ones_like(node['value'])
+            self._r_dist[name] = dist.Normal(mu=r_mu, sigma=r_sigma)
         for name, node in self._prototype_trace.iter_stochastic_nodes():
             if not node['fn'].reparameterized:
                 raise ValueError('Found non-reparameterized node in the model at site: {}'.format(name))
@@ -124,65 +83,45 @@ class HMC(TracePosterior):
         for name, node in self._prototype_trace.iter_param_nodes():
             self._cached_param_grads[name] = node['value'].grad
 
-    def _cleanup(self):
+    def cleanup(self):
         # reset the param values to those stored before the hmc run
         for name, grad in self._cached_param_grads.items():
             param = pyro.get_param_store().get_param(name)
             param.grad = grad
 
-    def _traces(self, *args, **kwargs):
-        self._setup(*args, **kwargs)
+    def sample(self, trace, time_step):
+        z = {name: node['value'] for name, node in trace.iter_stochastic_nodes()}
         # sample p's from the distribution given by p_dist
-        r_dist = {}
-        z = {name: node['value'] for name, node in self._prototype_trace.iter_stochastic_nodes()}
-        for name, value in z.items():
-            r_mu = torch_zeros_like(value)
-            r_sigma = torch_ones_like(value)
-            r_dist[name] = dist.Normal(mu=r_mu, sigma=r_sigma)
-
-        # Run HMC iterations
-        t = 0
-        print('Simulating using HMC...')
-        while t < self.warmup_steps + self.num_samples:
-            if t % 100 == 0:
-                print('Iteration: {}'.format(t))
-            # sample momentum
-            r = {name: pyro.sample('r_{}_t={}'.format(name, t), r_dist[name]) for name in z}
-            z_new, r_new = verlet_integrator(z,
-                                             r,
-                                             self._grad_potential,
-                                             self.step_size,
-                                             self.num_steps)
-            energy_proposal = self._energy(z_new, r_new)
-            energy_current = self._energy(z, r)
-            # print("Energy - current: {}".format(energy_current))
-            # print("Energy - proposal: {}".format(energy_proposal))
-            delta_energy = energy_proposal - energy_current
-            t += 1
-            rand = pyro.sample('rand_t='.format(t), dist.uniform, a=ng_zeros(1), b=ng_ones(1))
-            if rand.log().data[0] < -delta_energy.data[0]:
-                self._accept_cnt += 1
-                z = z_new
-            if t < self.warmup_steps:
-                continue
-            yield (z, self._log_prob(z))
-        self._cleanup()
+        # sample momentum
+        r = {name: pyro.sample('r_{}_t={}'.format(name, time_step), self._r_dist[name]) for name in z}
+        z_new, r_new = verlet_integrator(z,
+                                         r,
+                                         self._grad_potential,
+                                         self.step_size,
+                                         self.num_steps)
+        energy_proposal = self._energy(z_new, r_new)
+        energy_current = self._energy(z, r)
+        delta_energy = energy_proposal - energy_current
+        rand = pyro.sample('rand_t='.format(time_step), dist.uniform, a=ng_zeros(1), b=ng_ones(1))
+        if rand.log().data[0] < -delta_energy.data[0]:
+            self._accept_cnt += 1
+            z = z_new
+        return self._get_trace(z)
 
     @property
-    def acceptance_ratio(self):
-        if self._accept_cnt is None:
-            raise AttributeError("The attribute _accept_cnt is not updated until the first simulation run.")
-        return self._accept_cnt / (self.warmup_steps + self.num_samples)
+    def num_accepts(self):
+        return self._accept_cnt
 
 
 def test_normal_normal():
     def model(data):
         mu = pyro.param('mu', Variable(torch.zeros(10), requires_grad=True))
         x = pyro.sample('x', dist.normal, mu=mu, sigma=Variable(torch.ones(10)))
-        pyro.sample('data', dist.normal, obs=data, mu=x, sigma=Variable(torch.ones(10)))
+        y = pyro.sample('y', dist.normal, mu=x, sigma=Variable(torch.ones(10)))
+        pyro.sample('data', dist.normal, obs=data, mu=y, sigma=Variable(torch.ones(10)))
 
     data = Variable(torch.ones(1, 10))
-    hmc = HMC(model, step_size=0.6, num_steps=3, num_samples=400, warmup_steps=50)
+    hmc = MCMC(model, kernel=HMC, num_samples=400, warmup_steps=50, step_size=0.6, num_steps=3)
     traces = []
     for t, _ in hmc._traces(data):
         traces.append(t['x'])
@@ -190,7 +129,7 @@ def test_normal_normal():
     print('Posterior mean:')
     print(torch.mean(torch.stack(traces), 0).data)
     # gradients should not have been back-propagated.
-    assert pyro.get_param_store().get_param('mu').grad is None
+    print(pyro.get_param_store().get_param('mu').grad)
 
 
 def test_verlet_integrator():
@@ -215,7 +154,7 @@ def test_verlet_integrator():
 
 
 def main():
-    test_verlet_integrator()
+    # test_verlet_integrator()
     test_normal_normal()
 
 

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -31,7 +31,7 @@ class MCMC(TracePosterior):
             self._t += 1
             if self._t < self.warmup_steps:
                 continue
-            yield (trace, trace.log_pdf())
+            yield (trace, 1.0)
         self.kernel.cleanup()
 
     @property

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -7,13 +7,8 @@ from pyro import poutine
 
 
 class MCMC(TracePosterior):
-    def __init__(self,
-                 model,
-                 kernel,
-                 warmup_steps,
-                 num_samples,
-                 *args,
-                 **kwargs):
+
+    def __init__(self, model, kernel, warmup_steps, num_samples, *args, **kwargs):
         self.model = model
         self.num_samples = num_samples
         self.warmup_steps = warmup_steps

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import, division, print_function
+
+import logging
+
+from pyro.infer import TracePosterior
+from pyro import poutine
+
+
+class MCMC(TracePosterior):
+    def __init__(self,
+                 model,
+                 kernel,
+                 warmup_steps,
+                 num_samples,
+                 *args,
+                 **kwargs):
+        self.model = model
+        self.num_samples = num_samples
+        self.warmup_steps = warmup_steps
+        self.kernel = kernel(model, *args, **kwargs)
+        self.logger = logging.getLogger(__name__)
+        super(MCMC, self).__init__()
+
+    def _traces(self, *args, **kwargs):
+        self.kernel.setup(*args, **kwargs)
+        # Run MCMC iterations
+        self.t = 0
+        trace = poutine.trace(self.model).get_trace(*args, **kwargs)
+        while self.t < self.warmup_steps + self.num_samples:
+            if self.t % 100 == 0:
+                self.logger.info('MCMC Iteration: {}'.format(self.t))
+            trace = self.kernel.sample(trace, self.t)
+            self.t += 1
+            if self.t < self.warmup_steps:
+                continue
+            yield (trace, trace.log_pdf())
+        self.kernel.cleanup()
+
+    @property
+    def acceptance_ratio(self):
+        return self.kernel.num_accepts / self.t

--- a/pyro/infer/mcmc/trace_kernel.py
+++ b/pyro/infer/mcmc/trace_kernel.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function
+
+from abc import abstractmethod, ABCMeta
+
+from six import add_metaclass
+
+
+@add_metaclass(ABCMeta)
+class TraceKernel(object):
+    @abstractmethod
+    def setup(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def cleanup(self):
+        pass
+
+    @abstractmethod
+    def num_accepts(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def sample(self, trace, *args, **kwargs):
+        raise NotImplementedError

--- a/pyro/infer/mcmc/trace_kernel.py
+++ b/pyro/infer/mcmc/trace_kernel.py
@@ -7,6 +7,7 @@ from six import add_metaclass
 
 @add_metaclass(ABCMeta)
 class TraceKernel(object):
+
     @abstractmethod
     def setup(self, *args, **kwargs):
         pass

--- a/pyro/infer/mcmc/verlet_integrator.py
+++ b/pyro/infer/mcmc/verlet_integrator.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from torch.autograd import Variable
 
 

--- a/pyro/infer/mcmc/verlet_integrator.py
+++ b/pyro/infer/mcmc/verlet_integrator.py
@@ -1,0 +1,48 @@
+from torch.autograd import Variable
+
+
+def verlet_integrator(z, r, grad_potential, step_size, num_steps):
+    """
+    Velocity Verlet integrator.
+
+    :param z: dictionary of sample site names and their current values
+    :param r: dictionary of sample site names and corresponding momenta
+    :param grad_potential: function that returns gradient of the potential given z
+        for each sample site
+    :return: (z_next, r_next) having same types as (z, r)
+    """
+    # deep copy the current state - (z, r)
+    z_next = {key: val.clone().detach() for key, val in z.items()}
+    r_next = {key: val.clone().detach() for key, val in r.items()}
+    retain_grads(z_next)
+    grads = grad_potential(z_next)
+
+    for _ in range(num_steps):
+        # detach graph nodes for next iteration
+        detach_nodes(z_next)
+        detach_nodes(r_next)
+        for site_name in z_next:
+            # r(n+1/2)
+            r_next[site_name] = r_next[site_name] + 0.5 * step_size * (-grads[site_name])
+            # z(n+1)
+            z_next[site_name] = z_next[site_name] + step_size * r_next[site_name]
+        # retain gradients for intermediate nodes in backward step
+        retain_grads(z_next)
+        grads = grad_potential(z_next)
+        for site_name in r_next:
+            # r(n+1)
+            r_next[site_name] = r_next[site_name] + 0.5 * step_size * (-grads[site_name])
+    return z_next, r_next
+
+
+def retain_grads(z):
+    for value in z.values():
+        # XXX: can be removed with PyTorch 0.3
+        if value.is_leaf and not value.requires_grad:
+            value.requires_grad = True
+        value.retain_grad()
+
+
+def detach_nodes(z):
+    for key, value in z.items():
+        z[key] = Variable(value.data, requires_grad=True)

--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -162,3 +162,19 @@ class Trace(networkx.DiGraph):
         are not reparameterizable primitive distributions
         """
         return list(set(self.stochastic_nodes) - set(self.reparameterized_nodes))
+
+    def iter_param_nodes(self):
+        """
+        Returns an iterator over param nodes
+        """
+        for name, node in self.nodes.items():
+            if node["type"] == "param":
+                yield name, node
+
+    def iter_stochastic_nodes(self):
+        """
+        Returns an iterator over stochastic nodes
+        """
+        for name, node in self.nodes.items():
+            if node["type"] == "sample" and not node["is_observed"]:
+                yield name, node

--- a/tests/infer/test_hmc.py
+++ b/tests/infer/test_hmc.py
@@ -12,6 +12,7 @@ from pyro.infer.mcmc.mcmc import MCMC
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+
 class GaussianChain(object):
     def __init__(self, dim, n, mu_0, lambda_prec):
         self.dim = dim

--- a/tests/infer/test_hmc.py
+++ b/tests/infer/test_hmc.py
@@ -1,0 +1,58 @@
+import pytest
+import torch
+import pyro.distributions as dist
+from torch.autograd import Variable
+
+import pyro
+from pyro.infer.mcmc.hmc import HMC
+from pyro.infer.mcmc.mcmc import MCMC
+
+
+class GaussianChain(object):
+    def __init__(self, dim, n, mu_0, lambda_prec):
+        self.dim = dim
+        self.n = n
+        self.mu_0 = Variable(torch.Tensor(torch.ones(self.dim) * mu_0), requires_grad=True)
+        self.lambda_prec = Variable(torch.Tensor(torch.ones(self.dim) * lambda_prec))
+
+    def model(self, data):
+        mu = pyro.param('mu_0', self.mu_0)
+        lambda_prec = self.lambda_prec
+        for i in range(1, self.n + 1):
+            mu = pyro.sample('mu_{}'.format(i), dist.normal, mu, lambda_prec)
+        pyro.sample('obs', dist.normal, mu=mu, sigma=lambda_prec, obs=data)
+
+    def analytic_values(self, data):
+        lambda_tilde_posts = [self.lambda_prec]
+        for k in range(1, self.n):
+            lambda_tilde_k = (self.lambda_prec * lambda_tilde_posts[k - 1]) /\
+                (self.lambda_prec + lambda_tilde_posts[k - 1])
+            lambda_tilde_posts.append(lambda_tilde_k)
+        lambda_n_post = data.size()[0] * self.lambda_prec + lambda_tilde_posts[self.n - 1]
+
+        target_mus = [None] * self.n
+        target_mu_n = data.sum(dim=0) * self.lambda_prec / lambda_n_post +\
+            self.mu_0 * lambda_tilde_posts[self.n - 1] / lambda_n_post
+        target_mus[-1] = target_mu_n
+        for k in range(self.n-2, -1, -1):
+            target_mus[k] = (self.mu_0 * lambda_tilde_posts[k - 1] + target_mus[k+1] * self.lambda_prec) / \
+                            (self.lambda_prec + lambda_tilde_posts[k])
+        return target_mus
+
+
+@pytest.mark.parametrize('dim, n', [(10, 3)])
+def test_hmc_conj_gaussian(dim, n):
+    fixture = GaussianChain(dim, n, 0, 1)
+    data = Variable(torch.ones(n, dim))
+    mcmc_run = MCMC(fixture.model, kernel=HMC, num_samples=400, warmup_steps=50, step_size=0.5, num_steps=4)
+    traces = []
+    for t, _ in mcmc_run._traces(data):
+        traces.append(t.nodes['mu_3']['value'])
+    print('Acceptance ratio: {}'.format(mcmc_run.acceptance_ratio))
+    print('Posterior mean:')
+    print(torch.mean(torch.stack(traces), 0).data)
+
+
+# g = GaussianChain(2, 2, 0, 1)
+# data = Variable(torch.ones(1, 2))
+# print g.analytic_values(data)

--- a/tests/infer/test_hmc.py
+++ b/tests/infer/test_hmc.py
@@ -66,7 +66,7 @@ class TestFixture(object):
 
     @property
     def data(self):
-        return Variable(torch.ones(self.num_samples, self.dim))
+        return Variable(torch.ones(self.num_obs, self.dim))
 
     def analytic_means(self, data):
         return self.fixture.analytic_means(data)
@@ -80,11 +80,11 @@ def mse(t1, t2):
 
 
 @pytest.mark.parametrize('fixture', [
-    TestFixture(dim=10, chain_len=3, num_obs=1, step_size=0.5, num_steps=4),
-    TestFixture(dim=10, chain_len=3, num_obs=5, step_size=0.4, num_steps=3),
-    TestFixture(dim=10, chain_len=7, num_obs=5, step_size=0.4, num_steps=3),
+    TestFixture(dim=10, chain_len=3, num_obs=1, step_size=0.5, num_steps=4, num_samples=600),
+    TestFixture(dim=10, chain_len=3, num_obs=5, step_size=0.4, num_steps=3, num_samples=700),
+    TestFixture(dim=10, chain_len=7, num_obs=1, step_size=0.4, num_steps=4, num_samples=1300),
     ], ids=lambda x: x.id_fn())
-def test_hmc_conj_gaussian(fixture):
+def test_hmc_conjugate_gaussian(fixture):
     mcmc_run = MCMC(fixture.model,
                     kernel=HMC,
                     num_samples=fixture.num_samples,

--- a/tests/infer/test_hmc.py
+++ b/tests/infer/test_hmc.py
@@ -1,17 +1,18 @@
+from __future__ import absolute_import, division, print_function
+
 import logging
 from collections import defaultdict
 
 import pytest
 import torch
-import pyro.distributions as dist
 from torch.autograd import Variable
 
 import pyro
+import pyro.distributions as dist
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.mcmc import MCMC
 from pyro.infer.mcmc.verlet_integrator import verlet_integrator
 from tests.common import assert_equal
-
 
 logging.basicConfig(format='%(levelname)s %(message)s')
 logger = logging.getLogger(__name__)
@@ -19,6 +20,7 @@ logger.setLevel(logging.INFO)
 
 
 class GaussianChain(object):
+
     def __init__(self, dim, n, mu_0, lambda_prec):
         self.dim = dim
         self.n = n
@@ -44,13 +46,14 @@ class GaussianChain(object):
         target_mu_n = data.sum(dim=0) * self.lambda_prec / lambda_n_post +\
             self.mu_0 * lambda_tilde_posts[self.n - 1] / lambda_n_post
         target_mus[-1] = target_mu_n
-        for k in range(self.n-2, -1, -1):
+        for k in range(self.n - 2, -1, -1):
             target_mus[k] = (self.mu_0 * lambda_tilde_posts[k - 1] + target_mus[k+1] * self.lambda_prec) / \
                             (self.lambda_prec + lambda_tilde_posts[k])
         return target_mus
 
 
 class TestFixture(object):
+
     def __init__(self, dim, chain_len, num_obs, step_size, num_steps, num_samples=600):
         self.dim = dim
         self.chain_len = chain_len
@@ -79,52 +82,35 @@ def mse(t1, t2):
     return (t1 - t2).pow(2).mean()
 
 
-@pytest.mark.parametrize('fixture', [
-    TestFixture(dim=10, chain_len=3, num_obs=1, step_size=0.5, num_steps=4, num_samples=600),
-    TestFixture(dim=10, chain_len=3, num_obs=5, step_size=0.4, num_steps=3, num_samples=700),
-    TestFixture(dim=10, chain_len=7, num_obs=1, step_size=0.4, num_steps=4, num_samples=1300),
-    ], ids=lambda x: x.id_fn())
+@pytest.mark.parametrize(
+    'fixture', [
+        TestFixture(dim=10, chain_len=3, num_obs=1, step_size=0.5, num_steps=4, num_samples=600),
+        TestFixture(dim=10, chain_len=3, num_obs=5, step_size=0.4, num_steps=3, num_samples=700),
+        TestFixture(dim=10, chain_len=7, num_obs=1, step_size=0.4, num_steps=4, num_samples=1300),
+    ],
+    ids=lambda x: x.id_fn())
 def test_hmc_conjugate_gaussian(fixture):
-    mcmc_run = MCMC(fixture.model,
-                    kernel=HMC,
-                    num_samples=fixture.num_samples,
-                    warmup_steps=50,
-                    step_size=fixture.step_size,
-                    num_steps=fixture.num_steps)
+    mcmc_run = MCMC(
+        fixture.model,
+        kernel=HMC,
+        num_samples=fixture.num_samples,
+        warmup_steps=50,
+        step_size=fixture.step_size,
+        num_steps=fixture.num_steps)
     post_trace = defaultdict(list)
     for t, _ in mcmc_run._traces(fixture.data):
-        for i in range(1, fixture.chain_len+1):
+        for i in range(1, fixture.chain_len + 1):
             param_name = 'mu_' + str(i)
             post_trace[param_name].append(t.nodes[param_name]['value'])
     analytic_means = fixture.analytic_means(fixture.data)
     logger.info('Acceptance ratio: {}'.format(mcmc_run.acceptance_ratio))
-    for i in range(1, fixture.chain_len+1):
+    for i in range(1, fixture.chain_len + 1):
         param_name = 'mu_' + str(i)
         latent_mu = torch.mean(torch.stack(post_trace[param_name]), 0)
-        analytic_mean = analytic_means[i-1]
+        analytic_mean = analytic_means[i - 1]
         # Actual vs expected posterior means for the latents
         logger.info('Posterior - {}'.format(param_name))
         logger.info(latent_mu)
         logger.info('Posterior (analytic) - {}'.format(param_name))
-        logger.info(analytic_means[i-1])
+        logger.info(analytic_means[i - 1])
         assert_equal(mse(latent_mu, analytic_mean).data[0], 0, prec=0.01)
-
-
-def test_verlet_integrator():
-    def energy(q, p):
-        return 0.5 * p['x'] ** 2 + 0.5 * q['x'] ** 2
-
-    def grad(q):
-        return {'x': q['x']}
-
-    q = {'x': Variable(torch.Tensor([0.0]), requires_grad=True)}
-    p = {'x': Variable(torch.Tensor([1.0]), requires_grad=True)}
-    energy_cur = energy(q, p)
-    logger.info("Energy - current: {}".format(energy_cur.data[0]))
-    q_new, p_new = verlet_integrator(q, p, grad, 0.01, 100)
-    assert q_new['x'].data[0] != q['x'].data[0]
-    energy_new = energy(q_new, p_new)
-    assert_equal(energy_new, energy_cur)
-    logger.info("q_old: {}, p_old: {}".format(q['x'].data[0], p['x'].data[0]))
-    logger.info("q_new: {}, p_new: {}".format(q_new['x'].data[0], p_new['x'].data[0]))
-    logger.info("Energy - new: {}".format(energy_new.data[0]))

--- a/tests/infer/test_hmc.py
+++ b/tests/infer/test_hmc.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 
 import pytest
 import torch
@@ -20,96 +20,107 @@ logger.setLevel(logging.INFO)
 
 class GaussianChain(object):
 
-    def __init__(self, dim, n, mu_0, lambda_prec):
+    def __init__(self, dim, chain_len, num_obs):
         self.dim = dim
-        self.n = n
-        self.mu_0 = Variable(torch.Tensor(torch.ones(self.dim) * mu_0), requires_grad=True)
-        self.lambda_prec = Variable(torch.Tensor(torch.ones(self.dim) * lambda_prec))
+        self.chain_len = chain_len
+        self.num_obs = num_obs
+        self.mu_0 = Variable(torch.Tensor(torch.zeros(self.dim)), requires_grad=True)
+        self.lambda_prec = Variable(torch.Tensor(torch.ones(self.dim)))
 
     def model(self, data):
         mu = pyro.param('mu_0', self.mu_0)
         lambda_prec = self.lambda_prec
-        for i in range(1, self.n + 1):
+        for i in range(1, self.chain_len + 1):
             mu = pyro.sample('mu_{}'.format(i), dist.normal, mu=mu, sigma=Variable(lambda_prec.data))
         pyro.sample('obs', dist.normal, mu=mu, sigma=Variable(lambda_prec.data), obs=data)
-
-    def analytic_means(self, data):
-        lambda_tilde_posts = [self.lambda_prec]
-        for k in range(1, self.n):
-            lambda_tilde_k = (self.lambda_prec * lambda_tilde_posts[k - 1]) /\
-                (self.lambda_prec + lambda_tilde_posts[k - 1])
-            lambda_tilde_posts.append(lambda_tilde_k)
-        lambda_n_post = data.size()[0] * self.lambda_prec + lambda_tilde_posts[self.n - 1]
-
-        target_mus = [None] * self.n
-        target_mu_n = data.sum(dim=0) * self.lambda_prec / lambda_n_post +\
-            self.mu_0 * lambda_tilde_posts[self.n - 1] / lambda_n_post
-        target_mus[-1] = target_mu_n
-        for k in range(self.n - 2, -1, -1):
-            target_mus[k] = (self.mu_0 * lambda_tilde_posts[k - 1] + target_mus[k+1] * self.lambda_prec) / \
-                            (self.lambda_prec + lambda_tilde_posts[k])
-        return target_mus
-
-
-class TestFixture(object):
-
-    def __init__(self, dim, chain_len, num_obs, step_size, num_steps, num_samples=600):
-        self.dim = dim
-        self.chain_len = chain_len
-        self.num_obs = num_obs
-        self.step_size = step_size
-        self.num_steps = num_steps
-        self.num_samples = num_samples
-        self.fixture = GaussianChain(dim, chain_len, 0, 1)
-
-    @property
-    def model(self):
-        return self.fixture.model
 
     @property
     def data(self):
         return Variable(torch.ones(self.num_obs, self.dim))
 
-    def analytic_means(self, data):
-        return self.fixture.analytic_means(data)
-
     def id_fn(self):
         return 'dim={}_chain-len={}_num_obs={}'.format(self.dim, self.chain_len, self.num_obs)
 
 
-def mse(t1, t2):
-    return (t1 - t2).pow(2).mean()
+def rmse(t1, t2):
+    return (t1 - t2).pow(2).mean().sqrt()
+
+
+T = namedtuple('TestCase', ['fixture', 'hmc_params', 'expected_means', 'expected_precs', 'mean_tol', 'std_tol'])
+
+# TODO: delete slow test cases once code is in master
+TEST_CASES = [
+    T(GaussianChain(dim=10, chain_len=3, num_obs=1),
+      hmc_params={'step_size': 0.5,
+                  'num_steps': 4,
+                  'num_samples': 800,
+                  'warmup_steps': 50},
+      expected_means=[0.25, 0.50, 0.75],
+      expected_precs=[1.33, 1, 1.33],
+      mean_tol=0.03,
+      std_tol=0.06),
+    # XXX: Very sensitive to HMC parameters. Biased estimate is obtained
+    # without enough samples and/or larger step size.
+    T(GaussianChain(dim=5, chain_len=2, num_obs=10000),
+      hmc_params={'step_size': 0.013,
+                  'num_steps': 25,
+                  'num_samples': 2000,
+                  'warmup_steps': 500},
+      expected_means=[0.5, 1.0],
+      expected_precs=[2.0, 10000],
+      mean_tol=0.05,
+      std_tol=0.05),
+    T(GaussianChain(dim=10, chain_len=4, num_obs=1),
+      hmc_params={'step_size': 0.46,
+                  'num_steps': 5,
+                  'num_samples': 1200,
+                  'warmup_steps': 300},
+      expected_means=[0.20, 0.40, 0.60, 0.80],
+      expected_precs=[1.25, 0.83, 0.83, 1.25],
+      mean_tol=0.06,
+      std_tol=0.06),
+    T(GaussianChain(dim=5, chain_len=9, num_obs=1),
+      hmc_params={'step_size': 0.3,
+                  'num_steps': 8,
+                  'num_samples': 3000,
+                  'warmup_steps': 500},
+      expected_means=[0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90],
+      expected_precs=[1.11, 0.63, 0.48, 0.42, 0.4, 0.42, 0.48, 0.63, 1.11],
+      mean_tol=0.08,
+      std_tol=0.08),
+]
+
+TEST_IDS = [t[0].id_fn() for t in TEST_CASES]
 
 
 @pytest.mark.parametrize(
-    'fixture', [
-        TestFixture(dim=10, chain_len=3, num_obs=1, step_size=0.5, num_steps=4, num_samples=600),
-        TestFixture(dim=10, chain_len=3, num_obs=5, step_size=0.4, num_steps=3, num_samples=700),
-        TestFixture(dim=10, chain_len=7, num_obs=1, step_size=0.4, num_steps=4, num_samples=1300),
-    ],
-    ids=lambda x: x.id_fn())
-def test_hmc_conjugate_gaussian(fixture):
-    mcmc_run = MCMC(
-        fixture.model,
-        kernel=HMC,
-        num_samples=fixture.num_samples,
-        warmup_steps=50,
-        step_size=fixture.step_size,
-        num_steps=fixture.num_steps)
+    'fixture, hmc_params, expected_means, expected_precs, mean_tol, std_tol', TEST_CASES, ids=TEST_IDS)
+def test_hmc_conjugate_gaussian(fixture, hmc_params, expected_means, expected_precs, mean_tol, std_tol):
+    mcmc_run = MCMC(fixture.model, kernel=HMC, **hmc_params)
+    pyro.get_param_store().clear()
     post_trace = defaultdict(list)
     for t, _ in mcmc_run._traces(fixture.data):
         for i in range(1, fixture.chain_len + 1):
             param_name = 'mu_' + str(i)
             post_trace[param_name].append(t.nodes[param_name]['value'])
-    analytic_means = fixture.analytic_means(fixture.data)
     logger.info('Acceptance ratio: {}'.format(mcmc_run.acceptance_ratio))
     for i in range(1, fixture.chain_len + 1):
         param_name = 'mu_' + str(i)
         latent_mu = torch.mean(torch.stack(post_trace[param_name]), 0)
-        analytic_mean = analytic_means[i - 1]
+        latent_std = torch.std(torch.stack(post_trace[param_name]), 0)
+        expected_mean = Variable(torch.ones(fixture.dim) * expected_means[i - 1])
+        expected_std = 1 / torch.sqrt(Variable(torch.ones(fixture.dim) * expected_precs[i - 1]))
+
         # Actual vs expected posterior means for the latents
-        logger.info('Posterior - {}'.format(param_name))
+        logger.info('Posterior mean (actual) - {}'.format(param_name))
         logger.info(latent_mu)
-        logger.info('Posterior (analytic) - {}'.format(param_name))
-        logger.info(analytic_means[i - 1])
-        assert_equal(mse(latent_mu, analytic_mean).data[0], 0, prec=0.01)
+        logger.info('Posterior mean (expected) - {}'.format(param_name))
+        logger.info(expected_mean)
+        assert_equal(rmse(latent_mu, expected_mean).data[0], 0, prec=mean_tol)
+
+        # Actual vs expected posterior precisions for the latents
+        logger.info('Posterior std (actual) - {}'.format(param_name))
+        logger.info(latent_std)
+        logger.info('Posterior std (expected) - {}'.format(param_name))
+        logger.info(expected_std)
+        assert_equal(rmse(latent_std, expected_std).data[0], 0, prec=std_tol)

--- a/tests/infer/test_hmc.py
+++ b/tests/infer/test_hmc.py
@@ -11,7 +11,6 @@ import pyro
 import pyro.distributions as dist
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.mcmc import MCMC
-from pyro.infer.mcmc.verlet_integrator import verlet_integrator
 from tests.common import assert_equal
 
 logging.basicConfig(format='%(levelname)s %(message)s')

--- a/tests/infer/test_integrator.py
+++ b/tests/infer/test_integrator.py
@@ -1,0 +1,80 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import torch
+from torch.autograd import Variable
+
+from pyro.infer.mcmc.verlet_integrator import verlet_integrator
+from tests.common import assert_equal
+
+
+def test_harmonic_oscillator():
+
+    def energy(q, p):
+        return 0.5 * p['x']**2 + 0.5 * q['x']**2
+
+    def grad(q):
+        return {'x': q['x']}
+
+    q = {'x': Variable(torch.Tensor([0.0]), requires_grad=True)}
+    p = {'x': Variable(torch.Tensor([1.0]), requires_grad=True)}
+    energy_cur = energy(q, p)
+    print("Energy - current: {}".format(energy_cur.data[0]))
+    q_new, p_new = verlet_integrator(q, p, grad, 0.01, 100)
+    assert q_new['x'].data[0] != q['x'].data[0]
+    energy_new = energy(q_new, p_new)
+    assert_equal(energy_new, energy_cur)
+    assert_equal(q_new['x'].data[0], np.sin(1.0), prec=1.0e-4)
+    assert_equal(p_new['x'].data[0], np.cos(1.0), prec=1.0e-4)
+    print("q_old: {}, p_old: {}".format(q['x'].data[0], p['x'].data[0]))
+    print("q_new: {}, p_new: {}".format(q_new['x'].data[0], p_new['x'].data[0]))
+    print("Energy - new: {}".format(energy_new.data[0]))
+    print("-------------------------------------")
+
+
+def test_circular_planetary_motion():
+
+    def energy(q, p):
+        return 0.5 * p['x'] ** 2 + 0.5 * p['y'] ** 2 - \
+            1.0 / torch.pow(q['x'] ** 2 + q['y'] ** 2, 0.5)
+
+    def grad(q):
+        return {
+            'x': q['x'] / torch.pow(q['x']**2 + q['y']**2, 1.5),
+            'y': q['y'] / torch.pow(q['x']**2 + q['y']**2, 1.5)
+        }
+
+    q = {'x': Variable(torch.Tensor([1.0]), requires_grad=True), 'y': Variable(torch.Tensor([0.0]), requires_grad=True)}
+    p = {'x': Variable(torch.Tensor([0.0]), requires_grad=True), 'y': Variable(torch.Tensor([1.0]), requires_grad=True)}
+    energy_initial = energy(q, p)
+    print("*** circular planetary motion ***")
+    print("initial energy: {}".format(energy_initial.data[0]))
+    q_new, p_new = verlet_integrator(q, p, grad, 0.01, 628)
+    energy_final = energy(q_new, p_new)
+    assert_equal(energy_final, energy_initial)
+    assert_equal(q_new['x'].data[0], 1.0, prec=5.0e-3)
+    assert_equal(q_new['y'].data[0], 0.0, prec=5.0e-3)
+    print("final energy: {}".format(energy_final.data[0]))
+    print("-------------------------------------")
+
+
+def test_quartic_oscillator():
+
+    def energy(q, p):
+        return 0.5 * p['x']**2 + 0.25 * torch.pow(q['x'], 4.0)
+
+    def grad(q):
+        return {'x': torch.pow(q['x'], 3.0)}
+
+    q = {'x': Variable(torch.Tensor([0.02]), requires_grad=True)}
+    p = {'x': Variable(torch.Tensor([0.0]), requires_grad=True)}
+    energy_initial = energy(q, p)
+    print("*** quartic oscillator ***")
+    print("initial energy: {}".format(energy_initial.data[0]))
+    q_new, p_new = verlet_integrator(q, p, grad, 0.1, 1810)
+    energy_final = energy(q_new, p_new)
+    assert_equal(energy_final, energy_initial)
+    assert_equal(q_new['x'].data[0], -0.02, prec=1.0e-4)
+    assert_equal(p_new['x'].data[0], 0.0, prec=1.0e-4)
+    print("final energy: {}".format(energy_final.data[0]))
+    print("-------------------------------------")


### PR DESCRIPTION
This is to get a discussion started around how the API for HMC should look like in Pyro. I have put in a very bare-bones HMC implementation (not well tested, or modularized) to guide the discussion. I have already had some really helpful discussions with @fritzo. I will create separate issues once we converge on the API and decide on what we would like to support in the very first version.

This version does the following:
 - The HMC class inherits from `TracePosterior` and returns a generator over traces.
 - It currently caches the values of the parameter gradients and resets them once the simulation is over. This is to ensure that none of the parameter values or their gradients are modified by the algorithm.
 -  The posterior is evaluated using all the data points. (see below).


### Discussion - Interface
 - [ ] Interface - Discussed with @fritzo, and one way to design the interface would be to in-place optimize the parameter values (consistent with #573) by placing an improper prior over them. It seem like this is the direction that Stan has taken too (and Tensorflow might take as well). Right now, the param values are treated as fixed and the trace can be used to get the posterior distribution over the sample sites. 
 - [ ] [If HMC inherits off of TracePosterior] We can use this with marginal and draw samples using `marginal(data)`. Since there is no data subsampling, it seems strange to have to supply the data argument each time (though I suppose `_dist_and_values` memoizes the call, so we are probably not rerunning the sim using the same data. Need to verify this!). Are there any other helper functions that we may need in AbstractInfer class? 
 - [ ] Does this satisfy other use cases - e.g. using this from within SVI? 

### Discussion - Near Term
 - [ ] Handling distribution parameters with constrained support. Right now this will just result in a rejection.
 - [ ] Initializing a good value for the mass matrix. Currently this is just an identity matrix.

### Discussion - Longer Term

 - [x] Does it makes sense to have mini-batch / subsampling support in the first version? If so, what are the best algorithms to look. @karalets mentioned about using SGLD for doing this. Update - defer until later, not possible with naive HMC.
 - [ ] Need to benchmark this, but please let me know if you notice potential scaling issues (aside from subsampling).
 - [ ] Other general helper utilities for assessing convergence, etc?

### Discussion (resolved):
 - [x] The leapfrog (verlet) integration is coupled to Pyro internals as it takes the execution trace from the previous step (latent state). This is not ideal, but I found that this was the easiest way to not have to convert a dictionary to a trace and vice-versa, as this can be directly passed to the function that computes the gradient of the potential. Any thoughts on modularizing this? Update - this is decoupled now.

 
Please put in any other issues worth discussing. 

EDIT - After addressing some issues with the previous version, this runs on current PyTorch.



