### PR TITLE
Added the RelaxedBernoulli and RelaxedCategorical distributions

### DIFF
--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -18,6 +18,8 @@ from pyro.distributions.normal import WrapNormal as Normal
 from pyro.distributions.one_hot_categorical import OneHotCategorical
 from pyro.distributions.poisson import Poisson
 from pyro.distributions.random_primitive import RandomPrimitive
+from pyro.distributions.relaxed_bernoulli import LogitRelaxedBernoulli, RelaxedBernoulli
+from pyro.distributions.relaxed_categorical import ExpRelaxedCategorical, RelaxedCategorical
 from pyro.distributions.uniform import Uniform
 
 # function aliases
@@ -25,6 +27,10 @@ bernoulli = RandomPrimitive(Bernoulli)
 beta = RandomPrimitive(Beta)
 binomial = RandomPrimitive(Binomial)
 categorical = RandomPrimitive(Categorical)
+logit_relaxed_bernoulli = RandomPrimitive(LogitRelaxedBernoulli)
+relaxed_bernoulli = RandomPrimitive(RelaxedBernoulli)
+exp_relaxed_categorical = RandomPrimitive(ExpRelaxedCategorical)
+relaxed_categorical = RandomPrimitive(RelaxedCategorical)
 cauchy = RandomPrimitive(Cauchy)
 delta = RandomPrimitive(Delta)
 dirichlet = RandomPrimitive(Dirichlet)

--- a/pyro/distributions/relaxed_bernoulli.py
+++ b/pyro/distributions/relaxed_bernoulli.py
@@ -1,0 +1,112 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+from torch.autograd import Variable
+
+from pyro.distributions.distribution import Distribution
+from pyro.distributions.transformed_distribution import SigmoidBijector, TransformedDistribution
+from pyro.distributions.util import _get_clamping_buffer, get_probs_and_logits
+
+
+class LogitRelaxedBernoulli(Distribution):
+    """
+    An LogitRelaxedBernoulli distribution is the log-transform of the RelaxedBernoulli
+    distribution. Each element of the vector of samples is in the range (-\infty, 0].
+
+    The intended use is to downstream compute the exp of these values, which is
+    then from a RelaxedOneHotCategorical distribution.
+
+    :param torch.Tensor temperature: Relaxation temperature. Should be a
+        positive, 1-dimensional Tensor.
+    :param torch.autograd.Variable ps: Probabilities. Should lie in the
+        interval `[0,1]`.
+    :param logits: Log odds, i.e. :math:`\\log(\\frac{p}{1 - p})`. Either `ps` or
+        `logits` should be specified, but not both.
+    :param batch_size: The number of elements in the batch used to generate
+        a sample. The batch dimension will be the leftmost dimension in the
+        generated sample.
+    :param log_pdf_mask: Tensor that is applied to the batch log pdf values
+        as a multiplier. The most common use case is supplying a boolean
+        tensor mask to mask out certain batch sites in the log pdf computation.
+    """
+    reparameterized = True
+
+    def __init__(self, temperature, ps=None, logits=None, batch_size=None, log_pdf_mask=None, *args, **kwargs):
+        if (ps is None) == (logits is None):
+            raise ValueError("Got ps={}, logits={}. Either `ps` or `logits` must be specified, "
+                             "but not both.".format(ps, logits))
+        if not isinstance(temperature, Variable) or \
+                len(temperature.size()) > 1 or temperature.data[0] <= 0:
+            raise ValueError("temperature should be a 1-dimensional torch.Tensor with positive value.")
+        self.temperature = temperature
+        self.ps, self.logits = get_probs_and_logits(ps=ps, logits=logits, is_multidimensional=False)
+        self.log_pdf_mask = log_pdf_mask
+        if self.ps.dim() == 1 and batch_size is not None:
+            self.ps = self.ps.expand(batch_size, self.ps.size(0))
+            self.logits = self.logits.expand(batch_size, self.logits.size(0))
+            if log_pdf_mask is not None and log_pdf_mask.dim() == 1:
+                self.log_pdf_mask = log_pdf_mask.expand(batch_size, log_pdf_mask.size(0))
+        super(LogitRelaxedBernoulli, self).__init__(*args, **kwargs)
+
+    def batch_shape(self, x=None):
+        """
+        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`.
+        """
+        event_dim = 1
+        ps = self.ps
+        if x is not None:
+            if x.size()[-event_dim] != ps.size()[-event_dim]:
+                raise ValueError("The event size for the data and distribution parameters must match.\n"
+                                 "Expected x.size()[-1] == self.ps.size()[-1], but got {} vs {}".format(
+                                     x.size(-1), ps.size(-1)))
+            try:
+                ps = self.ps.expand_as(x)
+            except RuntimeError as e:
+                raise ValueError("Parameter `ps` with shape {} is not broadcastable to "
+                                 "the data shape {}. \nError: {}".format(ps.size(), x.size(), str(e)))
+
+        return ps.size()[:-event_dim]
+
+    def event_shape(self):
+        """
+        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`.
+        """
+        event_dim = 1
+        return self.ps.size()[-event_dim:]
+
+    def sample(self):
+        """
+        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`.
+        """
+        uniforms = Variable(torch.zeros(self.logits.data.size()).uniform_())
+        eps = _get_clamping_buffer(uniforms)
+        uniforms = uniforms.clamp(min=eps, max=1 - eps)
+        logistic = uniforms.log() - (-uniforms).log1p()
+        z = (logistic + self.logits) / self.temperature
+        return z if self.reparameterized else z.detach()
+
+    def analytic_mean(self):
+        """
+        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
+        """
+        return self.logits / self.temperature
+
+    def batch_log_pdf(self, x):
+        """
+        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
+        """
+        batch_log_pdf_shape = self.batch_shape(x) + (1,)
+        u = -self.temperature * x + self.logits
+        log_prob = self.temperature.log() + u - 2 * torch.log(1 + torch.exp(u))
+        # XXX this allows for the user to mask out certain parts of the score, for example
+        # when the data is a ragged tensor. also useful for KL annealing. this entire logic
+        # will likely be done in a better/cleaner way in the future
+        if self.log_pdf_mask is not None:
+            log_prob = log_prob * self.log_pdf_mask
+        return torch.sum(log_prob, -1).contiguous().view(batch_log_pdf_shape)
+
+
+class RelaxedBernoulli(Distribution):
+
+    def __new__(cls, *args, **kwargs):
+        return TransformedDistribution(LogitRelaxedBernoulli(*args, **kwargs), SigmoidBijector())

--- a/pyro/distributions/relaxed_categorical.py
+++ b/pyro/distributions/relaxed_categorical.py
@@ -1,0 +1,131 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.autograd import Variable
+
+from pyro.distributions.distribution import Distribution
+from pyro.distributions.transformed_distribution import ExpBijector, TransformedDistribution
+from pyro.distributions.util import _get_clamping_buffer, get_probs_and_logits, log_gamma
+
+
+class ExpRelaxedCategorical(Distribution):
+    """ExpRelaxedCategorical distribution.
+
+    Conditinuous version of the log of a Categorical distribution using softmax
+    relaxation of Gumbel-Max distribution. Returns a log of a point in the
+    simplex. Based on the interface to OneHotCategorical
+
+    Implementation based on [1].
+
+    :param torch.Tensor temperature: Relaxation temperature. Should be a
+        positive, 1-dimensional Tensor.
+    :param ps: Probabilities. These should be non-negative and normalized
+        along the rightmost axis.
+    :type ps: torch.autograd.Variable
+    :param logits: Log probability values. When exponentiated, these should
+        sum to 1 along the last axis. Either `ps` or `logits` should be
+        specified but not both.
+    :type logits: torch.autograd.Variable
+    :param batch_size: Optional number of elements in the batch used to
+        generate a sample. The batch dimension will be the leftmost dimension
+        in the generated sample.
+    :type batch_size: int
+
+    [1] THE CONCRETE DISTRIBUTION: A CONTINUOUS RELAXATION OF DISCRETE RANDOM VARIABLES
+    (Maddison et al, 2017)
+    [2] CATEGORICAL REPARAMETERIZATION WITH GUMBEL-SOFTMAX
+    (Jang et al, 2017)
+    """
+    reparameterized = True
+
+    def __init__(self, temperature, ps=None, logits=None, batch_size=None, log_pdf_mask=None, *args, **kwargs):
+        self.temperature = temperature
+        if (ps is None) == (logits is None):
+            raise ValueError("Got ps={}, logits={}. Either `ps` or `logits` must be specified, "
+                             "but not both.".format(ps, logits))
+        self.ps, self.logits = get_probs_and_logits(ps, logits, is_multidimensional=True)
+        self.log_pdf_mask = log_pdf_mask
+        if self.ps.dim() == 1 and batch_size is not None:
+            self.ps = self.ps.expand(batch_size, self.ps.size(0))
+            self.logits = self.logits.expand(batch_size, self.logits.size(0))
+            if log_pdf_mask is not None and log_pdf_mask.dim() == 1:
+                self.log_pdf_mask = log_pdf_mask.expand(batch_size, log_pdf_mask.size(0))
+        super(ExpRelaxedCategorical, self).__init__(*args, **kwargs)
+
+    def _process_data(self, x):
+        if x is not None:
+            if isinstance(x, list):
+                x = np.array(x)
+            elif not isinstance(x, (Variable, torch.Tensor, np.ndarray)):
+                raise TypeError(("Data should be of type: list, Variable, Tensor, or numpy array"
+                                 "but was of {}".format(str(type(x)))))
+        return x
+
+    def batch_shape(self, x=None):
+        """
+        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
+        """
+        event_dim = 1
+        ps = self.ps
+        if x is not None:
+            x = self._process_data(x)
+            try:
+                ps = self.ps.expand(x.size()[:-event_dim] + self.event_shape())
+            except RuntimeError as e:
+                raise ValueError("Parameter `ps` with shape {} is not broadcastable to "
+                                 "the data shape {}. \nError: {}".format(ps.size(), x.size(), e))
+        return ps.size()[:-event_dim]
+
+    def event_shape(self):
+        """
+        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
+        """
+        event_dim = 1
+        return self.ps.size()[-event_dim:]
+
+    def shape(self, x=None):
+        """
+        Ref: :py:meth:`pyro.distributions.distribution.Distribution.shape`
+        """
+        return self.batch_shape(x) + self.event_shape()
+
+    def sample(self):
+        """
+        Draws either a single sample (if self.logits.dim() == 1), or one sample per param (if self.logits.dim() == 2).
+        Reparameterized.
+        """
+
+        # Sample Gumbels, G_k = -log(-log(U))
+        uniforms = torch.zeros(self.logits.data.size()).uniform_()
+        eps = _get_clamping_buffer(uniforms)
+        uniforms = uniforms.clamp(min=eps, max=1 - eps)
+        gumbels = Variable(uniforms.log().mul(-1).log().mul(-1))
+
+        # Reparameterize
+        z = F.log_softmax((self.logits + gumbels) / self.temperature, dim=-1)
+        return z if self.reparameterized else z.detach()
+
+    def batch_log_pdf(self, x):
+        """
+        Evaluates log probability densities for one or a batch of samples and parameters.
+
+        :return: tensor with log probabilities for each of the batches.
+        :rtype: torch.autograd.Variable
+        """
+        n = self.event_shape()[0]
+        logits = self.logits.expand(self.shape(x))
+        log_scale = Variable(log_gamma(
+            torch.Tensor([n]).expand(self.batch_shape(x)))) - self.temperature.log().mul(-(n - 1))
+        scores = logits.log() + x.mul(-self.temperature)
+        scores = scores.sum(dim=-1)
+
+        log_part = n * logits.mul(x.mul(-self.temperature).exp()).sum(dim=-1).log()
+        return (scores - log_part + log_scale).contiguous().view(self.batch_shape(x) + (1,))
+
+
+class RelaxedCategorical(Distribution):
+
+    def __new__(cls, *args, **kwargs):
+        return TransformedDistribution(ExpRelaxedCategorical(*args, **kwargs), ExpBijector())

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -8,7 +8,8 @@ import scipy.stats as sp
 
 import pyro.distributions as dist
 from pyro.distributions import (Bernoulli, Beta, Binomial, Categorical, Cauchy, Dirichlet, Exponential, Gamma,
-                                HalfCauchy, LogNormal, Multinomial, Normal, OneHotCategorical, Poisson, Uniform)
+                                HalfCauchy, LogNormal, Multinomial, Normal, OneHotCategorical, Poisson,
+                                RelaxedBernoulli, RelaxedCategorical, Uniform)
 from tests.distributions.dist_fixture import Fixture
 
 continuous_dists = [
@@ -121,6 +122,31 @@ continuous_dists = [
                  'test_data': [[1.0], [0.35]]}
             ],
             scipy_arg_fn=lambda mu, gamma: ((), {"loc": np.array(mu), "scale": np.array(gamma)})),
+    Fixture(pyro_dist=(dist.relaxed_bernoulli, RelaxedBernoulli),
+            examples=[
+                {'ps': [0.25],
+                 'temperature': [0.01],
+                 'test_data': [0.8]},
+                {'ps': [0.25, 0.25],
+                 'temperature': [0.6],
+                 'test_data': [[[0.2, 0.3]], [[0.15, 0.25]], [[0.3, 0.35]]]},
+                {'logits': [math.log(p / (1 - p)) for p in (0.25, 0.25)],
+                 'temperature': [0.2],
+                 'test_data': [[[0.25, 0.28]], [[0.15, 0.25]], [[0.3, 0.35]]]},
+            ],
+            prec=0.01,
+            min_samples=10000,
+            is_discrete=False),
+    Fixture(pyro_dist=(dist.relaxed_categorical, RelaxedCategorical),
+            examples=[
+                {'logits': [0.1, 1],
+                 'temperature': [0.2],
+                 'test_data': [[0.01, 0.99]]},
+                {'ps': [[0.1, 0.6, 0.3],
+                        [0.2, 0.4, 0.4]],
+                 'temperature': [0.8],
+                 'test_data': [[0.05, .65, 0.3], [0.12, 0.58, 0.3]]}
+            ]),
 ]
 
 discrete_dists = [

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-import pytest
 import torch
 
+import pytest
 from pyro.distributions import RandomPrimitive
 from pyro.util import ng_ones, ng_zeros
 from tests.common import assert_equal, xfail_if_not_implemented


### PR DESCRIPTION
This PR adds (basic) implementations of the Gumbel-softmax relaxed distributions (with some help from @srush).

It is blocked on https://github.com/uber/pyro/issues/293 since otherwise `test_batch_log_pdf` fails. It also adds a new skip to the log-pdf tests that currently exist, if scipy args aren't given - let me know if there's another solution to that problem that you'd prefer.

Before it should be merged, I think there's some useful tests to write. What do you think about testing whether the log-pdf implementation matches the `sample()` by implementing a rejection sampler and somehow automatically checking a q-q plot? Also, a temp -> 0 test should definitely be included. 