### PR TITLE
Minor tweaks to the AIR example

### DIFF
--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -16,7 +16,6 @@ from torch.autograd import Variable
 import pyro
 import pyro.distributions as dist
 from modules import Identity, Encoder, Decoder, MLP, Predict
-from pyro.distributions import Bernoulli, Uniform, Delta
 from pyro.util import ng_zeros, ng_ones, zeros
 
 

--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -47,7 +47,6 @@ class AIR(nn.Module):
                  use_masking=True,
                  use_baselines=True,
                  baseline_scalar=None,
-                 fudge_z_pres=False,
                  scale_prior_mean=3.0,
                  scale_prior_sd=0.1,
                  pos_prior_mean=0.0,
@@ -62,10 +61,9 @@ class AIR(nn.Module):
         self.window_size = window_size
         self.z_what_size = z_what_size
         self.rnn_hidden_size = rnn_hidden_size
-        self.use_masking = use_masking and not fudge_z_pres
-        self.use_baselines = use_baselines and not fudge_z_pres
+        self.use_masking = use_masking
+        self.use_baselines = use_baselines
         self.baseline_scalar = baseline_scalar
-        self.fudge_z_pres = fudge_z_pres
         self.likelihood_sd = likelihood_sd
         self.use_cuda = use_cuda
 
@@ -140,11 +138,9 @@ class AIR(nn.Module):
     def model_step(self, t, n, prev, z_pres_prior_p=default_z_pres_prior_p):
 
         # Sample presence indicators.
-        if not self.fudge_z_pres:
-            z_pres_dist = Bernoulli(z_pres_prior_p(t) * prev.z_pres)
-        else:
-            z_pres_dist = Uniform(self.ng_zeros(n, 1), self.ng_ones(n, 1))
-        z_pres = pyro.sample('z_pres_{}'.format(t), z_pres_dist)
+        z_pres = pyro.sample('z_pres_{}'.format(t),
+                             dist.bernoulli,
+                             z_pres_prior_p(t) * prev.z_pres)
 
         # If zero is sampled for a data point, then no more objects
         # will be added to its output image. We can't
@@ -239,12 +235,9 @@ class AIR(nn.Module):
         bl_value, bl_h, bl_c = self.baseline_step(prev, inputs)
 
         # Sample presence.
-        if not self.fudge_z_pres:
-            z_pres_dist = Bernoulli(z_pres_p * prev.z_pres)
-        else:
-            z_pres_dist = Delta(z_pres_p * prev.z_pres)
         z_pres = pyro.sample('z_pres_{}'.format(t),
-                             z_pres_dist,
+                             dist.bernoulli,
+                             z_pres_p * prev.z_pres,
                              baseline=dict(baseline_value=bl_value))
 
         log_pdf_mask = z_pres if self.use_masking else None

--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -170,8 +170,7 @@ def main(**kwargs):
                       'pos_prior_mean',
                       'pos_prior_sd',
                       'scale_prior_mean',
-                      'scale_prior_sd',
-                      'fudge_z_pres']
+                      'scale_prior_sd']
     model_args = {key: getattr(args, key) for key in model_arg_keys if key in args}
     air = AIR(
         num_steps=args.model_steps,
@@ -322,8 +321,6 @@ if __name__ == '__main__':
                         help='std. dev. of the window scale prior')
     parser.add_argument('--no-masking', action='store_true', default=False,
                         help='do not mask out the costs of unused choices')
-    parser.add_argument('--fudge-z-pres', action='store_true', default=False,
-                        help='fudge z_pres to remove discreteness for testing')
     parser.add_argument('--seed', type=int, help='random seed', default=None)
     parser.add_argument('-v', '--verbose', action='store_true', default=False,
                         help='write hyper parameters and network architecture to stdout')

--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -198,7 +198,7 @@ def main(**kwargs):
         vis.images(draw_many(x, tensor_to_objs(latents_to_tensor(z))))
 
     def per_param_optim_args(module_name, param_name, tags):
-        lr = 1e-3 if 'baseline' in tags else 1e-4
+        lr = args.baseline_learning_rate if 'baseline' in tags else args.learning_rate
         return {'lr': lr}
 
     svi = SVI(air.model, air.guide,
@@ -250,6 +250,10 @@ if __name__ == '__main__':
                         help='number of optimization steps to take')
     parser.add_argument('-b', '--batch-size', type=int, default=64,
                         help='batch size')
+    parser.add_argument('-lr', '--learning-rate', type=float, default=1e-4,
+                        help='learning rate')
+    parser.add_argument('-blr', '--baseline-learning-rate', type=float, default=1e-3,
+                        help='baseline learning rate')
     parser.add_argument('--progress-every', type=int, default=1,
                         help='number of steps between writing progress to stdout')
     parser.add_argument('--eval-every', type=int, default=0,


### PR DESCRIPTION
This PR:

1. Removes the option to `fudge_z_pres`, as promised in #589
2. Adds a CLA for learning rates.