### PR TITLE
Fix some minor typos of svi tutorials

### DIFF
--- a/tutorial/source/svi_part_i.ipynb
+++ b/tutorial/source/svi_part_i.ipynb
@@ -148,7 +148,7 @@
     "from pyro.optim import Adam\n",
     "\n",
     "def per_param_callable(module_name, param_name, tags):\n",
-    "    if 'param_name' == 'my_special_parameter':\n",
+    "    if param_name == 'my_special_parameter':\n",
     "        return {\"lr\": 0.010}\n",
     "    else:\n",
     "        return {\"lr\": 0.001}\n",

--- a/tutorial/source/svi_part_ii.ipynb
+++ b/tutorial/source/svi_part_ii.ipynb
@@ -152,7 +152,7 @@
     "def model(data):\n",
     "    beta = pyro.sample(\"beta\", ...) # sample the global RV\n",
     "    for i in pyro.irange(\"locals\", len(data)):\n",
-    "        z_i = pyro.sample(\"z_i\", ...)\n",
+    "        z_i = pyro.sample(\"z_{}\".format(i), ...)\n",
     "        # compute the parameter used to define the observation \n",
     "        # likelihood using the local random variable\n",
     "        theta_i = compute_something(z_i) \n",
@@ -167,7 +167,7 @@
     "    beta = pyro.sample(\"beta\", ...) # sample the global RV\n",
     "    for i in pyro.irange(\"locals\", len(data), subsample_size=5):\n",
     "        # sample the local RVs\n",
-    "        pyro.sample(\"z_i\", ..., lambda_i)\n",
+    "        pyro.sample(\"z_{}\".format(i), ..., lambda_i)\n",
     "```\n",
     "\n",
     "Note that crucially the indices will only be subsampled once in the guide; the Pyro backend makes sure that the same set of indices are used during execution of the model. For this reason `subsample_size` only needs to be specified in the guide."

--- a/tutorial/source/svi_part_iii.ipynb
+++ b/tutorial/source/svi_part_iii.ipynb
@@ -94,7 +94,7 @@
     "- \\sum_i \\log q_{\\phi}({\\bf z}_i | {\\rm Pa}_q ({\\bf z}_i))$$\n",
     "\n",
     "where we've broken the log ratio $\\log p_{\\theta}({\\bf x}, {\\bf z})/q_{\\phi}({\\bf z})$ into an observation log likelihood piece and a sum over the different latent random variables $\\{{\\bf z}_i \\}$. We've also introduced the notation \n",
-    "${\\rm Pa}_p (\\cdot)$ and ${\\rm Pa}_q (\\cdot)$ to denote the parents of a given random variable in the model and in the guide, respectively. (The reader might worry what the appropriate notion of dependency would be in the case of general stochastic functions; here we simply mean regular dependency within a single execution trace). The point is that different terms in the cost function have different dependencies on the random variables $\\{ {\\bf z}_i \\}$ and this is something we can leverage.\n",
+    "${\\rm Pa}_p (\\cdot)$ and ${\\rm Pa}_q (\\cdot)$ to denote the parents of a given random variable in the model and in the guide, respectively. (The reader might worry what the appropriate notion of dependency would be in the case of general stochastic functions; here we simply mean regular ol' dependency within a single execution trace). The point is that different terms in the cost function have different dependencies on the random variables $\\{ {\\bf z}_i \\}$ and this is something we can leverage.\n",
     "\n",
     "To make a long story short, for any non-reparameterizable latent random variable ${\\bf z}_i$ the surrogate loss is going to have a term \n",
     "\n",

--- a/tutorial/source/svi_part_iii.ipynb
+++ b/tutorial/source/svi_part_iii.ipynb
@@ -94,7 +94,7 @@
     "- \\sum_i \\log q_{\\phi}({\\bf z}_i | {\\rm Pa}_q ({\\bf z}_i))$$\n",
     "\n",
     "where we've broken the log ratio $\\log p_{\\theta}({\\bf x}, {\\bf z})/q_{\\phi}({\\bf z})$ into an observation log likelihood piece and a sum over the different latent random variables $\\{{\\bf z}_i \\}$. We've also introduced the notation \n",
-    "${\\rm Pa}_p (\\cdot)$ and ${\\rm Pa}_q (\\cdot)$ to denote the parents of a given random variable in the model and in the guide, respectively. (The reader might worry what the appropriate notion of dependency would be in the case of general stochastic functions; here we simply mean regular ol' dependency within a single execution trace). The point is that different terms in the cost function have different dependencies on the random variables $\\{ {\\bf z}_i \\}$ and this is something we can leverage.\n",
+    "${\\rm Pa}_p (\\cdot)$ and ${\\rm Pa}_q (\\cdot)$ to denote the parents of a given random variable in the model and in the guide, respectively. (The reader might worry what the appropriate notion of dependency would be in the case of general stochastic functions; here we simply mean regular dependency within a single execution trace). The point is that different terms in the cost function have different dependencies on the random variables $\\{ {\\bf z}_i \\}$ and this is something we can leverage.\n",
     "\n",
     "To make a long story short, for any non-reparameterizable latent random variable ${\\bf z}_i$ the surrogate loss is going to have a term \n",
     "\n",


### PR DESCRIPTION
This pull request fixes some minor typos which I catch from SVI tutorials. 