### PR TITLE
partial implementation of lax gradient estimator in tracegraph_elbo

### DIFF
--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -152,8 +152,8 @@ def _compute_elbo_non_reparam(guide_trace, guide_vec_md_nodes,  #
             #if not use_lax:
                 # block nn_baseline_input gradients except in baseline loss
             baseline += nn_baseline(detach_iterable(nn_baseline_input))
-            if use_lax:
-                baseline_undetached = nn_baseline(nn_baseline_input)
+            #if use_lax:
+            #    baseline_undetached = nn_baseline(nn_baseline_input)
             #else:
             #    baseline += nn_baseline(nn_baseline_input)
         elif use_baseline_value:
@@ -188,7 +188,7 @@ def _compute_elbo_non_reparam(guide_trace, guide_vec_md_nodes,  #
             else:
                 p.grad -= cost_x_grads[-1]
         if use_lax:
-            grads_baseline = autograd.grad(baseline_undetached, trainable_params_minus_bl_params,
+            grads_baseline = autograd.grad(baseline, trainable_params_minus_bl_params,
                                            create_graph=True, allow_unused=True)
             for k, g, p in zip(range(len(trainable_params_minus_bl_params)), grads_baseline,
                                trainable_params_minus_bl_params):

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 
 import networkx
 import numpy as np
-import torch
 import torch.autograd as autograd
 
 import pyro
@@ -327,7 +326,7 @@ class TraceGraph_ELBO(object):
         non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
         # collect parameters to train from model and guide
         trainable_params, trainable_params_minus_bl_params = _get_sorted_params(model_trace,
-            guide_trace, non_reparam_nodes)
+                                                                                guide_trace, non_reparam_nodes)
 
         # compute elbo for reparameterized nodes
         elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace, non_reparam_nodes)

--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -168,4 +168,4 @@ class Trace(networkx.DiGraph):
         """
         Gets a list of all param sites in trace
         """
-    	return [site["value"] for site in self.nodes.values() if site["type"] == "param"]
+        return [site["value"] for site in self.nodes.values() if site["type"] == "param"]

--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -162,3 +162,10 @@ class Trace(networkx.DiGraph):
         are not reparameterizable primitive distributions
         """
         return list(set(self.stochastic_nodes) - set(self.reparameterized_nodes))
+
+    @property
+    def parameters(self):
+        """
+        Gets a list of all param sites in trace
+        """
+    	return [site["value"] for site in self.nodes.values() if site["type"] == "param"]

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -133,9 +133,12 @@ class NormalNormalNormalTests(TestCase):
 
     def test_elbo_nonreparameterized_nn_baseline(self):
         self.do_elbo_test(False, True, 12000, 0.04, 0.0015, use_nn_baseline=True,
-                          use_decaying_avg_baseline=False)
+                          use_decaying_avg_baseline=False, use_lax=False)
+        self.do_elbo_test(False, True, 12000, 0.04, 0.0015, use_nn_baseline=True,
+                          use_decaying_avg_baseline=False, use_lax=True)
 
-    def do_elbo_test(self, repa1, repa2, n_steps, prec, lr, use_nn_baseline, use_decaying_avg_baseline):
+    def do_elbo_test(self, repa1, repa2, n_steps, prec, lr, use_nn_baseline, use_decaying_avg_baseline,
+                     use_lax=False):
         logger.info(" - - - - - DO NORMALNORMALNORMAL ELBO TEST - - - - - -")
         logger.info("[reparameterized = %s, %s; nn_baseline = %s, decaying_baseline = %s]" %
                     (repa1, repa2, use_nn_baseline, use_decaying_avg_baseline))
@@ -198,12 +201,6 @@ class NormalNormalNormalTests(TestCase):
                                       use_decaying_avg_baseline=use_decaying_avg_baseline))
 
             return mu_latent
-
-        # optim = Optimize(model, guide,
-        #                 torch.optim.Adam, {"lr": lr, "betas": (0.97, 0.999)},
-        #                 loss="ELBO", trace_graph=True,
-        #                 auxiliary_optim_constructor=torch.optim.Adam,
-        #                 auxiliary_optim_args={"lr": 5.0 * lr, "betas": (0.90, 0.999)})
 
         adam = optim.Adam({"lr": .0015, "betas": (0.97, 0.999)})
         svi = SVI(model, guide, adam, loss="ELBO", trace_graph=True)

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -140,8 +140,8 @@ class NormalNormalNormalTests(TestCase):
     def do_elbo_test(self, repa1, repa2, n_steps, prec, lr, use_nn_baseline, use_decaying_avg_baseline,
                      use_lax=False):
         logger.info(" - - - - - DO NORMALNORMALNORMAL ELBO TEST - - - - - -")
-        logger.info("[reparameterized = %s, %s; nn_baseline = %s, decaying_baseline = %s]" %
-                    (repa1, repa2, use_nn_baseline, use_decaying_avg_baseline))
+        logger.info("[reparameterized = %s, %s; nn_baseline = %s, decaying_baseline = %s, use_lax = %s]" %
+                    (repa1, repa2, use_nn_baseline, use_decaying_avg_baseline, use_lax))
         pyro.clear_param_store()
 
         if use_nn_baseline:
@@ -206,12 +206,11 @@ class NormalNormalNormalTests(TestCase):
 
         def per_param_callable(module_name, param_name, tags):
             if 'baseline' in tags:
-                return {"lr": 1.0e-2, "betas": (0.90, 0.999)}
+                return {"lr": 1.0e-1, "betas": (0.90, 0.999)}
             else:
                 return {"lr": 0.0015, "betas": (0.97, 0.999)}
 
         adam = optim.Adam(per_param_callable)
-        #adam = optim.Adam({"lr": .0015, "betas": (0.97, 0.999)})
         svi = SVI(model, guide, adam, loss="ELBO", trace_graph=True)
 
         for k in range(n_steps):
@@ -225,8 +224,8 @@ class NormalNormalNormalTests(TestCase):
 
             if k % 500 == 0:
                 logger.debug("errors [%04d]:  %.4f, %.4f" % (k, mu_error, log_sig_error))
-                logger.debug(", %.4f, %.4f" % (mu_prime_error, log_sig_prime_error))
-                logger.debug(", %.4f" % kappa_error)
+                logger.debug("                %.4f, %.4f, %.4f" % (mu_prime_error,
+                    log_sig_prime_error, kappa_error))
 
         self.assertEqual(0.0, mu_error, prec=prec)
         self.assertEqual(0.0, log_sig_error, prec=prec)

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -132,9 +132,9 @@ class NormalNormalNormalTests(TestCase):
                           use_decaying_avg_baseline=True)
 
     def test_elbo_nonreparameterized_nn_baseline(self):
-        self.do_elbo_test(False, True, 12000, 0.04, 0.0015, use_nn_baseline=True,
+        self.do_elbo_test(False, True, 5000, 0.04, 0.0015, use_nn_baseline=True,
                           use_decaying_avg_baseline=False, use_lax=False)
-        self.do_elbo_test(False, True, 12000, 0.04, 0.0015, use_nn_baseline=True,
+        self.do_elbo_test(False, True, 5000, 0.04, 0.0015, use_nn_baseline=True,
                           use_decaying_avg_baseline=False, use_lax=True)
 
     def do_elbo_test(self, repa1, repa2, n_steps, prec, lr, use_nn_baseline, use_decaying_avg_baseline,
@@ -206,7 +206,7 @@ class NormalNormalNormalTests(TestCase):
 
         def per_param_callable(module_name, param_name, tags):
             if 'baseline' in tags:
-                return {"lr": 1.0e-6, "betas": (0.90, 0.999)}
+                return {"lr": 1.0e-2, "betas": (0.90, 0.999)}
             else:
                 return {"lr": 0.0015, "betas": (0.97, 0.999)}
 
@@ -224,7 +224,7 @@ class NormalNormalNormalTests(TestCase):
             log_sig_prime_error = param_mse("log_sig_q_prime", -0.5 * torch.log(2.0 * self.lam0))
 
             if k % 500 == 0:
-                logger.debug("errors:  %.4f, %.4f" % (mu_error, log_sig_error))
+                logger.debug("errors [%04d]:  %.4f, %.4f" % (k, mu_error, log_sig_error))
                 logger.debug(", %.4f, %.4f" % (mu_prime_error, log_sig_prime_error))
                 logger.debug(", %.4f" % kappa_error)
 

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -124,11 +124,11 @@ class NormalNormalNormalTests(TestCase):
         self.do_elbo_test(True, True, 5000, 0.02, 0.002, False, False)
 
     def test_elbo_nonreparameterized_both_baselines(self):
-        self.do_elbo_test(False, False, 15000, 0.05, 0.001, use_nn_baseline=True,
+        self.do_elbo_test(False, False, 5000, 0.05, 0.001, use_nn_baseline=True,
                           use_decaying_avg_baseline=True)
 
     def test_elbo_nonreparameterized_decaying_baseline(self):
-        self.do_elbo_test(True, False, 12000, 0.04, 0.0015, use_nn_baseline=False,
+        self.do_elbo_test(True, False, 5000, 0.04, 0.0015, use_nn_baseline=False,
                           use_decaying_avg_baseline=True)
 
     def test_elbo_nonreparameterized_nn_baseline(self):
@@ -194,7 +194,8 @@ class NormalNormalNormalTests(TestCase):
             mu_latent_prime_dist = dist.Normal(kappa_q.expand_as(mu_latent) * mu_latent + mu_q_prime,
                                                sig_q_prime,
                                                reparameterized=repa1)
-            pyro.module("mu_prime_baseline", mu_prime_baseline, tags="baseline")
+            if mu_prime_baseline is not None:
+                pyro.module("mu_prime_baseline", mu_prime_baseline, tags="baseline")
             pyro.sample("mu_latent_prime",
                         mu_latent_prime_dist,
                         baseline=dict(nn_baseline=mu_prime_baseline,
@@ -206,7 +207,7 @@ class NormalNormalNormalTests(TestCase):
 
         def per_param_callable(module_name, param_name, tags):
             if 'baseline' in tags:
-                return {"lr": 1.0e-1, "betas": (0.90, 0.999)}
+                return {"lr": 5.0e-2, "betas": (0.90, 0.999)}
             else:
                 return {"lr": 0.0015, "betas": (0.97, 0.999)}
 


### PR DESCRIPTION
This implements the LAX part of RELAX from [Grathwohl et al. 2017](https://arxiv.org/abs/1711.00123).

this is pretty simple. this is exactly like the baseline estimator we already have. the only
different is that the baseline is trained via a different loss function: one tries to directly minimize
(gradient) variance instead of minimizing an ad hoc square loss of the form (baseline-cost)**2.

most of the complications have to do with using torch.autograd to setup the new baseline loss (which is necessary because of higher-order derivatives). this is currently a bit of a mess, especially since we're currently mixing autograd.backward() and autograd.grad().

there are still some known issues (e.g. the batch_log_pdf case). so this is very much a wip. putting
this here mostly for @fritzo's benefit. 