### PR TITLE
Add helper pyro.distributions.util.broadcast_shape()

### DIFF
--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -5,6 +5,28 @@ import torch.nn.functional as F
 from torch.autograd import Variable
 
 
+def broadcast_shape(*shapes):
+    """
+    Similar to ``np.broadcast()`` but for shapes.
+    Equivalent to ``np.broadcast(*map(np.empty, shapes)).shape``.
+
+    :param tuple shapes: shapes of tensors.
+    :returns: broadcasted shape
+    :rtype: tuple
+    :raises: ValueError
+    """
+    reversed_shape = []
+    for shape in shapes:
+        for i, size in enumerate(reversed(shape)):
+            if i >= len(reversed_shape):
+                reversed_shape.append(size)
+            elif reversed_shape[i] == 1:
+                reversed_shape[i] = size
+            elif size != 1 and reversed_shape[i] != size:
+                raise ValueError('shape mismatch: objects cannot be broadcast to a single shape')
+    return tuple(reversed(reversed_shape))
+
+
 def log_gamma(xx):
     gamma_coeff = [
         76.18009172947146,

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import pytest
+
+from pyro.distributions.util import broadcast_shape
+
+
+@pytest.mark.parametrize('shapes', [
+    ([],),
+    ([1],),
+    ([2],),
+    ([], []),
+    ([], [1]),
+    ([], [2]),
+    ([1], []),
+    ([2], []),
+    ([1], [2]),
+    ([2], [1]),
+    ([2], [2]),
+    ([2], [3, 1]),
+    ([2, 1], [3]),
+    ([2, 1], [1, 3]),
+    ([1, 2, 4, 1, 3], [6, 7, 1, 1, 5, 1]),
+    ([], [3, 1], [2], [4, 3, 1], [5, 4, 1, 1]),
+])
+def test_broadcast_shapes(shapes):
+    assert broadcast_shape(*shapes) == np.broadcast(*map(np.empty, shapes)).shape
+
+
+@pytest.mark.parametrize('shapes', [
+    ([3], [4]),
+    ([2, 1], [1, 3, 1]),
+])
+def test_broadcast_shapes_error(shapes):
+    with pytest.raises(ValueError):
+        broadcast_shape(*shapes)


### PR DESCRIPTION
This is useful for testing and simplifying broadcasting logic for batching tensors. Note that `np.broadcast()` does not work for torch variables on older PyTorch (e.g. 0.2 release). This prints the same error message as `np.broadcast()` when broadcasting fails.

## Tested

Added a unit test to demonstrate agreement with `np.broadcast()`.