### PR TITLE
Wrap torch.distributions.Normal for use in Pyro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ test-all: lint FORCE
 test-cuda: lint FORCE
 	PYRO_TENSOR_TYPE=torch.cuda.DoubleTensor pytest -vx -n 8 --stage unit
 
+test-torch-dist: lint FORCE
+	PYRO_USE_TORCH_DISTRIBUTIONS=1 pytest -vx -n auto --stage unit
+
 clean: FORCE
 	git clean -dfx -e pyro-egg.info
 

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -13,7 +13,7 @@ from pyro.distributions.gamma import Gamma
 from pyro.distributions.half_cauchy import HalfCauchy
 from pyro.distributions.log_normal import LogNormal
 from pyro.distributions.multinomial import Multinomial
-from pyro.distributions.normal import Normal
+from pyro.distributions.normal import WrapNormal as Normal
 from pyro.distributions.one_hot_categorical import OneHotCategorical
 from pyro.distributions.poisson import Poisson
 from pyro.distributions.random_primitive import RandomPrimitive

--- a/pyro/distributions/normal.py
+++ b/pyro/distributions/normal.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 import numpy as np
 import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import broadcast_shape, torch_wrapper
 
 
 class Normal(Distribution):
@@ -105,3 +108,61 @@ class Normal(Distribution):
         Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
         """
         return torch.pow(self.sigma, 2)
+
+
+class TorchNormal(Distribution):
+    """
+    Compatibility wrapper around
+    `torch.distributions.Normal <http://pytorch.org/docs/master/_modules/torch/distributions.html#Normal`_
+    """
+    try:
+        reparameterized = torch.distributions.Normal.reparameterized
+    except (ImportError, AttributeError):
+        reparameterized = False
+    enumerable = False
+
+    def __init__(self, mu, sigma, *args, **kwargs):
+        self._torch_dist = torch.distributions.Normal(mean=mu, std=sigma)
+        self._param_shape = torch.Size(broadcast_shape(mu.size(), sigma.size(), strict=True))
+        super(TorchNormal, self).__init__(*args, **kwargs)
+
+    def batch_shape(self, x=None):
+        x_shape = [] if x is None else x.size()
+        shape = torch.Size(broadcast_shape(x_shape, self._param_shape, strict=True))
+        return shape[:-1]
+
+    def event_shape(self):
+        return self._param_shape[-1:]
+
+    def sample(self):
+        return self._torch_dist.sample()
+
+    def batch_log_pdf(self, x):
+        batch_log_pdf_shape = self.batch_shape(x) + (1,)
+        if self.reparameterized:
+            log_pxs = self._torch_dist.log_prob(x, requires_grad=True)
+        else:
+            log_pxs = self._torch_dist.log_prob(x)
+        batch_log_pdf = torch.sum(log_pxs, -1)
+        return batch_log_pdf.contiguous().view(batch_log_pdf_shape)
+
+
+def _warn_fallback(message):
+    warnings.warn('{}, falling back to Normal'.format(message), DeprecationWarning)
+
+
+@torch_wrapper(Normal)
+def WrapNormal(mu, sigma, batch_size=None, log_pdf_mask=None, *args, **kwargs):
+    reparameterized = kwargs.pop('reparameterized', None)
+    if not hasattr(torch, 'distributions'):
+        _warn_fallback('Missing module torch.distribution')
+    elif not hasattr(torch.distributions, 'Normal'):
+        _warn_fallback('Missing class torch.distribution.Normal')
+    elif batch_size is not None or log_pdf_mask is not None or args or kwargs:
+        _warn_fallback('Unsupported args')
+    elif reparameterized and not TorchNormal.reparameterized:
+        _warn_fallback('Unsupported reparameterized=True')
+    else:
+        return TorchNormal(mu, sigma, reparameterized=reparameterized)
+    return Normal(mu, sigma, batch_size=batch_size, log_pdf_mask=log_pdf_mask,
+                  reparameterized=reparameterized, *args, **kwargs)

--- a/pyro/distributions/normal.py
+++ b/pyro/distributions/normal.py
@@ -113,7 +113,7 @@ class Normal(Distribution):
 class TorchNormal(Distribution):
     """
     Compatibility wrapper around
-    `torch.distributions.Normal <http://pytorch.org/docs/master/_modules/torch/distributions.html#Normal`_
+    `torch.distributions.Normal <http://pytorch.org/docs/master/_modules/torch/distributions.html#Normal>`_
     """
     try:
         reparameterized = torch.distributions.Normal.reparameterized

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -46,28 +46,6 @@ def broadcast_shape(*shapes, **kwargs):
     return tuple(reversed(reversed_shape))
 
 
-def broadcast_shape(*shapes):
-    """
-    Similar to ``np.broadcast()`` but for shapes.
-    Equivalent to ``np.broadcast(*map(np.empty, shapes)).shape``.
-
-    :param tuple shapes: shapes of tensors.
-    :returns: broadcasted shape
-    :rtype: tuple
-    :raises: ValueError
-    """
-    reversed_shape = []
-    for shape in shapes:
-        for i, size in enumerate(reversed(shape)):
-            if i >= len(reversed_shape):
-                reversed_shape.append(size)
-            elif reversed_shape[i] == 1:
-                reversed_shape[i] = size
-            elif size != 1 and reversed_shape[i] != size:
-                raise ValueError('shape mismatch: objects cannot be broadcast to a single shape')
-    return tuple(reversed(reversed_shape))
-
-
 def log_gamma(xx):
     gamma_coeff = [
         76.18009172947146,

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -5,6 +5,28 @@ import torch.nn.functional as F
 from torch.autograd import Variable
 
 
+def broadcast_shape(*shapes):
+    """
+    Similar to ``np.broadcast()`` but for shapes.
+    Equivalent to ``np.broadcast(*map(np.empty, shapes)).shape``.
+
+    :param tuple shapes: shapes of tensors.
+    :returns: broadcasted shape
+    :rtype: tuple
+    :raises: ValueError
+    """
+    reversed_shape = []
+    for shape in shapes:
+        for i, size in enumerate(reversed(shape)):
+            if i >= len(reversed_shape):
+                reversed_shape.append(size)
+            elif reversed_shape[i] == 1:
+                reversed_shape[i] = size
+            elif size != 1 and reversed_shape[i] != size:
+                raise ValueError('shape mismatch: objects cannot be broadcast to a single shape')
+    return tuple(reversed(reversed_shape))
+
+
 def log_gamma(xx):
     gamma_coeff = [
         76.18009172947146,

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -24,7 +24,7 @@ from pyro.distributions.util import broadcast_shape
     ([1, 2, 4, 1, 3], [6, 7, 1, 1, 5, 1]),
     ([], [3, 1], [2], [4, 3, 1], [5, 4, 1, 1]),
 ])
-def test_broadcast_shapes(shapes):
+def test_broadcast_shape(shapes):
     assert broadcast_shape(*shapes) == np.broadcast(*map(np.empty, shapes)).shape
 
 
@@ -32,6 +32,43 @@ def test_broadcast_shapes(shapes):
     ([3], [4]),
     ([2, 1], [1, 3, 1]),
 ])
-def test_broadcast_shapes_error(shapes):
+def test_broadcast_shape_error(shapes):
     with pytest.raises(ValueError):
         broadcast_shape(*shapes)
+
+
+@pytest.mark.parametrize('shapes', [
+    ([],),
+    ([1],),
+    ([2],),
+    ([], []),
+    ([], [1]),
+    ([], [2]),
+    ([1], []),
+    ([2], []),
+    ([1], [1]),
+    ([2], [2]),
+    ([2], [2]),
+    ([2], [3, 2]),
+    ([2, 3], [3]),
+    ([2, 3], [2, 3]),
+    ([4], [1, 2, 3, 4], [2, 3, 4], [3, 4]),
+])
+def test_broadcast_shape_strict(shapes):
+    assert broadcast_shape(*shapes, strict=True) == np.broadcast(*map(np.empty, shapes)).shape
+
+
+@pytest.mark.parametrize('shapes', [
+    ([1], [2]),
+    ([2], [1]),
+    ([3], [4]),
+    ([2], [3, 1]),
+    ([2, 1], [3]),
+    ([2, 1], [1, 3]),
+    ([2, 1], [1, 3, 1]),
+    ([1, 2, 4, 1, 3], [6, 7, 1, 1, 5, 1]),
+    ([], [3, 1], [2], [4, 3, 1], [5, 4, 1, 1]),
+])
+def test_broadcast_shape_strict_error(shapes):
+    with pytest.raises(ValueError):
+        broadcast_shape(*shapes, strict=True)

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import pytest
+
+from pyro.distributions.util import broadcast_shape
+
+
+@pytest.mark.parametrize('shapes', [
+    ([],),
+    ([1],),
+    ([2],),
+    ([], []),
+    ([], [1]),
+    ([], [2]),
+    ([1], []),
+    ([2], []),
+    ([1], [2]),
+    ([2], [1]),
+    ([2], [2]),
+    ([2], [3, 1]),
+    ([2, 1], [3]),
+    ([2, 1], [1, 3]),
+    ([1, 2, 4, 1, 3], [6, 7, 1, 1, 5, 1]),
+    ([], [3, 1], [2], [4, 3, 1], [5, 4, 1, 1]),
+])
+def test_broadcast_shapes(shapes):
+    assert broadcast_shape(*shapes) == np.broadcast(*map(np.empty, shapes)).shape
+
+
+@pytest.mark.parametrize('shapes', [
+    ([3], [4]),
+    ([2, 1], [1, 3, 1]),
+])
+def test_broadcast_shapes_error(shapes):
+    with pytest.raises(ValueError):
+        broadcast_shape(*shapes)


### PR DESCRIPTION
Addresses #606 

This creates an optional wrapper to use `torch.distributions.Normal` in Pyro. The torch version is only used if all of the following are satisfied:
- The environment variable `PYRO_USE_TORCH_DISTRIBUTIONS=1` is set
- The `torch.distributions` module exists (it is missing in PyTorch 0.2 release)
- The `torch.distributions.Normal` class exists
- All requested features are available (e.g. `torch.distributions.Normal` is reparameterized if `reparameterized=True`, also `log_pdf_mask` is not supported).

If any of the previous conditions are not satisfied, Pyro falls back to the standard implementation.

## Tested

The torch distribution will not be exercised on travis. Tests pass locally except for an [unrelated bug](https://github.com/pytorch/pytorch/issues/3914) in PyTorch master 0.4.0a0+709fcfd.