### PR TITLE
Use @copy_docs_from on all existing distributions

### DIFF
--- a/pyro/distributions/bernoulli.py
+++ b/pyro/distributions/bernoulli.py
@@ -4,9 +4,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
-from pyro.distributions.util import get_probs_and_logits
+from pyro.distributions.util import copy_docs_from, get_probs_and_logits
 
 
+@copy_docs_from(Distribution)
 class Bernoulli(Distribution):
     """
     Bernoulli distribution.
@@ -44,9 +45,6 @@ class Bernoulli(Distribution):
         super(Bernoulli, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`.
-        """
         event_dim = 1
         ps = self.ps
         if x is not None:
@@ -63,22 +61,13 @@ class Bernoulli(Distribution):
         return ps.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`.
-        """
         event_dim = 1
         return self.ps.size()[-event_dim:]
 
     def sample(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`.
-        """
         return Variable(torch.bernoulli(self.ps.data))
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         batch_log_pdf_shape = self.batch_shape(x) + (1,)
         max_val = (-self.logits).clamp(min=0)
         binary_cross_entropy = self.logits - self.logits * x + max_val + \
@@ -113,13 +102,7 @@ class Bernoulli(Distribution):
         return Variable(result)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`.
-        """
         return self.ps
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`.
-        """
         return self.ps * (1 - self.ps)

--- a/pyro/distributions/beta.py
+++ b/pyro/distributions/beta.py
@@ -7,9 +7,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
-from pyro.distributions.util import log_gamma
+from pyro.distributions.util import copy_docs_from, log_gamma
 
 
+@copy_docs_from(Distribution)
 class Beta(Distribution):
     """
     Univariate beta distribution parameterized by `alpha` and `beta`.
@@ -34,9 +35,6 @@ class Beta(Distribution):
         super(Beta, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         alpha = self.alpha
         if x is not None:
@@ -52,16 +50,10 @@ class Beta(Distribution):
         return alpha.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`.
-        """
         event_dim = 1
         return self.alpha.size()[-event_dim:]
 
     def sample(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample.`
-        """
         np_sample = spr.beta.rvs(self.alpha.data.cpu().numpy(), self.beta.data.cpu().numpy())
         if isinstance(np_sample, numbers.Number):
             np_sample = [np_sample]
@@ -70,9 +62,6 @@ class Beta(Distribution):
         return x
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         alpha = self.alpha.expand(self.shape(x))
         beta = self.beta.expand(self.shape(x))
         one = Variable(torch.ones(x.size()).type_as(alpha.data))
@@ -86,14 +75,8 @@ class Beta(Distribution):
         return batch_log_pdf.contiguous().view(batch_log_pdf_shape)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
-        """
         return self.alpha / (self.alpha + self.beta)
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
-        """
         return torch.pow(self.analytic_mean(), 2.0) * self.beta / \
             (self.alpha * (self.alpha + self.beta + Variable(torch.ones([1]))))

--- a/pyro/distributions/binomial.py
+++ b/pyro/distributions/binomial.py
@@ -6,9 +6,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
-from pyro.distributions.util import log_gamma, torch_multinomial
+from pyro.distributions.util import copy_docs_from, log_gamma, torch_multinomial
 
 
+@copy_docs_from(Distribution)
 class Binomial(Distribution):
     """
     Binomial distribution.
@@ -36,9 +37,6 @@ class Binomial(Distribution):
         super(Binomial, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         ps = self.ps
         if x is not None:
@@ -54,16 +52,10 @@ class Binomial(Distribution):
         return ps.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         event_dim = 1
         return self.ps.size()[-event_dim:]
 
     def sample(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`
-        """
         return torch.sum(self.expanded_sample(), dim=-1, keepdim=True)
 
     def expanded_sample(self):
@@ -76,9 +68,6 @@ class Binomial(Distribution):
         return Variable(torch_multinomial(ps.data, n, replacement=True))
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         batch_log_pdf_shape = self.batch_shape(x) + (1,)
         log_factorial_n = log_gamma(self.n + 1)
         log_factorial_xs = log_gamma(x + 1) + log_gamma(self.n - x + 1)
@@ -87,13 +76,7 @@ class Binomial(Distribution):
         return batch_log_pdf.contiguous().view(batch_log_pdf_shape)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
-        """
         return self.n * self.ps
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
-        """
         return self.n * self.ps * (1 - self.ps)

--- a/pyro/distributions/categorical.py
+++ b/pyro/distributions/categorical.py
@@ -5,9 +5,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
-from pyro.distributions.util import get_probs_and_logits, torch_multinomial, torch_zeros_like
+from pyro.distributions.util import copy_docs_from, get_probs_and_logits, torch_multinomial, torch_zeros_like
 
 
+@copy_docs_from(Distribution)
 class Categorical(Distribution):
     """
     Categorical (discrete) distribution.
@@ -63,9 +64,6 @@ class Categorical(Distribution):
         return x
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         ps = self.ps
         if x is not None:
@@ -79,9 +77,6 @@ class Categorical(Distribution):
         return ps.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         return (1,)
 
     def sample(self):

--- a/pyro/distributions/cauchy.py
+++ b/pyro/distributions/cauchy.py
@@ -8,8 +8,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import copy_docs_from
 
 
+@copy_docs_from(Distribution)
 class Cauchy(Distribution):
     """
     Cauchy (a.k.a. Lorentz) distribution.
@@ -38,9 +40,6 @@ class Cauchy(Distribution):
         super(Cauchy, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         mu = self.mu
         if x is not None:
@@ -56,16 +55,10 @@ class Cauchy(Distribution):
         return mu.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         event_dim = 1
         return self.mu.size()[-event_dim:]
 
     def sample(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`
-        """
         np_sample = spr.cauchy.rvs(self.mu.data.cpu().numpy(), self.gamma.data.cpu().numpy())
         if isinstance(np_sample, numbers.Number):
             np_sample = [np_sample]
@@ -73,9 +66,6 @@ class Cauchy(Distribution):
         return sample
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         # expand to patch size of input
         mu = self.mu.expand(self.shape(x))
         gamma = self.gamma.expand(self.shape(x))
@@ -86,13 +76,7 @@ class Cauchy(Distribution):
         return log_pdf.contiguous().view(batch_log_pdf_shape)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
-        """
         raise ValueError("Cauchy has no defined mean")
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
-        """
         raise ValueError("Cauchy has no defined variance")

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -4,8 +4,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import copy_docs_from
 
 
+@copy_docs_from(Distribution)
 class Delta(Distribution):
     """
     Degenerate discrete distribution (a single point).
@@ -27,9 +29,6 @@ class Delta(Distribution):
         super(Delta, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         v = self.v
         if x is not None:
@@ -45,22 +44,13 @@ class Delta(Distribution):
         return v.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         event_dim = 1
         return self.v.size()[-event_dim:]
 
     def sample(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`
-        """
         return self.v
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         v = self.v
         v = v.expand(self.shape(x))
         batch_shape = self.batch_shape(x) + (1,)

--- a/pyro/distributions/dirichlet.py
+++ b/pyro/distributions/dirichlet.py
@@ -6,9 +6,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
-from pyro.distributions.util import log_beta
+from pyro.distributions.util import copy_docs_from, log_beta
 
 
+@copy_docs_from(Distribution)
 class Dirichlet(Distribution):
     """
     Dirichlet distribution parameterized by a vector `alpha`.
@@ -32,9 +33,6 @@ class Dirichlet(Distribution):
         super(Dirichlet, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         alpha = self.alpha
         if x is not None:
@@ -50,9 +48,6 @@ class Dirichlet(Distribution):
         return alpha.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         return self.alpha.size()[-1:]
 
     def sample(self):
@@ -94,15 +89,9 @@ class Dirichlet(Distribution):
         return (x_sum - beta).contiguous().view(batch_log_pdf_shape)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
-        """
         sum_alpha = torch.sum(self.alpha)
         return self.alpha / sum_alpha
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
-        """
         sum_alpha = torch.sum(self.alpha)
         return self.alpha * (sum_alpha - self.alpha) / (torch.pow(sum_alpha, 2) * (1 + sum_alpha))

--- a/pyro/distributions/exponential.py
+++ b/pyro/distributions/exponential.py
@@ -4,8 +4,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import copy_docs_from
 
 
+@copy_docs_from(Distribution)
 class Exponential(Distribution):
     """
     Exponential parameterized by scale `lambda`.
@@ -25,9 +27,6 @@ class Exponential(Distribution):
         super(Exponential, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         lam = self.lam
         if x is not None:
@@ -43,39 +42,22 @@ class Exponential(Distribution):
         return lam.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         event_dim = 1
         return self.lam.size()[-event_dim:]
 
     def sample(self):
-        """
-        Reparameterized sampler.
-
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`
-        """
         eps = Variable(torch.rand(self.lam.size()).type_as(self.lam.data))
         x = -torch.log(eps) / self.lam
         return x
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         lam = self.lam.expand(self.shape(x))
         ll = -lam * x + torch.log(lam)
         batch_log_pdf_shape = self.batch_shape(x) + (1,)
         return torch.sum(ll, -1).contiguous().view(batch_log_pdf_shape)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
-        """
         return torch.pow(self.lam, -1.0)
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
-        """
         return torch.pow(self.lam, -2.0)

--- a/pyro/distributions/gamma.py
+++ b/pyro/distributions/gamma.py
@@ -7,9 +7,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
-from pyro.distributions.util import log_gamma
+from pyro.distributions.util import copy_docs_from, log_gamma
 
 
+@copy_docs_from(Distribution)
 class Gamma(Distribution):
     """
     Gamma distribution parameterized by `alpha` and `beta`.
@@ -33,9 +34,6 @@ class Gamma(Distribution):
         super(Gamma, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         alpha = self.alpha
         if x is not None:
@@ -51,16 +49,10 @@ class Gamma(Distribution):
         return alpha.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         event_dim = 1
         return self.alpha.size()[-event_dim:]
 
     def sample(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`
-        """
         theta = torch.pow(self.beta, -1.0)
         np_sample = spr.gamma.rvs(self.alpha.data.cpu().numpy(), scale=theta.data.cpu().numpy())
         if isinstance(np_sample, numbers.Number):
@@ -70,9 +62,6 @@ class Gamma(Distribution):
         return x
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         alpha = self.alpha.expand(self.shape(x))
         beta = self.beta.expand(self.shape(x))
         ll_1 = -beta * x
@@ -84,13 +73,7 @@ class Gamma(Distribution):
         return log_pdf.contiguous().view(batch_log_pdf_shape)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
-        """
         return self.alpha / self.beta
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
-        """
         return self.alpha / torch.pow(self.beta, 2.0)

--- a/pyro/distributions/half_cauchy.py
+++ b/pyro/distributions/half_cauchy.py
@@ -8,8 +8,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import copy_docs_from
 
 
+@copy_docs_from(Distribution)
 class HalfCauchy(Distribution):
     """
     Half-Cauchy distribution.
@@ -36,9 +38,6 @@ class HalfCauchy(Distribution):
         super(HalfCauchy, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         mu = self.mu
         if x is not None:
@@ -54,16 +53,10 @@ class HalfCauchy(Distribution):
         return mu.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         event_dim = 1
         return self.mu.size()[-event_dim:]
 
     def sample(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`
-        """
         np_sample = spr.halfcauchy.rvs(self.mu.data.cpu().numpy(), scale=self.gamma.data.cpu().numpy())
         if isinstance(np_sample, numbers.Number):
             np_sample = [np_sample]
@@ -71,9 +64,6 @@ class HalfCauchy(Distribution):
         return sample
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         # expand to patch size of input
         mu = self.mu.expand(self.shape(x))
         gamma = self.gamma.expand(self.shape(x))

--- a/pyro/distributions/log_normal.py
+++ b/pyro/distributions/log_normal.py
@@ -5,8 +5,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import copy_docs_from
 
 
+@copy_docs_from(Distribution)
 class LogNormal(Distribution):
     """
     Log-normal distribution.
@@ -34,9 +36,6 @@ class LogNormal(Distribution):
         super(LogNormal, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         mu = self.mu
         if x is not None:
@@ -52,25 +51,15 @@ class LogNormal(Distribution):
         return mu.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         event_dim = 1
         return self.mu.size()[-event_dim:]
 
     def sample(self):
-        """
-        Reparameterized log-normal sampler.
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`
-        """
         eps = Variable(torch.randn(self.mu.size()).type_as(self.mu.data))
         z = self.mu + self.sigma * eps
         return torch.exp(z)
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         mu = self.mu.expand(self.shape(x))
         sigma = self.sigma.expand(self.shape(x))
         ll_1 = Variable(torch.Tensor([-0.5 * np.log(2.0 * np.pi)]).type_as(mu.data).expand_as(x))
@@ -81,14 +70,8 @@ class LogNormal(Distribution):
         return batch_log_pdf.contiguous().view(batch_log_pdf_shape)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
-        """
         return torch.exp(self.mu + 0.5 * torch.pow(self.sigma, 2.0))
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
-        """
         return (torch.exp(torch.pow(self.sigma, 2.0)) - Variable(torch.ones(1))) * \
             torch.pow(self.analytic_mean(), 2)

--- a/pyro/distributions/multinomial.py
+++ b/pyro/distributions/multinomial.py
@@ -7,9 +7,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
-from pyro.distributions.util import log_gamma, torch_multinomial
+from pyro.distributions.util import copy_docs_from, log_gamma, torch_multinomial
 
 
+@copy_docs_from(Distribution)
 class Multinomial(Distribution):
     """
     Multinomial distribution.
@@ -40,9 +41,6 @@ class Multinomial(Distribution):
         super(Multinomial, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         ps = self.ps
         if x is not None:
@@ -58,16 +56,10 @@ class Multinomial(Distribution):
         return ps.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         event_dim = 1
         return self.ps.size()[-event_dim:]
 
     def sample(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`
-        """
         counts = np.apply_along_axis(
             lambda x: np.bincount(x, minlength=self.ps.size()[-1]),
             axis=-1,
@@ -86,9 +78,6 @@ class Multinomial(Distribution):
         return Variable(torch_multinomial(self.ps.data, n, replacement=True))
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         batch_log_pdf_shape = self.batch_shape(x) + (1,)
         log_factorial_n = log_gamma(x.sum(-1) + 1)
         log_factorial_xs = log_gamma(x + 1).sum(-1)
@@ -97,13 +86,7 @@ class Multinomial(Distribution):
         return batch_log_pdf.contiguous().view(batch_log_pdf_shape)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
-        """
         return self.n * self.ps
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
-        """
         return self.n * self.ps * (1 - self.ps)

--- a/pyro/distributions/normal.py
+++ b/pyro/distributions/normal.py
@@ -5,8 +5,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import copy_docs_from
 
 
+@copy_docs_from(Distribution)
 class Normal(Distribution):
     """
     Univariate normal (Gaussian) distribution.
@@ -39,9 +41,6 @@ class Normal(Distribution):
         super(Normal, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         mu = self.mu
         if x is not None:
@@ -57,30 +56,17 @@ class Normal(Distribution):
         return mu.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         # XXX Until PyTorch supports scalars, this should return (1,)
         # XXX After PyTorch supports scalars, this should return ()
         event_dim = 1
         return self.mu.size()[-event_dim:]
 
     def sample(self):
-        """
-        Reparameterized Normal sampler.
-
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`
-        """
         eps = Variable(torch.randn(self.mu.size()).type_as(self.mu.data))
         z = self.mu + eps * self.sigma
         return z if self.reparameterized else z.detach()
 
     def batch_log_pdf(self, x):
-        """
-        Diagonal Normal log-likelihood
-
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         # expand to patch size of input
         mu = self.mu.expand(self.shape(x))
         sigma = self.sigma.expand(self.shape(x))
@@ -95,13 +81,7 @@ class Normal(Distribution):
         return batch_log_pdf.contiguous().view(batch_log_pdf_shape)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
-        """
         return self.mu
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
-        """
         return torch.pow(self.sigma, 2)

--- a/pyro/distributions/one_hot_categorical.py
+++ b/pyro/distributions/one_hot_categorical.py
@@ -4,9 +4,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
-from pyro.distributions.util import get_probs_and_logits, torch_eye, torch_multinomial, torch_zeros_like
+from pyro.distributions.util import copy_docs_from, get_probs_and_logits, torch_eye, torch_multinomial, torch_zeros_like
 
 
+@copy_docs_from(Distribution)
 class OneHotCategorical(Distribution):
     """
     OneHotCategorical (discrete) distribution.
@@ -48,9 +49,6 @@ class OneHotCategorical(Distribution):
         return x
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         ps = self.ps
         if x is not None:
@@ -63,16 +61,10 @@ class OneHotCategorical(Distribution):
         return ps.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         event_dim = 1
         return self.ps.size()[-event_dim:]
 
     def shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.shape`
-        """
         return self.batch_shape(x) + self.event_shape()
 
     def sample(self):
@@ -143,13 +135,7 @@ class OneHotCategorical(Distribution):
         return Variable(result)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`.
-        """
         return self.ps
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`.
-        """
         return self.ps * (1 - self.ps)

--- a/pyro/distributions/poisson.py
+++ b/pyro/distributions/poisson.py
@@ -5,9 +5,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
-from pyro.distributions.util import log_gamma
+from pyro.distributions.util import copy_docs_from, log_gamma
 
 
+@copy_docs_from(Distribution)
 class Poisson(Distribution):
     """
     Poisson distribution over integers parameterized by scale `lambda`.
@@ -26,9 +27,6 @@ class Poisson(Distribution):
         super(Poisson, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         lam = self.lam
         if x is not None:
@@ -44,23 +42,14 @@ class Poisson(Distribution):
         return lam.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         event_dim = 1
         return self.lam.size()[-event_dim:]
 
     def sample(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`
-        """
         x = npr.poisson(lam=self.lam.data.cpu().numpy()).astype("float")
         return Variable(torch.Tensor(x).type_as(self.lam.data))
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         lam = self.lam.expand(self.shape(x))
         ll_1 = torch.sum(x * torch.log(lam), -1)
         ll_2 = -torch.sum(lam, -1)
@@ -70,13 +59,7 @@ class Poisson(Distribution):
         return batch_log_pdf.contiguous().view(batch_log_pdf_shape)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
-        """
         return self.lam
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
-        """
         return self.lam

--- a/pyro/distributions/transformed_distribution.py
+++ b/pyro/distributions/transformed_distribution.py
@@ -9,9 +9,11 @@ from six import add_metaclass
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import copy_docs_from
 from pyro.nn import AutoRegressiveNN
 
 
+@copy_docs_from(Distribution)
 class TransformedDistribution(Distribution):
     """
     Transforms the base distribution by applying a sequence of `Bijector`s to it.
@@ -54,15 +56,9 @@ class TransformedDistribution(Distribution):
         return next_input
 
     def batch_shape(self, x=None, *args, **kwargs):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         return self.base_dist.batch_shape(x, *args, **kwargs)
 
     def event_shape(self, *args, **kwargs):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         return self.base_dist.event_shape(*args, **kwargs)
 
     def log_pdf(self, y, *args, **kwargs):
@@ -85,9 +81,6 @@ class TransformedDistribution(Distribution):
         return log_pdf
 
     def batch_log_pdf(self, y, *args, **kwargs):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         value = y
         log_det_jacobian = 0.0
         for bijector in reversed(self.bijectors):

--- a/pyro/distributions/uniform.py
+++ b/pyro/distributions/uniform.py
@@ -4,8 +4,10 @@ import torch
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import copy_docs_from
 
 
+@copy_docs_from(Distribution)
 class Uniform(Distribution):
     """
     Uniform distribution over the continuous interval `[a, b]`.
@@ -27,9 +29,6 @@ class Uniform(Distribution):
         super(Uniform, self).__init__(*args, **kwargs)
 
     def batch_shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_shape`
-        """
         event_dim = 1
         a = self.a
         if x is not None:
@@ -45,29 +44,17 @@ class Uniform(Distribution):
         return a.size()[:-event_dim]
 
     def event_shape(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.event_shape`
-        """
         event_dim = 1
         return self.a.size()[-event_dim:]
 
     def shape(self, x=None):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.shape`
-        """
         return self.batch_shape(x) + self.event_shape()
 
     def sample(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.sample`
-        """
         eps = Variable(torch.rand(self.a.size()).type_as(self.a.data))
         return self.a + torch.mul(eps, self.b - self.a)
 
     def batch_log_pdf(self, x):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.batch_log_pdf`
-        """
         a = self.a.expand(self.shape(x))
         b = self.b.expand(self.shape(x))
         lb = x.ge(a).type_as(a)
@@ -76,13 +63,7 @@ class Uniform(Distribution):
         return torch.sum(torch.log(lb.mul(ub)) - torch.log(b - a), -1).contiguous().view(batch_log_pdf_shape)
 
     def analytic_mean(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_mean`
-        """
         return 0.5 * (self.a + self.b)
 
     def analytic_var(self):
-        """
-        Ref: :py:meth:`pyro.distributions.distribution.Distribution.analytic_var`
-        """
         return torch.pow(self.b - self.a, 2) / 12

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -21,7 +21,6 @@ def copy_docs_from(source_class):
             source_attr = getattr(source_class, name, None)
             source_doc = getattr(source_attr, '__doc__', None)
             if source_doc and not getattr(destin_attr, '__doc__', None):
-                print('DEBUG ' + name)
                 destin_attr.__doc__ = source_doc
         return destin_class
 


### PR DESCRIPTION
This simplifies our task of migrating docs from pyro.distributions.* to pyro.distribution.torch.*

## Tested

Ran `make docs` and verified that they look good.