### PR TITLE
Fix GPU device placement when calling tensor.cuda()

### DIFF
--- a/pyro/distributions/bernoulli.py
+++ b/pyro/distributions/bernoulli.py
@@ -106,7 +106,7 @@ class Bernoulli(Distribution):
             sample.
         :rtype: torch.autograd.Variable.
         """
-        result = torch.arange(2).long()
+        result = torch.arange(0, 2).long()
         result = result.view((-1,) + (1,) * self.ps.dim()).expand((-1,) + self.ps.size())
         if self.ps.is_cuda:
             result = result.cuda(self.ps.get_device())

--- a/pyro/distributions/bernoulli.py
+++ b/pyro/distributions/bernoulli.py
@@ -106,7 +106,11 @@ class Bernoulli(Distribution):
             sample.
         :rtype: torch.autograd.Variable.
         """
-        return Variable(torch.stack([torch.Tensor([t]).expand_as(self.ps) for t in [0, 1]]))
+        result = torch.arange(2).long()
+        result = result.view((-1,) + (1,) * self.ps.dim()).expand((-1,) + self.ps.size())
+        if self.ps.is_cuda:
+            result = result.cuda(self.ps.get_device())
+        return Variable(result)
 
     def analytic_mean(self):
         """

--- a/pyro/distributions/bernoulli.py
+++ b/pyro/distributions/bernoulli.py
@@ -106,7 +106,7 @@ class Bernoulli(Distribution):
             sample.
         :rtype: torch.autograd.Variable.
         """
-        result = torch.arange(0, 2).long()
+        result = torch.arange(0, 2)  # TODO Convert to LongTensor or ByteTensor.
         result = result.view((-1,) + (1,) * self.ps.dim()).expand((2,) + self.ps.size())
         if self.ps.is_cuda:
             result = result.cuda(self.ps.get_device())

--- a/pyro/distributions/bernoulli.py
+++ b/pyro/distributions/bernoulli.py
@@ -107,7 +107,7 @@ class Bernoulli(Distribution):
         :rtype: torch.autograd.Variable.
         """
         result = torch.arange(0, 2).long()
-        result = result.view((-1,) + (1,) * self.ps.dim()).expand((-1,) + self.ps.size())
+        result = result.view((-1,) + (1,) * self.ps.dim()).expand((2,) + self.ps.size())
         if self.ps.is_cuda:
             result = result.cuda(self.ps.get_device())
         return Variable(result)

--- a/pyro/distributions/binomial.py
+++ b/pyro/distributions/binomial.py
@@ -26,7 +26,7 @@ class Binomial(Distribution):
         if isinstance(n, numbers.Number):
             n = torch.LongTensor([n]).type_as(ps.data)
             if ps.is_cuda:
-                n = n.cuda()
+                n = n.cuda(ps.get_device())
             n = Variable(n)
         self.ps = ps
         self.n = n

--- a/pyro/distributions/categorical.py
+++ b/pyro/distributions/categorical.py
@@ -179,7 +179,7 @@ class Categorical(Distribution):
         elif vs is not None:
             result = torch.transpose(vs, 0, -1).contiguous().view(support_samples_size)
         else:
-            shape = self.ps.shape[:-1] + (1,)
+            shape = self.ps.size()[:-1] + (1,)
             result = torch.arange(self.ps.size(-1)).long()
             result = result.view((-1,) + (1,) * len(shape)).expand((-1,) + shape)
 

--- a/pyro/distributions/categorical.py
+++ b/pyro/distributions/categorical.py
@@ -131,7 +131,7 @@ class Categorical(Distribution):
             boolean_mask = torch.from_numpy((vs == x).astype(int))
         # probability tensor mask when data is pytorch tensor
         else:
-            x = x.cuda() if logits.is_cuda else x.cpu()
+            x = x.cuda(logits.get_device()) if logits.is_cuda else x.cpu()
             batch_ps_shape = self.batch_shape(x) + logits.size()[-1:]
             logits = logits.expand(batch_ps_shape)
 
@@ -140,7 +140,7 @@ class Categorical(Distribution):
                 boolean_mask = (vs == x)
             else:
                 boolean_mask = torch_zeros_like(logits.data).scatter_(-1, x.data.long(), 1)
-        boolean_mask = boolean_mask.cuda() if logits.is_cuda else boolean_mask.cpu()
+        boolean_mask = boolean_mask.cuda(logits.get_device()) if logits.is_cuda else boolean_mask.cpu()
         if not isinstance(boolean_mask, Variable):
             boolean_mask = Variable(boolean_mask)
         # apply log function to masked probability tensor
@@ -174,11 +174,17 @@ class Categorical(Distribution):
         support_samples_size = self.ps.size()[-1:] + sample_shape
         vs = self.vs
 
-        if vs is not None:
-            if isinstance(vs, np.ndarray):
-                return vs.transpose().reshape(*support_samples_size)
-            else:
-                return torch.transpose(vs, 0, -1).contiguous().view(support_samples_size)
-        LongTensor = torch.cuda.LongTensor if self.ps.is_cuda else torch.LongTensor
-        return Variable(
-            torch.stack([LongTensor([t]).expand(sample_shape) for t in torch.arange(0, self.ps.size(-1)).long()]))
+        if isinstance(vs, np.ndarray):
+            return vs.transpose().reshape(*support_samples_size)
+        elif vs is not None:
+            result = torch.transpose(vs, 0, -1).contiguous().view(support_samples_size)
+        else:
+            shape = self.ps.shape[:-1] + (1,)
+            result = torch.arange(self.ps.size(-1)).long()
+            result = result.view((-1,) + (1,) * len(shape)).expand((-1,) + shape)
+
+        if not isinstance(result, Variable):
+            result = Variable(result)
+        if self.ps.is_cuda:
+            result = result.cuda(self.ps.get_device())
+        return result

--- a/pyro/distributions/categorical.py
+++ b/pyro/distributions/categorical.py
@@ -180,8 +180,9 @@ class Categorical(Distribution):
             result = torch.transpose(vs, 0, -1).contiguous().view(support_samples_size)
         else:
             shape = self.ps.size()[:-1] + (1,)
-            result = torch.arange(0, self.ps.size(-1)).long()
-            result = result.view((-1,) + (1,) * len(shape)).expand((-1,) + shape)
+            cardinality = self.ps.size()[-1]
+            result = torch.arange(0, cardinality).long()
+            result = result.view((cardinality,) + (1,) * len(shape)).expand((cardinality,) + shape)
 
         if not isinstance(result, Variable):
             result = Variable(result)

--- a/pyro/distributions/categorical.py
+++ b/pyro/distributions/categorical.py
@@ -180,7 +180,7 @@ class Categorical(Distribution):
             result = torch.transpose(vs, 0, -1).contiguous().view(support_samples_size)
         else:
             shape = self.ps.size()[:-1] + (1,)
-            result = torch.arange(self.ps.size(-1)).long()
+            result = torch.arange(0, self.ps.size(-1)).long()
             result = result.view((-1,) + (1,) * len(shape)).expand((-1,) + shape)
 
         if not isinstance(result, Variable):

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -75,4 +75,4 @@ class Delta(Distribution):
         :return: torch variable enumerating the support of the delta distribution.
         :rtype: torch.autograd.Variable.
         """
-        return Variable(self.v.data)
+        return Variable(self.v.data.unsqueeze(0))

--- a/pyro/distributions/multinomial.py
+++ b/pyro/distributions/multinomial.py
@@ -30,7 +30,7 @@ class Multinomial(Distribution):
         if isinstance(n, numbers.Number):
             n = torch.LongTensor([n]).type_as(ps.data)
             if ps.is_cuda:
-                n = n.cuda()
+                n = n.cuda(ps.get_device())
             n = Variable(n)
         self.ps = ps
         self.n = n
@@ -74,7 +74,7 @@ class Multinomial(Distribution):
             arr=self.expanded_sample().data.cpu().numpy())
         counts = torch.from_numpy(counts)
         if self.ps.is_cuda:
-            counts = counts.cuda()
+            counts = counts.cuda(self.ps.get_device())
         return Variable(counts)
 
     def expanded_sample(self):

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -89,7 +89,7 @@ def move_to_same_host_as(source, destin):
     """
     Returns source or a copy of `source` such that `source.is_cuda == `destin.is_cuda`.
     """
-    return source.cuda() if destin.is_cuda else source.cpu()
+    return source.cuda(destin.get_device()) if destin.is_cuda else source.cpu()
 
 
 def torch_zeros_like(x):

--- a/tests/distributions/test_delta.py
+++ b/tests/distributions/test_delta.py
@@ -17,8 +17,8 @@ class TestDelta(TestCase):
         self.batch_test_data_1 = Variable(torch.arange(0, 4).unsqueeze(1).expand(4, 3))
         self.batch_test_data_2 = Variable(torch.arange(4, 8).unsqueeze(1).expand(4, 3))
         self.batch_test_data_3 = Variable(torch.Tensor([[3], [3], [3], [3]]))
-        self.expected_support = [[0], [1], [2], [3]]
-        self.expected_support_non_vec = [3]
+        self.expected_support = [[[0], [1], [2], [3]]]
+        self.expected_support_non_vec = [[3]]
         self.analytic_mean = 3
         self.analytic_var = 0
         self.n_samples = 10
@@ -48,5 +48,7 @@ class TestDelta(TestCase):
     def test_support(self):
         actual_support = dist.delta.enumerate_support(self.vs)
         actual_support_non_vec = dist.delta.enumerate_support(self.v)
+        assert len(actual_support) == 1
+        assert len(actual_support_non_vec) == 1
         assert_equal(actual_support.data, torch.Tensor(self.expected_support))
         assert_equal(actual_support_non_vec.data, torch.Tensor(self.expected_support_non_vec))

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -33,7 +33,7 @@ def test_broadcast_shape(shapes):
     ([2, 1], [1, 3, 1]),
 ])
 def test_broadcast_shape_error(shapes):
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, RuntimeError)):
         broadcast_shape(*shapes)
 
 


### PR DESCRIPTION
Fixes #623 
Suggested by @apaszke

This also fixes the shape of `distributions.Delta.enumerate_support()`, which was returning an element rather than a singleton tensor containing that element (to see the difference, consider `for x in dist.enumerate_support(): ...`).

## Testing

I tested that this runs on a single GPU but I have not tested on a multi-GPU system.