### PR TITLE
Add default logging support

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -5,6 +5,7 @@ import copy
 import warnings
 from collections import OrderedDict
 from inspect import isclass
+import logging
 
 import torch
 from torch.autograd import Variable
@@ -16,6 +17,9 @@ from pyro.poutine import _PYRO_STACK, condition, do  # noqa: F401
 from pyro.util import apply_stack, deep_getattr, get_tensor_data, ones, set_rng_seed, zeros  # noqa: F401
 
 __version__ = '0.1.2'
+
+# Default logger to prevent 'No handler found' warning.
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
 def get_param_store():

--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 import pyro.poutine as poutine
 
 from .abstract_infer import TracePosterior
+
+logger = logging.getLogger(__name__)
 
 
 class Importance(TracePosterior):
@@ -22,7 +26,7 @@ class Importance(TracePosterior):
         super(Importance, self).__init__()
         if num_samples is None:
             num_samples = 10
-            print("num_samples not provided, defaulting to {}".format(num_samples))
+            logger.warn("num_samples not provided, defaulting to {}".format(num_samples))
         if guide is None:
             # propose from the prior by making a guide from the model by hiding observes
             guide = poutine.block(model, hide_types=["observe"])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 # create log handler for tests
 handler = logging.StreamHandler()
-formatter = logging.Formatter('%(levelname).1s %(name)s \n %(message)s')
+formatter = logging.Formatter('%(levelname).1s %(name)s \t %(message)s')
 handler.setFormatter(formatter)
 
 # set default logging level for tests

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 # create log handler for tests
 handler = logging.StreamHandler()
-formatter = logging.Formatter('%(levelname)s - %(message)s')
+formatter = logging.Formatter('%(levelname).1s %(name)s \n %(message)s')
 handler.setFormatter(formatter)
 
 # set default logging level for tests

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,14 @@
 from __future__ import absolute_import, division, print_function
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# create log handler for tests
+handler = logging.StreamHandler()
+formatter = logging.Formatter('%(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+
+# set default logging level for tests
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 import numpy as np
 import pytest
 import torch
@@ -12,6 +14,8 @@ from pyro.infer import SVI
 from pyro.optim import Adam
 from pyro.util import ng_ones, ng_zeros
 from tests.common import assert_equal
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("reparameterized", [True, False], ids=["reparam", "nonreparam"])
@@ -48,6 +52,6 @@ def test_subsample_gradient(trace_graph, reparameterized, subsample):
 
     expected_grads = {'mu': np.array([0.5, -2.0]), 'sigma': np.array([2.0])}
     for name in sorted(params):
-        print('\nexpected {} = {}'.format(name, expected_grads[name]))
-        print('actual   {} = {}'.format(name, actual_grads[name]))
+        logger.info('\nexpected {} = {}'.format(name, expected_grads[name]))
+        logger.info('actual   {} = {}'.format(name, actual_grads[name]))
     assert_equal(actual_grads, expected_grads, prec=precision)

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
 import warnings
 
 import pytest
@@ -10,6 +11,8 @@ import pyro
 import pyro.distributions as dist
 from pyro.infer import SVI
 from pyro.optim import Adam
+
+logger = logging.getLogger(__name__)
 
 # This file tests a variety of model,guide pairs with valid and invalid structure.
 
@@ -44,7 +47,7 @@ def assert_warning(model, guide, **kwargs):
         inference.step()
         assert len(w), 'No warnings were raised'
         for warning in w:
-            print(warning)
+            logger.warn(warning)
 
 
 @pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -47,7 +47,7 @@ def assert_warning(model, guide, **kwargs):
         inference.step()
         assert len(w), 'No warnings were raised'
         for warning in w:
-            logger.warn(warning)
+            logger.info(warning)
 
 
 @pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -98,7 +98,7 @@ class GaussianChainTests(TestCase):
     def do_elbo_test(self, reparameterized, n_steps, lr, prec, difficulty=1.0):
         n_repa_nodes = torch.sum(self.which_nodes_reparam) if not reparameterized else self.N
         logger.info(" - - - - - DO GAUSSIAN %d-CHAIN ELBO TEST  [reparameterized = %s; %d/%d] - - - - - " %
-              (self.N, reparameterized, n_repa_nodes, self.N))
+                    (self.N, reparameterized, n_repa_nodes, self.N))
         if self.N < 0:
             def array_to_string(y):
                 return str(map(lambda x: "%.3f" % x.data.cpu().numpy()[0], y))
@@ -363,9 +363,9 @@ class GaussianPyramidTests(TestCase):
         n_repa_nodes = torch.sum(self.which_nodes_reparam) if not reparameterized \
             else len(self.q_topo_sort)
         logger.info((" - - - DO GAUSSIAN %d-LAYERED PYRAMID ELBO TEST " +
-              "(with a total of %d RVs) [reparameterized=%s; %d/%d; perm=%s] - - -") %
-              (self.N, (2 ** self.N) - 1, reparameterized, n_repa_nodes,
-               len(self.q_topo_sort), model_permutation))
+                     "(with a total of %d RVs) [reparameterized=%s; %d/%d; perm=%s] - - -") %
+                    (self.N, (2 ** self.N) - 1, reparameterized, n_repa_nodes,
+                     len(self.q_topo_sort), model_permutation))
         pyro.clear_param_store()
 
         def model(*args, **kwargs):

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -103,12 +103,12 @@ class GaussianChainTests(TestCase):
             def array_to_string(y):
                 return str(map(lambda x: "%.3f" % x.data.cpu().numpy()[0], y))
 
-        logger.debug("lambdas: " + array_to_string(self.lambdas))
-        logger.debug("target_mus: " + array_to_string(self.target_mus[1:]))
-        logger.debug("target_kappas: " + array_to_string(self.target_kappas[1:]))
-        logger.debug("lambda_posts: " + array_to_string(self.lambda_posts[1:]))
-        logger.debug("lambda_tilde_posts: " + array_to_string(self.lambda_tilde_posts))
-        pyro.clear_param_store()
+            logger.debug("lambdas: " + array_to_string(self.lambdas))
+            logger.debug("target_mus: " + array_to_string(self.target_mus[1:]))
+            logger.debug("target_kappas: " + array_to_string(self.target_kappas[1:]))
+            logger.debug("lambda_posts: " + array_to_string(self.lambda_posts[1:]))
+            logger.debug("lambda_tilde_posts: " + array_to_string(self.lambda_tilde_posts))
+            pyro.clear_param_store()
 
         def model(*args, **kwargs):
             next_mean = self.mu0

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -96,19 +96,18 @@ class GaussianChainTests(TestCase):
         self.do_elbo_test(False, 5000, 0.001, 0.05, difficulty=0.6)
 
     def do_elbo_test(self, reparameterized, n_steps, lr, prec, difficulty=1.0):
-        if self.verbose:
-            n_repa_nodes = torch.sum(self.which_nodes_reparam) if not reparameterized else self.N
-            print(" - - - - - DO GAUSSIAN %d-CHAIN ELBO TEST  [reparameterized = %s; %d/%d] - - - - - " %
-                  (self.N, reparameterized, n_repa_nodes, self.N))
-            if self.N < 0:
-                def array_to_string(y):
-                    return str(map(lambda x: "%.3f" % x.data.cpu().numpy()[0], y))
+        n_repa_nodes = torch.sum(self.which_nodes_reparam) if not reparameterized else self.N
+        logger.info(" - - - - - DO GAUSSIAN %d-CHAIN ELBO TEST  [reparameterized = %s; %d/%d] - - - - - " %
+              (self.N, reparameterized, n_repa_nodes, self.N))
+        if self.N < 0:
+            def array_to_string(y):
+                return str(map(lambda x: "%.3f" % x.data.cpu().numpy()[0], y))
 
-            logger.debug("lambdas: " + array_to_string(self.lambdas))
-            logger.debug("target_mus: " + array_to_string(self.target_mus[1:]))
-            logger.debug("target_kappas: " + array_to_string(self.target_kappas[1:]))
-            logger.debug("lambda_posts: " + array_to_string(self.lambda_posts[1:]))
-            logger.debug("lambda_tilde_posts: " + array_to_string(self.lambda_tilde_posts))
+        logger.debug("lambdas: " + array_to_string(self.lambdas))
+        logger.debug("target_mus: " + array_to_string(self.target_mus[1:]))
+        logger.debug("target_kappas: " + array_to_string(self.target_kappas[1:]))
+        logger.debug("lambda_posts: " + array_to_string(self.lambda_posts[1:]))
+        logger.debug("lambda_tilde_posts: " + array_to_string(self.lambda_tilde_posts))
         pyro.clear_param_store()
 
         def model(*args, **kwargs):
@@ -361,13 +360,12 @@ class GaussianPyramidTests(TestCase):
 
     def do_elbo_test(self, reparameterized, n_steps, lr, prec, beta1,
                      difficulty=1.0, model_permutation=False):
-        if self.verbose:
-            n_repa_nodes = torch.sum(self.which_nodes_reparam) if not reparameterized \
-                else len(self.q_topo_sort)
-            logger.info((" - - - DO GAUSSIAN %d-LAYERED PYRAMID ELBO TEST " +
-                  "(with a total of %d RVs) [reparameterized=%s; %d/%d; perm=%s] - - -") %
-                  (self.N, (2 ** self.N) - 1, reparameterized, n_repa_nodes,
-                   len(self.q_topo_sort), model_permutation))
+        n_repa_nodes = torch.sum(self.which_nodes_reparam) if not reparameterized \
+            else len(self.q_topo_sort)
+        logger.info((" - - - DO GAUSSIAN %d-LAYERED PYRAMID ELBO TEST " +
+              "(with a total of %d RVs) [reparameterized=%s; %d/%d; perm=%s] - - -") %
+              (self.N, (2 ** self.N) - 1, reparameterized, n_repa_nodes,
+               len(self.q_topo_sort), model_permutation))
         pyro.clear_param_store()
 
         def model(*args, **kwargs):

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -218,8 +218,8 @@ class NormalNormalNormalTests(TestCase):
             log_sig_prime_error = param_mse("log_sig_q_prime", -0.5 * torch.log(2.0 * self.lam0))
 
             if k % 500 == 0:
-                logger.debug("errors:  %.4f, %.4f" % (mu_error, log_sig_error), end='')
-                logger.debug(", %.4f, %.4f" % (mu_prime_error, log_sig_prime_error), end='')
+                logger.debug("errors:  %.4f, %.4f" % (mu_error, log_sig_error))
+                logger.debug(", %.4f, %.4f" % (mu_prime_error, log_sig_prime_error))
                 logger.debug(", %.4f" % kappa_error)
 
         self.assertEqual(0.0, mu_error, prec=prec)

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -339,8 +339,8 @@ class PoissonGammaTests(TestCase):
             svi.step()
             alpha_error = param_abs_error("alpha_q_log", self.log_alpha_n)
             beta_error = param_abs_error("beta_q_log", self.log_beta_n)
-            if k % 500 == 0 and self.verbose:
-                print("alpha_q_log_error, beta_q_log_error: %.4f, %.4f" % (alpha_error, beta_error))
+            if k % 500 == 0:
+                logger.debug("alpha_q_log_error, beta_q_log_error: %.4f, %.4f" % (alpha_error, beta_error))
 
         self.assertEqual(0.0, alpha_error, prec=0.08)
         self.assertEqual(0.0, beta_error, prec=0.08)

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -7,6 +7,7 @@ from torch import nn as nn
 from torch.autograd import Variable
 from torch.nn import Parameter
 
+import logging
 import pyro
 import pyro.distributions as dist
 import pyro.optim as optim
@@ -17,6 +18,7 @@ from tests.common import TestCase
 from tests.distributions.test_transformed_distribution import AffineExp
 
 pytestmark = pytest.mark.stage("integration", "integration_batch_2")
+logger = logging.getLogger(__name__)
 
 
 def param_mse(name, target):
@@ -48,7 +50,6 @@ class NormalNormalTests(TestCase):
         self.analytic_log_sig_n = -0.5 * torch.log(self.analytic_lam_n)
         self.analytic_mu_n = self.sum_data * (self.lam / self.analytic_lam_n) +\
             self.mu0 * (self.lam0 / self.analytic_lam_n)
-        self.verbose = True
 
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, 1000)
@@ -58,8 +59,7 @@ class NormalNormalTests(TestCase):
         self.do_elbo_test(False, 5000)
 
     def do_elbo_test(self, reparameterized, n_steps):
-        if self.verbose:
-            print(" - - - - - DO NORMALNORMAL ELBO TEST  [reparameterized = %s] - - - - - " % reparameterized)
+        logger.info(" - - - - - DO NORMALNORMAL ELBO TEST  [reparameterized = %s] - - - - - " % reparameterized)
         pyro.clear_param_store()
 
         def model():
@@ -91,8 +91,8 @@ class NormalNormalTests(TestCase):
 
             mu_error = param_mse("mu_q", self.analytic_mu_n)
             log_sig_error = param_mse("log_sig_q", self.analytic_log_sig_n)
-            if k % 250 == 0 and self.verbose:
-                print("mu error, log(sigma) error:  %.4f, %.4f" % (mu_error, log_sig_error))
+            if k % 250 == 0:
+                logger.debug("mu error, log(sigma) error:  %.4f, %.4f" % (mu_error, log_sig_error))
 
         self.assertEqual(0.0, mu_error, prec=0.03)
         self.assertEqual(0.0, log_sig_error, prec=0.03)
@@ -119,7 +119,6 @@ class NormalNormalNormalTests(TestCase):
         self.analytic_log_sig_n = -0.5 * torch.log(self.analytic_lam_n)
         self.analytic_mu_n = self.sum_data * (self.lam / self.analytic_lam_n) +\
             self.mu0 * (self.lam0 / self.analytic_lam_n)
-        self.verbose = True
 
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, True, 5000, 0.02, 0.002, False, False)
@@ -137,10 +136,9 @@ class NormalNormalNormalTests(TestCase):
                           use_decaying_avg_baseline=False)
 
     def do_elbo_test(self, repa1, repa2, n_steps, prec, lr, use_nn_baseline, use_decaying_avg_baseline):
-        if self.verbose:
-            print(" - - - - - DO NORMALNORMALNORMAL ELBO TEST - - - - - -")
-            print("[reparameterized = %s, %s; nn_baseline = %s, decaying_baseline = %s]" %
-                  (repa1, repa2, use_nn_baseline, use_decaying_avg_baseline))
+        logger.info(" - - - - - DO NORMALNORMALNORMAL ELBO TEST - - - - - -")
+        logger.info("[reparameterized = %s, %s; nn_baseline = %s, decaying_baseline = %s]" %
+                    (repa1, repa2, use_nn_baseline, use_decaying_avg_baseline))
         pyro.clear_param_store()
 
         if use_nn_baseline:
@@ -219,10 +217,10 @@ class NormalNormalNormalTests(TestCase):
             kappa_error = param_mse("kappa_q", 0.5 * ng_ones(1))
             log_sig_prime_error = param_mse("log_sig_q_prime", -0.5 * torch.log(2.0 * self.lam0))
 
-            if k % 500 == 0 and self.verbose:
-                print("errors:  %.4f, %.4f" % (mu_error, log_sig_error), end='')
-                print(", %.4f, %.4f" % (mu_prime_error, log_sig_prime_error), end='')
-                print(", %.4f" % kappa_error)
+            if k % 500 == 0:
+                logger.debug("errors:  %.4f, %.4f" % (mu_error, log_sig_error), end='')
+                logger.debug(", %.4f, %.4f" % (mu_prime_error, log_sig_prime_error), end='')
+                logger.debug(", %.4f" % kappa_error)
 
         self.assertEqual(0.0, mu_error, prec=prec)
         self.assertEqual(0.0, log_sig_error, prec=prec)
@@ -250,11 +248,9 @@ class BernoulliBetaTests(TestCase):
         # posterior beta
         self.log_alpha_n = torch.log(self.alpha_n)
         self.log_beta_n = torch.log(self.beta_n)
-        self.verbose = True
 
     def test_elbo_nonreparameterized(self):
-        if self.verbose:
-            print(" - - - - - DO BERNOULLI-BETA ELBO TEST - - - - - ")
+        logger.info(" - - - - - DO BERNOULLI-BETA ELBO TEST - - - - - ")
         pyro.clear_param_store()
 
         def model():
@@ -283,8 +279,8 @@ class BernoulliBetaTests(TestCase):
             alpha_error = param_abs_error("alpha_q_log", self.log_alpha_n)
             beta_error = param_abs_error("beta_q_log", self.log_beta_n)
 
-            if k % 500 == 0 and self.verbose:
-                print("alpha_error, beta_error: %.4f, %.4f" % (alpha_error, beta_error))
+            if k % 500 == 0:
+                logger.debug("alpha_error, beta_error: %.4f, %.4f" % (alpha_error, beta_error))
 
         self.assertEqual(0.0, alpha_error, prec=0.03)
         self.assertEqual(0.0, beta_error, prec=0.04)
@@ -308,11 +304,9 @@ class PoissonGammaTests(TestCase):
             Variable(torch.Tensor([self.n_data]))  # posterior beta
         self.log_alpha_n = torch.log(self.alpha_n)
         self.log_beta_n = torch.log(self.beta_n)
-        self.verbose = True
 
     def test_elbo_nonreparameterized(self):
-        if self.verbose:
-            print(" - - - - - DO POISSON-GAMMA ELBO TEST - - - - - ")
+        logger.info(" - - - - - DO POISSON-GAMMA ELBO TEST - - - - - ")
         pyro.clear_param_store()
 
         def model():
@@ -366,11 +360,9 @@ class ExponentialGammaTests(TestCase):
         self.beta_n = self.beta0 + torch.sum(self.data)  # posterior beta
         self.log_alpha_n = torch.log(self.alpha_n)
         self.log_beta_n = torch.log(self.beta_n)
-        self.verbose = True
 
     def test_elbo_nonreparameterized(self):
-        if self.verbose:
-            print(" - - - - - DO EXPONENTIAL-GAMMA ELBO TEST - - - - - ")
+        logger.info(" - - - - - DO EXPONENTIAL-GAMMA ELBO TEST - - - - - ")
         pyro.clear_param_store()
 
         def model():
@@ -399,8 +391,8 @@ class ExponentialGammaTests(TestCase):
             alpha_error = param_abs_error("alpha_q_log", self.log_alpha_n)
             beta_error = param_abs_error("beta_q_log", self.log_beta_n)
 
-            if k % 500 == 0 and self.verbose:
-                print("alpha_error, beta_error: %.4f, %.4f" % (alpha_error, beta_error))
+            if k % 500 == 0:
+                logger.debug("alpha_error, beta_error: %.4f, %.4f" % (alpha_error, beta_error))
 
         self.assertEqual(0.0, alpha_error, prec=0.03)
         self.assertEqual(0.0, beta_error, prec=0.03)
@@ -432,7 +424,6 @@ class LogNormalNormalTests(TestCase):
         self.mu_n = mu_numerator / self.tau_n  # posterior mu
         self.log_mu_n = torch.log(self.mu_n)
         self.log_tau_n = torch.log(self.tau_n)
-        self.verbose = True
 
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, 7000, 0.95, 0.001)
@@ -441,8 +432,7 @@ class LogNormalNormalTests(TestCase):
         self.do_elbo_test(False, 7000, 0.95, 0.001)
 
     def do_elbo_test(self, reparameterized, n_steps, beta1, lr):
-        if self.verbose:
-            print(" - - - - - DO LOGNORMAL-NORMAL ELBO TEST [repa = %s] - - - - - " % reparameterized)
+        logger.info(" - - - - - DO LOGNORMAL-NORMAL ELBO TEST [repa = %s] - - - - - " % reparameterized)
         pyro.clear_param_store()
         pt_guide = LogNormalNormalGuide(self.log_mu_n.data + 0.17,
                                         self.log_tau_n.data - 0.143)
@@ -471,15 +461,14 @@ class LogNormalNormalTests(TestCase):
 
             mu_error = param_abs_error("mymodule$$$mu_q_log", self.log_mu_n)
             tau_error = param_abs_error("mymodule$$$tau_q_log", self.log_tau_n)
-            if k % 500 == 0 and self.verbose:
-                print("mu_error, tau_error = %.4f, %.4f" % (mu_error, tau_error))
+            if k % 500 == 0:
+                logger.debug("mu_error, tau_error = %.4f, %.4f" % (mu_error, tau_error))
 
         self.assertEqual(0.0, mu_error, prec=0.05)
         self.assertEqual(0.0, tau_error, prec=0.05)
 
     def test_elbo_with_transformed_distribution(self):
-        if self.verbose:
-            print(" - - - - - DO LOGNORMAL-NORMAL ELBO TEST [uses TransformedDistribution] - - - - - ")
+        logger.info(" - - - - - DO LOGNORMAL-NORMAL ELBO TEST [uses TransformedDistribution] - - - - - ")
         pyro.clear_param_store()
 
         def model():
@@ -512,8 +501,8 @@ class LogNormalNormalTests(TestCase):
             mu_error = param_abs_error("mu_q_log", self.log_mu_n)
             tau_error = param_abs_error("tau_q_log", self.log_tau_n)
 
-            if k % 500 == 0 and self.verbose:
-                print("mu_error, tau_error = %.4f, %.4f" % (mu_error, tau_error))
+            if k % 500 == 0:
+                logger.debug("mu_error, tau_error = %.4f, %.4f" % (mu_error, tau_error))
 
         self.assertEqual(0.0, mu_error, prec=0.05)
         self.assertEqual(0.0, tau_error, prec=0.05)
@@ -543,7 +532,6 @@ class RaoBlackwellizationTests(TestCase):
         self.analytic_log_sig_n = -0.5 * torch.log(self.analytic_lam_n)
         self.analytic_mu_n = self.sum_data * (self.lam / self.analytic_lam_n) +\
             self.mu0 * (self.lam0 / self.analytic_lam_n)
-        self.verbose = True
 
     # this tests rao-blackwellization in elbo for nested list map_datas
     def test_nested_list_map_data_in_elbo(self, n_steps=4000):
@@ -604,8 +592,8 @@ class RaoBlackwellizationTests(TestCase):
 
             mu_error = param_mse("mu_q", self.analytic_mu_n)
             log_sig_error = param_mse("log_sig_q", self.analytic_log_sig_n)
-            if k % 500 == 0 and self.verbose:
-                print("mu error, log(sigma) error:  %.4f, %.4f" % (mu_error, log_sig_error))
+            if k % 500 == 0:
+                logger.debug("mu error, log(sigma) error:  %.4f, %.4f" % (mu_error, log_sig_error))
 
         self.assertEqual(0.0, mu_error, prec=0.04)
         self.assertEqual(0.0, log_sig_error, prec=0.04)
@@ -710,10 +698,10 @@ class RaoBlackwellizationTests(TestCase):
                     superfluous_error = torch.max(torch.max(mean_0_error, mean_1_error), mean_2_error)
                     superfluous_errors.append(superfluous_error.data.cpu().numpy()[0])
 
-            if step % 500 == 0 and self.verbose:
-                print("mu error, log(sigma) error:  %.4f, %.4f" % (mu_error, log_sig_error))
+            if step % 500 == 0:
+                logger.debug("mu error, log(sigma) error:  %.4f, %.4f" % (mu_error, log_sig_error))
                 if n_superfluous_top > 0 or n_superfluous_bottom > 0:
-                    print("superfluous error: %.4f" % np.max(superfluous_errors))
+                    logger.debug("superfluous error: %.4f" % np.max(superfluous_errors))
 
         self.assertEqual(0.0, mu_error, prec=0.04)
         self.assertEqual(0.0, log_sig_error, prec=0.05)

--- a/tests/nn/test_clipped_nn.py
+++ b/tests/nn/test_clipped_nn.py
@@ -1,11 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 import pytest
 import torch
 from torch.autograd import Variable
 
 from pyro.nn.clipped_nn import ClippedSigmoid, ClippedSoftmax
 from tests.common import assert_equal
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize('Tensor', [torch.FloatTensor, torch.DoubleTensor])
@@ -18,8 +22,8 @@ def test_clipped_softmax(Tensor):
         clipped_softmax = ClippedSoftmax(epsilon)
     ps = Variable(Tensor([[0, 1]]))
     softmax_ps = clipped_softmax(ps)
-    print("epsilon = {}".format(epsilon))
-    print("softmax_ps = {}".format(softmax_ps))
+    logger.info("epsilon = {}".format(epsilon))
+    logger.info("softmax_ps = {}".format(softmax_ps))
     assert (softmax_ps.data >= epsilon).all()
     assert (softmax_ps.data <= 1 - epsilon).all()
     assert_equal(softmax_ps.data.sum(), 1.0)
@@ -35,7 +39,7 @@ def test_clipped_sigmoid(Tensor):
         clipped_sigmoid = ClippedSigmoid(epsilon)
     ps = Variable(Tensor([0, 1]))
     sigmoid_ps = clipped_sigmoid(ps)
-    print("epsilon = {}".format(epsilon))
-    print("sigmoid_ps = {}".format(sigmoid_ps))
+    logger.info("epsilon = {}".format(epsilon))
+    logger.info("sigmoid_ps = {}".format(sigmoid_ps))
     assert (sigmoid_ps.data >= epsilon).all()
     assert (sigmoid_ps.data <= 1 - epsilon).all()

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 import pytest
 import torch
 from torch.autograd import Variable
@@ -10,6 +12,8 @@ import pyro.optim as optim
 import pyro.poutine as poutine
 from pyro.infer import SVI
 from tests.common import assert_equal, requires_cuda
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.stage("integration", "integration_batch_1")
@@ -43,12 +47,9 @@ def test_elbo_mapdata(batch_size, map_type):
     analytic_log_sig_n = -0.5 * torch.log(analytic_lam_n)
     analytic_mu_n = sum_data * (lam / analytic_lam_n) +\
         mu0 * (lam0 / analytic_lam_n)
-    verbose = True
     n_steps = 7000
 
-    if verbose:
-        print("DOING ELBO TEST [bs = {}, map_type = {}]".format(
-            batch_size, map_type))
+    logger.debug("DOING ELBO TEST [bs = {}, map_type = {}]".format(batch_size, map_type))
     pyro.clear_param_store()
 
     def model():

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -107,8 +107,8 @@ def test_elbo_mapdata(batch_size, map_type):
                 pyro.param("log_sig_q"),
                 2.0))
 
-        if verbose and k % 500 == 0:
-            print("errors", mu_error.data.cpu().numpy()[0], log_sig_error.data.cpu().numpy()[0])
+        if k % 500 == 0:
+            logger.debug("errors", mu_error.data.cpu().numpy()[0], log_sig_error.data.cpu().numpy()[0])
 
     assert_equal(Variable(torch.zeros(1)), mu_error, prec=0.05)
     assert_equal(Variable(torch.zeros(1)), log_sig_error, prec=0.06)

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -108,7 +108,7 @@ def test_elbo_mapdata(batch_size, map_type):
                 2.0))
 
         if k % 500 == 0:
-            logger.debug("errors", mu_error.data.cpu().numpy()[0], log_sig_error.data.cpu().numpy()[0])
+            logger.debug("errors - {}, {}".format(mu_error.data.cpu().numpy()[0], log_sig_error.data.cpu().numpy()[0]))
 
     assert_equal(Variable(torch.zeros(1)), mu_error, prec=0.05)
     assert_equal(Variable(torch.zeros(1)), log_sig_error, prec=0.06)


### PR DESCRIPTION
Fixes #608. Refer to the task for more details. This is needed so that MCMC algorithms can output diagnostic messages to the logger.