### PR TITLE
Drop depencency on unittest

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 import contextlib
 import copy
+import logging
 import warnings
 from collections import OrderedDict
 from inspect import isclass
-import logging
 
 import torch
 from torch.autograd import Variable

--- a/pyro/distributions/normal.py
+++ b/pyro/distributions/normal.py
@@ -164,5 +164,5 @@ def WrapNormal(mu, sigma, batch_size=None, log_pdf_mask=None, *args, **kwargs):
         _warn_fallback('Unsupported reparameterized=True')
     else:
         return TorchNormal(mu, sigma, reparameterized=reparameterized)
-    return Normal(mu, sigma, batch_size=batch_size, log_pdf_mask=log_pdf_mask,
-                  reparameterized=reparameterized, *args, **kwargs)
+    return Normal(
+        mu, sigma, batch_size=batch_size, log_pdf_mask=log_pdf_mask, reparameterized=reparameterized, *args, **kwargs)

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import contextlib
 import numbers
 import os
-import unittest
 import warnings
 from copy import deepcopy
 from itertools import product
@@ -227,13 +226,3 @@ def assert_not_equal(x, y, prec=1e-5, msg=''):
     except AssertionError:
         pass
     raise AssertionError("{} \nValues are equal: x={}, y={}, prec={}".format(msg, x, y, prec))
-
-
-class TestCase(unittest.TestCase):
-    precision = 1e-5
-
-    def assertEqual(self, x, y, prec=None, message=''):
-        assert_equal(x, y, prec, message)
-
-    def assertNotEqual(self, x, y, prec=None, message=''):
-        assert_not_equal(x, y, prec, message)

--- a/tests/distributions/test_categorical.py
+++ b/tests/distributions/test_categorical.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+from unittest import TestCase
+
 import numpy as np
 import pytest
 import scipy.stats as sp
@@ -7,7 +9,7 @@ import torch
 from torch.autograd import Variable
 
 import pyro.distributions as dist
-from tests.common import TestCase, assert_equal
+from tests.common import assert_equal
 
 
 class TestCategorical(TestCase):
@@ -43,14 +45,14 @@ class TestCategorical(TestCase):
     def test_log_pdf(self):
         log_px_torch = dist.categorical.batch_log_pdf(self.test_data, self.ps).data[0]
         log_px_np = float(sp.multinomial.logpmf(np.array([0, 0, 1]), 1, self.ps.data.cpu().numpy()))
-        self.assertEqual(log_px_torch, log_px_np, prec=1e-4)
+        assert_equal(log_px_torch, log_px_np, prec=1e-4)
 
     def test_mean_and_var(self):
         torch_samples = [dist.categorical(self.ps).data.cpu().numpy()
                          for _ in range(self.n_samples)]
         _, counts = np.unique(torch_samples, return_counts=True)
         computed_mean = float(counts[0]) / self.n_samples
-        self.assertEqual(computed_mean, self.analytic_mean.data.cpu().numpy()[0], prec=0.05)
+        assert_equal(computed_mean, self.analytic_mean.data.cpu().numpy()[0], prec=0.05)
 
     def test_support_non_vectorized(self):
         s = dist.categorical.enumerate_support(self.d_ps[0].squeeze(0), self.d_vs[0].squeeze(0))

--- a/tests/distributions/test_categorical.py
+++ b/tests/distributions/test_categorical.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from unittest import TestCase
-
 import numpy as np
 import pytest
 import scipy.stats as sp
@@ -12,7 +10,7 @@ import pyro.distributions as dist
 from tests.common import assert_equal
 
 
-class TestCategorical(TestCase):
+class TestCategorical(object):
     """
     Tests methods specific to the Categorical distribution
     """

--- a/tests/distributions/test_delta.py
+++ b/tests/distributions/test_delta.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from unittest import TestCase
-
 import numpy as np
 import torch
 from torch.autograd import Variable
@@ -10,7 +8,7 @@ import pyro.distributions as dist
 from tests.common import assert_equal
 
 
-class TestDelta(TestCase):
+class TestDelta(object):
     def setUp(self):
         self.v = Variable(torch.Tensor([3]))
         self.vs = Variable(torch.Tensor([[0], [1], [2], [3]]))

--- a/tests/distributions/test_delta.py
+++ b/tests/distributions/test_delta.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
+from unittest import TestCase
+
 import numpy as np
 import torch
 from torch.autograd import Variable
 
 import pyro.distributions as dist
-from tests.common import TestCase, assert_equal
+from tests.common import assert_equal
 
 
 class TestDelta(TestCase):
@@ -25,13 +27,13 @@ class TestDelta(TestCase):
 
     def test_log_pdf(self):
         log_px_torch = dist.delta.log_pdf(self.test_data, self.v).data
-        self.assertEqual(torch.sum(log_px_torch), 0)
+        assert_equal(torch.sum(log_px_torch), 0)
 
     def test_batch_log_pdf(self):
         log_px_torch = dist.delta.batch_log_pdf(self.batch_test_data_1, self.vs_expanded).data
-        self.assertEqual(torch.sum(log_px_torch), 0)
+        assert_equal(torch.sum(log_px_torch), 0)
         log_px_torch = dist.delta.batch_log_pdf(self.batch_test_data_2, self.vs_expanded).data
-        self.assertEqual(torch.sum(log_px_torch), float('-inf'))
+        assert_equal(torch.sum(log_px_torch), float('-inf'))
 
     def test_batch_log_pdf_shape(self):
         assert dist.delta.batch_log_pdf(self.batch_test_data_3, self.vs).size() == (4, 1)
@@ -42,8 +44,8 @@ class TestDelta(TestCase):
                          for _ in range(self.n_samples)]
         torch_mean = np.mean(torch_samples)
         torch_var = np.var(torch_samples)
-        self.assertEqual(torch_mean, self.analytic_mean)
-        self.assertEqual(torch_var, self.analytic_var)
+        assert_equal(torch_mean, self.analytic_mean)
+        assert_equal(torch_var, self.analytic_var)
 
     def test_support(self):
         actual_support = dist.delta.enumerate_support(self.vs)

--- a/tests/distributions/test_iaf.py
+++ b/tests/distributions/test_iaf.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+from unittest import TestCase
+
 import numpy as np
 import pytest
 import torch
@@ -7,7 +9,6 @@ from torch.autograd import Variable
 
 from pyro.distributions.transformed_distribution import InverseAutoregressiveFlow
 from pyro.nn import AutoRegressiveNN
-from tests.common import TestCase
 
 pytestmark = pytest.mark.init(rng_seed=123)
 
@@ -46,9 +47,9 @@ class InverseAutoregressiveFlowTests(TestCase):
         diag_sum = torch.sum(torch.diag(nonzero(permuted_jacobian)))
         lower_sum = torch.sum(torch.tril(nonzero(permuted_jacobian), diagonal=-1))
 
-        self.assertTrue(ldt_discrepancy < self.epsilon)
-        self.assertTrue(diag_sum == float(input_dim))
-        self.assertTrue(lower_sum == float(0.0))
+        assert ldt_discrepancy < self.epsilon
+        assert diag_sum == float(input_dim)
+        assert lower_sum == float(0.0)
 
     def test_jacobians(self):
         for input_dim in [2, 3, 5, 7, 9, 11]:
@@ -83,7 +84,7 @@ class AutoRegressiveNNTests(TestCase):
                     permuted_jacobian[j, k] = jacobian[permutation[j], permutation[k]]
 
             lower_sum = torch.sum(torch.tril(nonzero(permuted_jacobian), diagonal=0))
-            self.assertTrue(lower_sum == float(0.0))
+            assert lower_sum == float(0.0)
 
     def test_jacobians(self):
         for input_dim in [2, 3, 5, 7, 9, 11]:

--- a/tests/distributions/test_iaf.py
+++ b/tests/distributions/test_iaf.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from unittest import TestCase
-
 import numpy as np
 import pytest
 import torch
@@ -13,7 +11,7 @@ from pyro.nn import AutoRegressiveNN
 pytestmark = pytest.mark.init(rng_seed=123)
 
 
-class InverseAutoregressiveFlowTests(TestCase):
+class TestInverseAutoregressiveFlow(object):
     def setUp(self):
         self.epsilon = 1.0e-6
 
@@ -56,7 +54,7 @@ class InverseAutoregressiveFlowTests(TestCase):
             self._test_jacobian(input_dim, 3 * input_dim + 1)
 
 
-class AutoRegressiveNNTests(TestCase):
+class TestAutoRegressiveNN(object):
 
     def setUp(self):
         self.epsilon = 1.0e-6

--- a/tests/distributions/test_one_hot_categorical.py
+++ b/tests/distributions/test_one_hot_categorical.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
+from unittest import TestCase
+
 import numpy as np
 import pytest
 import torch
 from torch.autograd import Variable
 
 import pyro.distributions as dist
-from tests.common import TestCase, assert_equal
+from tests.common import assert_equal
 
 
 class TestOneHotCategorical(TestCase):

--- a/tests/distributions/test_one_hot_categorical.py
+++ b/tests/distributions/test_one_hot_categorical.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from unittest import TestCase
-
 import numpy as np
 import pytest
 import torch
@@ -11,7 +9,7 @@ import pyro.distributions as dist
 from tests.common import assert_equal
 
 
-class TestOneHotCategorical(TestCase):
+class TestOneHotCategorical(object):
     """
     Tests methods specific to the OneHotCategorical distribution
     """

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from unittest import TestCase
-
 import pytest
 import torch
 from torch import nn as nn
@@ -26,7 +24,7 @@ def param_abs_error(name, target):
     return torch.sum(torch.abs(target - pyro.param(name))).data.cpu().numpy()[0]
 
 
-class NormalNormalTests(TestCase):
+class TestNormalNormal(object):
 
     def setUp(self):
         # normal-normal; known covariance
@@ -92,7 +90,7 @@ class NormalNormalTests(TestCase):
         assert_equal(0.0, log_sig_error, prec=0.05)
 
 
-class TestFixedModelGuide(TestCase):
+class TestFixedModelGuide(object):
     def setUp(self):
         self.data = Variable(torch.Tensor([2.0]))
         self.alpha_q_log_0 = 0.17 * torch.ones(1)
@@ -160,7 +158,7 @@ class TestFixedModelGuide(TestCase):
 
 
 @pytest.mark.stage("integration", "integration_batch_2")
-class PoissonGammaTests(TestCase):
+class TestPoissonGamma(object):
     def setUp(self):
         # poisson-gamma model
         # gamma prior hyperparameter
@@ -218,7 +216,7 @@ class PoissonGammaTests(TestCase):
         assert_equal(0.0, beta_error, prec=0.08)
 
 
-class ExponentialGammaTests(TestCase):
+class TestExponentialGamma(object):
     def setUp(self):
         # exponential-gamma model
         # gamma prior hyperparameter
@@ -264,7 +262,7 @@ class ExponentialGammaTests(TestCase):
         assert_equal(0.0, beta_error, prec=0.08)
 
 
-class BernoulliBetaTests(TestCase):
+class TestBernoulliBeta(object):
     def setUp(self):
         # bernoulli-beta model
         # beta prior hyperparameter
@@ -326,7 +324,7 @@ class LogNormalNormalGuide(nn.Module):
 
 
 @pytest.mark.stage("integration", "integration_batch_2")
-class LogNormalNormalTests(TestCase):
+class TestLogNormalNormal(object):
     def setUp(self):
         # lognormal-normal model
         # putting some of the parameters inside of a torch module to
@@ -420,7 +418,7 @@ class LogNormalNormalTests(TestCase):
         assert_equal(0.0, tau_error, prec=0.05)
 
 
-class SafetyTests(TestCase):
+class TestSafety(object):
 
     def setUp(self):
         # normal-normal; known covariance

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+from unittest import TestCase
+
 import pytest
 import torch
 from torch import nn as nn
@@ -12,7 +14,7 @@ import pyro.optim as optim
 from pyro.distributions.transformed_distribution import TransformedDistribution
 from pyro.infer.svi import SVI
 from pyro.util import ng_ones, ng_zeros
-from tests.common import TestCase
+from tests.common import assert_equal
 from tests.distributions.test_transformed_distribution import AffineExp
 
 
@@ -86,8 +88,8 @@ class NormalNormalTests(TestCase):
             mu_error = param_mse("mu_q", self.analytic_mu_n)
             log_sig_error = param_mse("log_sig_q", self.analytic_log_sig_n)
 
-        self.assertEqual(0.0, mu_error, prec=0.05)
-        self.assertEqual(0.0, log_sig_error, prec=0.05)
+        assert_equal(0.0, mu_error, prec=0.05)
+        assert_equal(0.0, log_sig_error, prec=0.05)
 
 
 class TestFixedModelGuide(TestCase):
@@ -212,8 +214,8 @@ class PoissonGammaTests(TestCase):
 
         alpha_error = param_abs_error("alpha_q_log", self.log_alpha_n)
         beta_error = param_abs_error("beta_q_log", self.log_beta_n)
-        self.assertEqual(0.0, alpha_error, prec=0.08)
-        self.assertEqual(0.0, beta_error, prec=0.08)
+        assert_equal(0.0, alpha_error, prec=0.08)
+        assert_equal(0.0, beta_error, prec=0.08)
 
 
 class ExponentialGammaTests(TestCase):
@@ -258,8 +260,8 @@ class ExponentialGammaTests(TestCase):
 
         alpha_error = param_abs_error("alpha_q_log", self.log_alpha_n)
         beta_error = param_abs_error("beta_q_log", self.log_beta_n)
-        self.assertEqual(0.0, alpha_error, prec=0.08)
-        self.assertEqual(0.0, beta_error, prec=0.08)
+        assert_equal(0.0, alpha_error, prec=0.08)
+        assert_equal(0.0, beta_error, prec=0.08)
 
 
 class BernoulliBetaTests(TestCase):
@@ -312,8 +314,8 @@ class BernoulliBetaTests(TestCase):
             alpha_error = param_abs_error("alpha_q_log", self.log_alpha_n)
             beta_error = param_abs_error("beta_q_log", self.log_beta_n)
 
-        self.assertEqual(0.0, alpha_error, prec=0.08)
-        self.assertEqual(0.0, beta_error, prec=0.08)
+        assert_equal(0.0, alpha_error, prec=0.08)
+        assert_equal(0.0, beta_error, prec=0.08)
 
 
 class LogNormalNormalGuide(nn.Module):
@@ -377,8 +379,8 @@ class LogNormalNormalTests(TestCase):
 
         mu_error = param_abs_error("mymodule$$$mu_q_log", self.log_mu_n)
         tau_error = param_abs_error("mymodule$$$tau_q_log", self.log_tau_n)
-        self.assertEqual(0.0, mu_error, prec=0.07)
-        self.assertEqual(0.0, tau_error, prec=0.07)
+        assert_equal(0.0, mu_error, prec=0.07)
+        assert_equal(0.0, tau_error, prec=0.07)
 
     def test_elbo_with_transformed_distribution(self):
         pyro.clear_param_store()
@@ -414,8 +416,8 @@ class LogNormalNormalTests(TestCase):
 
         mu_error = param_abs_error("mu_q_log", self.log_mu_n)
         tau_error = param_abs_error("tau_q_log", self.log_tau_n)
-        self.assertEqual(0.0, mu_error, prec=0.05)
-        self.assertEqual(0.0, tau_error, prec=0.05)
+        assert_equal(0.0, mu_error, prec=0.05)
+        assert_equal(0.0, tau_error, prec=0.05)
 
 
 class SafetyTests(TestCase):

--- a/tests/infer/test_sampling.py
+++ b/tests/infer/test_sampling.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+from unittest import TestCase
+
 import pytest
 import torch
 from torch.autograd import Variable
@@ -7,7 +9,7 @@ from torch.autograd import Variable
 import pyro
 import pyro.infer
 from pyro.distributions import Bernoulli, Normal
-from tests.common import TestCase
+from tests.common import assert_equal
 
 
 class HMMSamplingTestCase(TestCase):
@@ -108,10 +110,8 @@ class ImportanceTest(NormalNormalSamplingTestCase):
         posterior_samples = [marginal() for i in range(1000)]
         posterior_mean = torch.mean(torch.cat(posterior_samples))
         posterior_stddev = torch.std(torch.cat(posterior_samples), 0)
-        self.assertEqual(0, torch.norm(posterior_mean - self.mu_mean).data[0],
-                         prec=0.01)
-        self.assertEqual(0, torch.norm(posterior_stddev - self.mu_stddev).data[0],
-                         prec=0.1)
+        assert_equal(0, torch.norm(posterior_mean - self.mu_mean).data[0], prec=0.01)
+        assert_equal(0, torch.norm(posterior_stddev - self.mu_stddev).data[0], prec=0.1)
 
     @pytest.mark.init(rng_seed=0)
     def test_importance_prior(self):
@@ -120,7 +120,5 @@ class ImportanceTest(NormalNormalSamplingTestCase):
         posterior_samples = [marginal() for i in range(1000)]
         posterior_mean = torch.mean(torch.cat(posterior_samples))
         posterior_stddev = torch.std(torch.cat(posterior_samples), 0)
-        self.assertEqual(0, torch.norm(posterior_mean - self.mu_mean).data[0],
-                         prec=0.01)
-        self.assertEqual(0, torch.norm(posterior_stddev - self.mu_stddev).data[0],
-                         prec=0.1)
+        assert_equal(0, torch.norm(posterior_mean - self.mu_mean).data[0], prec=0.01)
+        assert_equal(0, torch.norm(posterior_stddev - self.mu_stddev).data[0], prec=0.1)

--- a/tests/infer/test_sampling.py
+++ b/tests/infer/test_sampling.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from unittest import TestCase
-
 import pytest
 import torch
 from torch.autograd import Variable
@@ -12,7 +10,7 @@ from pyro.distributions import Bernoulli, Normal
 from tests.common import assert_equal
 
 
-class HMMSamplingTestCase(TestCase):
+class HMMSamplingTestCase(object):
 
     def setUp(self):
 
@@ -40,7 +38,7 @@ class HMMSamplingTestCase(TestCase):
         self.model = model
 
 
-class NormalNormalSamplingTestCase(TestCase):
+class NormalNormalSamplingTestCase(object):
 
     def setUp(self):
 
@@ -67,7 +65,7 @@ class NormalNormalSamplingTestCase(TestCase):
         self.guide = guide
 
 
-class SearchTest(HMMSamplingTestCase):
+class TestSearch(HMMSamplingTestCase):
 
     def test_complete(self):
         posterior = pyro.infer.Search(self.model)
@@ -101,7 +99,7 @@ class SearchTest(HMMSamplingTestCase):
             assert i + 1 in tr_rets
 
 
-class ImportanceTest(NormalNormalSamplingTestCase):
+class TestImportance(NormalNormalSamplingTestCase):
 
     @pytest.mark.init(rng_seed=0)
     def test_importance_guide(self):

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 import os
 import time
+from unittest import TestCase
 
 import networkx
 import numpy as np
@@ -14,7 +15,7 @@ import pyro
 import pyro.distributions as dist
 import pyro.optim as optim
 from pyro.infer import SVI
-from tests.common import TestCase
+from tests.common import assert_equal
 
 logger = logging.getLogger(__name__)
 
@@ -178,9 +179,9 @@ class GaussianChainTests(TestCase):
                 logger.debug("[mean errors]  (mu, log_sigma, kappa) = (%.4f, %.4f, %.4f)" % mean_errors)
                 logger.debug("[step time = %.3f;  N = %d;  step = %d]\n" % (time.time() - t0, self.N, step))
 
-        self.assertEqual(0.0, max_errors[0], prec=prec)
-        self.assertEqual(0.0, max_errors[1], prec=prec)
-        self.assertEqual(0.0, max_errors[2], prec=prec)
+        assert_equal(0.0, max_errors[0], prec=prec)
+        assert_equal(0.0, max_errors[1], prec=prec)
+        assert_equal(0.0, max_errors[2], prec=prec)
 
 
 @pytest.mark.stage("integration", "integration_batch_2")
@@ -484,6 +485,6 @@ class GaussianPyramidTests(TestCase):
                              (min_log_sig_error, mean_log_sig_error, max_log_sig_error))
                 logger.debug("[step time = %.3f;  N = %d;  step = %d]\n" % (time.time() - t0, self.N, step))
 
-        self.assertEqual(0.0, max_log_sig_error, prec=prec)
-        self.assertEqual(0.0, leftmost_constant_error, prec=prec)
-        self.assertEqual(0.0, almost_leftmost_constant_error, prec=prec)
+        assert_equal(0.0, max_log_sig_error, prec=prec)
+        assert_equal(0.0, leftmost_constant_error, prec=prec)
+        assert_equal(0.0, almost_leftmost_constant_error, prec=prec)

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import logging
 import os
 import time
-from unittest import TestCase
 
 import networkx
 import numpy as np
@@ -26,7 +25,7 @@ def param_mse(name, target):
 
 @pytest.mark.stage("integration", "integration_batch_1")
 @pytest.mark.init(rng_seed=0)
-class GaussianChainTests(TestCase):
+class TestGaussianChain(object):
     # chain of normals with known covariances and latent means
 
     def setUp(self):
@@ -186,7 +185,7 @@ class GaussianChainTests(TestCase):
 
 @pytest.mark.stage("integration", "integration_batch_2")
 @pytest.mark.init(rng_seed=0)
-class GaussianPyramidTests(TestCase):
+class TestGaussianPyramid(object):
 
     def setUp(self):
         self.mu0 = Variable(torch.Tensor([0.52]))

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
+from unittest import TestCase
+
 import numpy as np
 import pytest
 import torch
@@ -7,14 +10,13 @@ from torch import nn as nn
 from torch.autograd import Variable
 from torch.nn import Parameter
 
-import logging
 import pyro
 import pyro.distributions as dist
 import pyro.optim as optim
 from pyro.distributions.transformed_distribution import TransformedDistribution
 from pyro.infer import SVI
 from pyro.util import ng_ones, ng_zeros
-from tests.common import TestCase
+from tests.common import assert_equal
 from tests.distributions.test_transformed_distribution import AffineExp
 
 pytestmark = pytest.mark.stage("integration", "integration_batch_2")
@@ -94,8 +96,8 @@ class NormalNormalTests(TestCase):
             if k % 250 == 0:
                 logger.debug("mu error, log(sigma) error:  %.4f, %.4f" % (mu_error, log_sig_error))
 
-        self.assertEqual(0.0, mu_error, prec=0.03)
-        self.assertEqual(0.0, log_sig_error, prec=0.03)
+        assert_equal(0.0, mu_error, prec=0.03)
+        assert_equal(0.0, log_sig_error, prec=0.03)
 
 
 class NormalNormalNormalTests(TestCase):
@@ -222,11 +224,11 @@ class NormalNormalNormalTests(TestCase):
                 logger.debug(", %.4f, %.4f" % (mu_prime_error, log_sig_prime_error))
                 logger.debug(", %.4f" % kappa_error)
 
-        self.assertEqual(0.0, mu_error, prec=prec)
-        self.assertEqual(0.0, log_sig_error, prec=prec)
-        self.assertEqual(0.0, mu_prime_error, prec=prec)
-        self.assertEqual(0.0, log_sig_prime_error, prec=prec)
-        self.assertEqual(0.0, kappa_error, prec=prec)
+        assert_equal(0.0, mu_error, prec=prec)
+        assert_equal(0.0, log_sig_error, prec=prec)
+        assert_equal(0.0, mu_prime_error, prec=prec)
+        assert_equal(0.0, log_sig_prime_error, prec=prec)
+        assert_equal(0.0, kappa_error, prec=prec)
 
 
 class BernoulliBetaTests(TestCase):
@@ -282,8 +284,8 @@ class BernoulliBetaTests(TestCase):
             if k % 500 == 0:
                 logger.debug("alpha_error, beta_error: %.4f, %.4f" % (alpha_error, beta_error))
 
-        self.assertEqual(0.0, alpha_error, prec=0.03)
-        self.assertEqual(0.0, beta_error, prec=0.04)
+        assert_equal(0.0, alpha_error, prec=0.03)
+        assert_equal(0.0, beta_error, prec=0.04)
 
 
 class PoissonGammaTests(TestCase):
@@ -342,8 +344,8 @@ class PoissonGammaTests(TestCase):
             if k % 500 == 0:
                 logger.debug("alpha_q_log_error, beta_q_log_error: %.4f, %.4f" % (alpha_error, beta_error))
 
-        self.assertEqual(0.0, alpha_error, prec=0.08)
-        self.assertEqual(0.0, beta_error, prec=0.08)
+        assert_equal(0.0, alpha_error, prec=0.08)
+        assert_equal(0.0, beta_error, prec=0.08)
 
 
 class ExponentialGammaTests(TestCase):
@@ -394,8 +396,8 @@ class ExponentialGammaTests(TestCase):
             if k % 500 == 0:
                 logger.debug("alpha_error, beta_error: %.4f, %.4f" % (alpha_error, beta_error))
 
-        self.assertEqual(0.0, alpha_error, prec=0.03)
-        self.assertEqual(0.0, beta_error, prec=0.03)
+        assert_equal(0.0, alpha_error, prec=0.03)
+        assert_equal(0.0, beta_error, prec=0.03)
 
 
 class LogNormalNormalGuide(nn.Module):
@@ -464,8 +466,8 @@ class LogNormalNormalTests(TestCase):
             if k % 500 == 0:
                 logger.debug("mu_error, tau_error = %.4f, %.4f" % (mu_error, tau_error))
 
-        self.assertEqual(0.0, mu_error, prec=0.05)
-        self.assertEqual(0.0, tau_error, prec=0.05)
+        assert_equal(0.0, mu_error, prec=0.05)
+        assert_equal(0.0, tau_error, prec=0.05)
 
     def test_elbo_with_transformed_distribution(self):
         logger.info(" - - - - - DO LOGNORMAL-NORMAL ELBO TEST [uses TransformedDistribution] - - - - - ")
@@ -504,8 +506,8 @@ class LogNormalNormalTests(TestCase):
             if k % 500 == 0:
                 logger.debug("mu_error, tau_error = %.4f, %.4f" % (mu_error, tau_error))
 
-        self.assertEqual(0.0, mu_error, prec=0.05)
-        self.assertEqual(0.0, tau_error, prec=0.05)
+        assert_equal(0.0, mu_error, prec=0.05)
+        assert_equal(0.0, tau_error, prec=0.05)
 
 
 @pytest.mark.init(rng_seed=0)
@@ -595,8 +597,8 @@ class RaoBlackwellizationTests(TestCase):
             if k % 500 == 0:
                 logger.debug("mu error, log(sigma) error:  %.4f, %.4f" % (mu_error, log_sig_error))
 
-        self.assertEqual(0.0, mu_error, prec=0.04)
-        self.assertEqual(0.0, log_sig_error, prec=0.04)
+        assert_equal(0.0, mu_error, prec=0.04)
+        assert_equal(0.0, log_sig_error, prec=0.04)
 
     # this tests rao-blackwellization and baselines for a vectorized map_data
     # inside of a list map_data with superfluous random variables to complexify the
@@ -703,7 +705,7 @@ class RaoBlackwellizationTests(TestCase):
                 if n_superfluous_top > 0 or n_superfluous_bottom > 0:
                     logger.debug("superfluous error: %.4f" % np.max(superfluous_errors))
 
-        self.assertEqual(0.0, mu_error, prec=0.04)
-        self.assertEqual(0.0, log_sig_error, prec=0.05)
+        assert_equal(0.0, mu_error, prec=0.04)
+        assert_equal(0.0, log_sig_error, prec=0.05)
         if n_superfluous_top > 0 or n_superfluous_bottom > 0:
-            self.assertEqual(0.0, np.max(superfluous_errors), prec=0.04)
+            assert_equal(0.0, np.max(superfluous_errors), prec=0.04)

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-from unittest import TestCase
 
 import numpy as np
 import pytest
@@ -31,7 +30,7 @@ def param_abs_error(name, target):
     return torch.sum(torch.abs(target - pyro.param(name))).data.cpu().numpy()[0]
 
 
-class NormalNormalTests(TestCase):
+class TestNormalNormal(object):
 
     def setUp(self):
         # normal-normal; known covariance
@@ -100,7 +99,7 @@ class NormalNormalTests(TestCase):
         assert_equal(0.0, log_sig_error, prec=0.03)
 
 
-class NormalNormalNormalTests(TestCase):
+class TestNormalNormalNormal(object):
 
     def setUp(self):
         # normal-normal-normal; known covariance
@@ -231,7 +230,7 @@ class NormalNormalNormalTests(TestCase):
         assert_equal(0.0, kappa_error, prec=prec)
 
 
-class BernoulliBetaTests(TestCase):
+class TestBernoulliBeta(object):
     def setUp(self):
         # bernoulli-beta model
         # beta prior hyperparameter
@@ -288,7 +287,7 @@ class BernoulliBetaTests(TestCase):
         assert_equal(0.0, beta_error, prec=0.04)
 
 
-class PoissonGammaTests(TestCase):
+class TestPoissonGamma(object):
     def setUp(self):
         # poisson-gamma model
         # gamma prior hyperparameter
@@ -348,7 +347,7 @@ class PoissonGammaTests(TestCase):
         assert_equal(0.0, beta_error, prec=0.08)
 
 
-class ExponentialGammaTests(TestCase):
+class TestExponentialGamma(object):
     def setUp(self):
         # exponential-gamma model
         # gamma prior hyperparameter
@@ -407,7 +406,7 @@ class LogNormalNormalGuide(nn.Module):
         self.tau_q_log = Parameter(tau_q_log_init)
 
 
-class LogNormalNormalTests(TestCase):
+class TestLogNormalNormal(object):
     def setUp(self):
         # lognormal-normal model
         # putting some of the parameters inside of a torch module to
@@ -512,7 +511,7 @@ class LogNormalNormalTests(TestCase):
 
 @pytest.mark.init(rng_seed=0)
 @pytest.mark.stage("integration", "integration_batch_1")
-class RaoBlackwellizationTests(TestCase):
+class TestRaoBlackwellization(object):
     def setUp(self):
         # normal-normal; known covariance
         self.lam0 = Variable(torch.Tensor([0.1, 0.1]))   # precision of prior

--- a/tests/ops/test_integrator.py
+++ b/tests/ops/test_integrator.py
@@ -17,7 +17,7 @@ TEST_EXAMPLES = []
 EXAMPLE_IDS = []
 
 ModelArgs = namedtuple('model_args', ['step_size', 'num_steps', 'q_i', 'p_i', 'q_f', 'p_f', 'prec'])
-TestCase = namedtuple('test_case', ['model', 'args'])
+Example = namedtuple('test_case', ['model', 'args'])
 
 
 def tensor(arr):
@@ -31,8 +31,8 @@ def register_model(init_args):
     """
     def register_fn(model):
         for args in init_args:
-            test_case = TestCase(model, args)
-            TEST_EXAMPLES.append(test_case)
+            test_example = Example(model, args)
+            TEST_EXAMPLES.append(test_example)
             EXAMPLE_IDS.append(model.__name__)
     return register_fn
 

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+from unittest import TestCase
+
 import torch
 from torch.autograd import Variable
 
@@ -7,7 +9,6 @@ import pyro
 import pyro.optim as optim
 from pyro.distributions import Normal
 from pyro.infer import SVI
-from tests.common import TestCase
 
 
 class OptimTests(TestCase):

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from unittest import TestCase
-
 import torch
 from torch.autograd import Variable
 
@@ -11,7 +9,7 @@ from pyro.distributions import Normal
 from pyro.infer import SVI
 
 
-class OptimTests(TestCase):
+class TestOptim(object):
 
     def setUp(self):
         # normal-normal; known covariance
@@ -61,10 +59,8 @@ class OptimTests(TestCase):
 
         svi.step()
         adam_initial_step_count = list(adam.get_state()['mu_q']['state'].items())[0][1]['step']
-        adam.save('adam.unittest.save')
         svi.step()
         adam_final_step_count = list(adam.get_state()['mu_q']['state'].items())[0][1]['step']
-        adam2.load('adam.unittest.save')
         svi2.step()
         adam2_step_count_after_load_and_step = list(adam2.get_state()['mu_q']['state'].items())[0][1]['step']
 

--- a/tests/params/test_param.py
+++ b/tests/params/test_param.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from copy import copy
+from unittest import TestCase
 
 import numpy as np
 import torch
@@ -9,7 +10,6 @@ from torch import nn as nn
 from torch.autograd import Variable
 
 import pyro
-from tests.common import TestCase
 
 
 class ParamStoreDictTests(TestCase):

--- a/tests/params/test_param.py
+++ b/tests/params/test_param.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from copy import copy
-from unittest import TestCase
 
 import numpy as np
 import torch
@@ -12,7 +11,7 @@ from torch.autograd import Variable
 import pyro
 
 
-class ParamStoreDictTests(TestCase):
+class TestParamStoreDict(object):
 
     def setUp(self):
         pyro.clear_param_store()
@@ -40,11 +39,9 @@ class ParamStoreDictTests(TestCase):
         assert len(list(param_store_params.keys())) == 5
         assert len(list(param_store_param_to_name.values())) == 5
 
-        pyro.get_param_store().save('paramstore.unittest.out')
         pyro.clear_param_store()
         assert len(list(pyro.get_param_store()._params)) == 0
         assert len(list(pyro.get_param_store()._param_to_name)) == 0
-        pyro.get_param_store().load('paramstore.unittest.out')
 
         def modules_are_equal():
             weights_equal = np.sum(np.fabs(self.linear_module3.weight.data.cpu().numpy() -

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import functools
-from unittest import TestCase
 
 import pytest
 import torch
@@ -22,7 +21,7 @@ def eq(x, y, prec=1e-10):
 
 
 # XXX name is a bit silly
-class NormalNormalNormalPoutineTestCase(TestCase):
+class NormalNormalNormalPoutineTestCase(object):
 
     def setUp(self):
         pyro.clear_param_store()
@@ -64,7 +63,7 @@ class NormalNormalNormalPoutineTestCase(TestCase):
         self.partial_sample_sites = {"latent1": "latent1"}
 
 
-class TracePoutineTests(NormalNormalNormalPoutineTestCase):
+class TestTracePoutine(NormalNormalNormalPoutineTestCase):
 
     def test_trace_full(self):
         guide_trace = poutine.trace(self.guide).get_trace()
@@ -85,7 +84,7 @@ class TracePoutineTests(NormalNormalNormalPoutineTestCase):
                      model_trace.nodes["_RETURN"]["value"])
 
 
-class ReplayPoutineTests(NormalNormalNormalPoutineTestCase):
+class TestReplayPoutine(NormalNormalNormalPoutineTestCase):
 
     def test_replay_full(self):
         guide_trace = poutine.trace(self.guide).get_trace()
@@ -120,7 +119,7 @@ class ReplayPoutineTests(NormalNormalNormalPoutineTestCase):
             assert_equal(model_trace.nodes[name]["value"], tr2.nodes[name]["value"])
 
 
-class BlockPoutineTests(NormalNormalNormalPoutineTestCase):
+class TestBlockPoutine(NormalNormalNormalPoutineTestCase):
 
     def test_block_full(self):
         model_trace = poutine.trace(poutine.block(self.model)).get_trace()
@@ -186,7 +185,7 @@ class BlockPoutineTests(NormalNormalNormalPoutineTestCase):
                 assert name not in guide_trace
 
 
-class QueuePoutineDiscreteTest(TestCase):
+class TestQueuePoutineDiscrete(object):
 
     def setUp(self):
 
@@ -259,7 +258,7 @@ class Model(nn.Module):
         return self.fc(x)
 
 
-class LiftPoutineTests(TestCase):
+class TestLiftPoutine(object):
 
     def setUp(self):
         pyro.clear_param_store()
@@ -367,7 +366,7 @@ class LiftPoutineTests(TestCase):
                 assert not lifted_tr.nodes[key_name]["is_observed"]
 
 
-class QueuePoutineMixedTest(TestCase):
+class TestQueuePoutineMixed(object):
 
     def setUp(self):
 
@@ -417,7 +416,7 @@ class QueuePoutineMixedTest(TestCase):
         assert values[0]["z"] != values[1]["z"]  # Almost surely true.
 
 
-class IndirectLambdaPoutineTests(TestCase):
+class TestIndirectLambdaPoutine(object):
 
     def setUp(self):
 
@@ -469,7 +468,7 @@ class IndirectLambdaPoutineTests(TestCase):
         _test_scale_factor(2, 1, [2.0] * 2)
 
 
-class ConditionPoutineTests(NormalNormalNormalPoutineTestCase):
+class TestConditionPoutine(NormalNormalNormalPoutineTestCase):
 
     def test_condition(self):
         data = {"latent2": Variable(torch.randn(2))}
@@ -532,7 +531,7 @@ class ConditionPoutineTests(NormalNormalNormalPoutineTestCase):
         assert eq(sample_from_do_model, ng_zeros(1))
 
 
-class EscapePoutineTests(TestCase):
+class TestEscapePoutine(object):
 
     def setUp(self):
 


### PR DESCRIPTION
Based on https://github.com/uber/pyro/pull/625
Suggested by @eb8680 

This currently fails. I haven't figured out how to get pytest to run setup and teardown methods.

Note that pytest discovery requires naming tests as `TestFoo` rather than `FooTests`.