### PR TITLE
Provide polyfill shim for torch.no_grad()

### DIFF
--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -293,10 +293,10 @@ def main(args):
     test_seq_lengths = rep(test_seq_lengths)
     val_batch, val_batch_reversed, val_batch_mask, val_seq_lengths = poly.get_mini_batch(
         np.arange(n_eval_samples * val_data_sequences.shape[0]), rep(val_data_sequences),
-        val_seq_lengths, volatile=True, cuda=args.cuda)
+        val_seq_lengths, cuda=args.cuda)
     test_batch, test_batch_reversed, test_batch_mask, test_seq_lengths = poly.get_mini_batch(
         np.arange(n_eval_samples * test_data_sequences.shape[0]), rep(test_data_sequences),
-        test_seq_lengths, volatile=True, cuda=args.cuda)
+        test_seq_lengths, cuda=args.cuda)
 
     # instantiate the dmm
     dmm = DMM(rnn_dropout_rate=args.rnn_dropout_rate, num_iafs=args.num_iafs,

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -102,7 +102,7 @@ def get_mini_batch_mask(mini_batch, seq_lengths):
 # as a mini-batch in reverse temporal order (`mini_batch_reversed`).
 # it also deals with the fact that packed sequences (which are what what we
 # feed to the PyTorch rnn) need to be sorted by sequence length.
-def get_mini_batch(mini_batch_indices, sequences, seq_lengths, volatile=False, cuda=False):
+def get_mini_batch(mini_batch_indices, sequences, seq_lengths, cuda=False):
     # get the sequence lengths of the mini-batch
     seq_lengths = seq_lengths[mini_batch_indices]
     # sort the sequence lengths
@@ -120,9 +120,9 @@ def get_mini_batch(mini_batch_indices, sequences, seq_lengths, volatile=False, c
     mini_batch_mask = get_mini_batch_mask(mini_batch, sorted_seq_lengths)
 
     # wrap in PyTorch Variables
-    mini_batch = Variable(torch.Tensor(mini_batch), volatile=volatile)
-    mini_batch_reversed = Variable(torch.Tensor(mini_batch_reversed), volatile=volatile)
-    mini_batch_mask = Variable(torch.Tensor(mini_batch_mask), volatile=volatile)
+    mini_batch = Variable(torch.Tensor(mini_batch))
+    mini_batch_reversed = Variable(torch.Tensor(mini_batch_reversed))
+    mini_batch_mask = Variable(torch.Tensor(mini_batch_mask))
 
     # cuda() here because need to cuda() before packing
     if cuda:

--- a/examples/ss_vae_M2.py
+++ b/examples/ss_vae_M2.py
@@ -8,17 +8,16 @@ from utils.mnist_cached import MNISTCached, setup_data_loaders
 from pyro.infer import SVI
 from pyro.optim import Adam
 from pyro.nn import ClippedSoftmax, ClippedSigmoid
+from pyro.shim import parse_torch_version
 from utils.custom_mlp import MLP, Exp
 from utils.vae_plots import plot_conditional_samples_ssvae, mnist_test_tsne_ssvae
 from util import set_seed, print_and_log, mkdir_p
 import torch.nn as nn
 
 version_warning = '''
-11/02/2017: This example does not work with the release version 0.2 of pytorch.
-Please install Pytorch from the latest master branch of pytorch or wait a week for the new release.
-This example uses a data loader that requires very recent PyTorch features.
+11/02/2017: This example does not work with PyTorch 0.2, please install PyTorch 0.3.
 '''
-torch_version = pyro.util.parse_torch_version()
+torch_version = parse_torch_version()
 if (torch_version < (0, 2, 1) and not torch_version[-1].startswith("+")):
     print(version_warning)
     sys.exit(0)

--- a/examples/vae_comparison.py
+++ b/examples/vae_comparison.py
@@ -16,6 +16,7 @@ from examples.util import RESULTS_DIR
 from pyro.distributions import Normal, Bernoulli
 from pyro.infer import SVI
 from pyro.optim import Adam
+from pyro.shim import torch_no_grad
 from pyro.util import ng_zeros, ng_ones
 
 """
@@ -125,9 +126,10 @@ class VAE(object):
         self.set_train(is_train=False)
         test_loss = 0
         for i, (x, _) in enumerate(self.test_loader):
-            x = Variable(x, volatile=True)
-            recon_x = self.model_eval(x)[0]
-            test_loss += self.compute_loss_and_gradient(x)
+            with torch_no_grad():
+                x = Variable(x)
+                recon_x = self.model_eval(x)[0]
+                test_loss += self.compute_loss_and_gradient(x)
             if i == 0:
                 n = min(x.size(0), 8)
                 comparison = torch.cat([x[:n],

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -59,8 +59,6 @@ class Trace_ELBO(object):
         """
         runs the guide and runs the model against the guide with
         the result packaged as a trace generator
-
-        XXX support for automatically settings args/kwargs to volatile?
         """
 
         for i in range(self.num_particles):

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -197,8 +197,6 @@ class TraceGraph_ELBO(object):
         """
         runs the guide and runs the model against the guide with
         the result packaged as a tracegraph generator
-
-        XXX support for automatically settings args/kwargs to volatile?
         """
 
         for i in range(self.num_particles):

--- a/pyro/shim.py
+++ b/pyro/shim.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, division, print_function
+
+import contextlib
+import re
+
+import torch
+
+
+def parse_torch_version():
+    """
+    Parses `torch.__version__` into a semver-ish version tuple.
+    This is needed to handle subpatch `_n` parts outside of the semver spec.
+
+    :returns: a tuple `(major, minor, patch, extra_stuff)`
+    """
+    match = re.match(r"(\d\.\d\.\d)(.*)", torch.__version__)
+    major, minor, patch = map(int, match.group(1).split("."))
+    extra_stuff = match.group(2)
+    return major, minor, patch, extra_stuff
+
+
+# Polyfill to bridge the change of .volatile between PyTorch 0.3 and 0.4.
+try:
+    # These work in PyTorch 0.4 prerelease.
+    torch_no_grad = torch.no_grad
+
+    def is_volatile(variable):
+        return False
+
+except AttributeError:
+    # These work in PyTorch 0.3 and earlier.
+
+    @contextlib.contextmanager
+    def torch_no_grad():
+        yield
+
+    def is_volatile(variable):
+        return variable.volatile

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -1,30 +1,17 @@
 from __future__ import absolute_import, division, print_function
 
 import functools
-import re
 import warnings
 
 import graphviz
 import numpy as np
-import torch
-from torch.autograd import Variable
-from torch.nn import Parameter
 
+import torch
 from pyro.poutine.poutine import _PYRO_STACK
 from pyro.poutine.util import site_is_subsample
-
-
-def parse_torch_version():
-    """
-    Parses `torch.__version__` into a semver-ish version tuple.
-    This is needed to handle subpatch `_n` parts outside of the semver spec.
-
-    :returns: a tuple `(major, minor, patch, extra_stuff)`
-    """
-    match = re.match(r"(\d\.\d\.\d)(.*)", torch.__version__)
-    major, minor, patch = map(int, match.group(1).split("."))
-    extra_stuff = match.group(2)
-    return major, minor, patch, extra_stuff
+from pyro.shim import is_volatile
+from torch.autograd import Variable
+from torch.nn import Parameter
 
 
 def detach_iterable(iterable):
@@ -142,7 +129,7 @@ def zero_grads(tensors):
     """
     for p in tensors:
         if p.grad is not None:
-            if p.grad.volatile:
+            if is_volatile(p.grad):
                 p.grad.data.zero_()
             else:
                 data = p.grad.data

--- a/tutorial/source/dmm.ipynb
+++ b/tutorial/source/dmm.ipynb
@@ -742,17 +742,17 @@
     "test_seq_lengths = rep(test_seq_lengths)\n",
     "val_batch, val_batch_reversed, val_batch_mask, val_seq_lengths = poly.get_mini_batch(\n",
     "    np.arange(n_eval_samples * val_data_sequences.shape[0]), rep(val_data_sequences),\n",
-    "    val_seq_lengths, volatile=True, cuda=args.cuda)\n",
+    "    val_seq_lengths, cuda=args.cuda)\n",
     "test_batch, test_batch_reversed, test_batch_mask, test_seq_lengths = poly.get_mini_batch(\n",
     "    np.arange(n_eval_samples * test_data_sequences.shape[0]), rep(test_data_sequences),\n",
-    "    test_seq_lengths, volatile=True, cuda=args.cuda)"
+    "    test_seq_lengths, cuda=args.cuda)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that we make use of the same helper function `get_mini_batch` as before, except this time we select the entire datasets. Also, we mark the data as `volatile`, which lets PyTorch know that we won't be computing any gradients; this results in further speed-ups. With the test and validation data now fully prepped, we define the helper function that does the evaluation: "
+    "With the test and validation data now fully prepped, we define the helper function that does the evaluation: "
    ]
   },
   {


### PR DESCRIPTION
PyTorch 0.4 is dropping the `.volatile` attribute in favor of a `torch.no_grad()` context manager. Pyro's tests suite currently fails against PyTorch master. This PR fixes the tests by:
- adding a `pyro.shim` module
- addding `torch_no_grad()` and `is_volatile()` methods that work in PyTorch 0.2, 0.3, and 0.4 (master)
- removing all `volatile=True` from codebase (I believe this changes performance but not semantics)

## Tested:
- CI tests run against PyTorch 0.2
- ran `make test` against PyTorch 0.3
- ran `make test` against PyTorch 0.4 master 2017-12-21 (tests failed before this PR)