### PR TITLE
Refactor TorchDistribution and wrap torch.distributions.Bernoulli

### DIFF
--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-from pyro.distributions.bernoulli import Bernoulli
 from pyro.distributions.binomial import Binomial
 from pyro.distributions.categorical import Categorical
 from pyro.distributions.cauchy import Cauchy
@@ -21,18 +20,19 @@ USE_TORCH_DISTRIBUTIONS = int(os.environ.get('PYRO_USE_TORCH_DISTRIBUTIONS', 0))
 
 # distribution classes with working torch versions
 if USE_TORCH_DISTRIBUTIONS:
+    from pyro.distributions.torch.bernoulli import Bernoulli
     from pyro.distributions.torch.beta import Beta
     from pyro.distributions.torch.dirichlet import Dirichlet
     from pyro.distributions.torch.exponential import Exponential
     from pyro.distributions.torch.gamma import Gamma
     from pyro.distributions.torch.normal import Normal
 else:
+    from pyro.distributions.bernoulli import Bernoulli
     from pyro.distributions.beta import Beta
     from pyro.distributions.dirichlet import Dirichlet
     from pyro.distributions.exponential import Exponential
     from pyro.distributions.gamma import Gamma
     from pyro.distributions.normal import Normal
-
 
 # function aliases
 bernoulli = RandomPrimitive(Bernoulli)

--- a/pyro/distributions/torch/bernoulli.py
+++ b/pyro/distributions/torch/bernoulli.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 
 from pyro.distributions.bernoulli import Bernoulli as _Bernoulli
 from pyro.distributions.torch_wrapper import TorchDistribution
-from pyro.distributions.util import copy_docs_from
+from pyro.distributions.util import copy_docs_from, get_clamping_buffer
 
 
 @copy_docs_from(_Bernoulli)
@@ -18,6 +18,8 @@ class Bernoulli(TorchDistribution):
                              "but not both.".format(ps, logits))
         if ps is None:
             ps = F.sigmoid(logits)
+        eps = get_clamping_buffer(ps)
+        ps = ps.clamp(min=eps, max=1-eps)
         torch_dist = torch.distributions.Bernoulli(ps)
         x_shape = ps.size()
         event_dim = 1

--- a/pyro/distributions/torch/bernoulli.py
+++ b/pyro/distributions/torch/bernoulli.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+import torch.nn.functional as F
+
+from pyro.distributions.bernoulli import Bernoulli as _Bernoulli
+from pyro.distributions.torch_wrapper import TorchDistribution
+from pyro.distributions.util import copy_docs_from
+
+
+@copy_docs_from(_Bernoulli)
+class Bernoulli(TorchDistribution):
+    enumerable = True
+
+    def __init__(self, ps=None, logits=None, *args, **kwargs):
+        if (ps is None) == (logits is None):
+            raise ValueError("Got ps={}, logits={}. Either `ps` or `logits` must be specified, "
+                             "but not both.".format(ps, logits))
+        if ps is None:
+            ps = F.sigmoid(logits)
+        torch_dist = torch.distributions.Bernoulli(ps)
+        x_shape = ps.size()
+        event_dim = 1
+        super(Bernoulli, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)

--- a/pyro/distributions/torch/beta.py
+++ b/pyro/distributions/torch/beta.py
@@ -13,13 +13,6 @@ class Beta(TorchDistribution):
 
     def __init__(self, alpha, beta, *args, **kwargs):
         torch_dist = torch.distributions.Beta(alpha, beta)
-        super(Beta, self).__init__(torch_dist, *args, **kwargs)
-        self._param_shape = broadcast_shape(alpha.size(), beta.size(), strict=True)
-
-    def batch_shape(self, x=None):
-        x_shape = [] if x is None else x.size()
-        shape = torch.Size(broadcast_shape(x_shape, self._param_shape, strict=True))
-        return shape[:-1]
-
-    def event_shape(self):
-        return self._param_shape[-1:]
+        x_shape = torch.Size(broadcast_shape(alpha.size(), beta.size(), strict=True))
+        event_dim = 1
+        super(Beta, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)

--- a/pyro/distributions/torch/categorical.py
+++ b/pyro/distributions/torch/categorical.py
@@ -4,32 +4,23 @@ import torch
 
 from pyro.distributions.categorical import Categorical as _Categorical
 from pyro.distributions.torch_wrapper import TorchDistribution
-from pyro.distributions.util import broadcast_shape, copy_docs_from
+from pyro.distributions.util import copy_docs_from
 
 
 @copy_docs_from(_Categorical)
 class Categorical(TorchDistribution):
-    """
-    Compatibility wrapper around
-    `torch.distributions.Categorical <http://pytorch.org/docs/master/_modules/torch/distributions.html#Categorical>`_
-    """
     enumerable = True
 
     def __init__(self, ps=None, vs=None, logits=None, *args, **kwargs):
+        if vs is not None:
+            raise NotImplementedError
         if logits is not None:
             ps = torch.exp(logits - torch.max(logits))
             ps /= ps.sum(-1, True)
-        self._param_shape = ps.size()
         torch_dist = torch.distributions.Categorical(ps)
-        super(Categorical, self).__init__(torch_dist, *args, **kwargs)
-
-    def batch_shape(self, x=None):
-        x_shape = [] if x is None else x.size()
-        shape = torch.Size(broadcast_shape(x_shape, self._param_shape, strict=True))
-        return shape[:-1]
-
-    def event_shape(self):
-        return self._param_shape[-1:]
+        x_shape = ps.size()[:-1]
+        event_dim = 0
+        super(Categorical, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)
 
     def batch_log_pdf(self, x):
         return self.torch_dist.log_prob(x.long())

--- a/pyro/distributions/torch/dirichlet.py
+++ b/pyro/distributions/torch/dirichlet.py
@@ -4,7 +4,7 @@ import torch
 
 from pyro.distributions.dirichlet import Dirichlet as _Dirichlet
 from pyro.distributions.torch_wrapper import TorchDistribution
-from pyro.distributions.util import broadcast_shape, copy_docs_from
+from pyro.distributions.util import copy_docs_from
 
 
 @copy_docs_from(_Dirichlet)
@@ -13,16 +13,9 @@ class Dirichlet(TorchDistribution):
 
     def __init__(self, alpha, *args, **kwargs):
         torch_dist = torch.distributions.Dirichlet(alpha)
-        super(Dirichlet, self).__init__(torch_dist, *args, **kwargs)
-        self._param_shape = alpha.size()
-
-    def batch_shape(self, x=None):
-        x_shape = [] if x is None else x.size()
-        shape = torch.Size(broadcast_shape(x_shape, self._param_shape, strict=True))
-        return shape[:-1]
-
-    def event_shape(self):
-        return self._param_shape[-1:]
+        x_shape = alpha.size()
+        event_dim = 1
+        super(Dirichlet, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)
 
     def batch_log_pdf(self, x):
         batch_log_pdf = self.torch_dist.log_prob(x).view(self.batch_shape(x) + (1,))

--- a/pyro/distributions/torch/exponential.py
+++ b/pyro/distributions/torch/exponential.py
@@ -4,7 +4,7 @@ import torch
 
 from pyro.distributions.exponential import Exponential as _Exponential
 from pyro.distributions.torch_wrapper import TorchDistribution
-from pyro.distributions.util import broadcast_shape, copy_docs_from
+from pyro.distributions.util import copy_docs_from
 
 
 @copy_docs_from(_Exponential)
@@ -13,13 +13,6 @@ class Exponential(TorchDistribution):
 
     def __init__(self, lam, *args, **kwargs):
         torch_dist = torch.distributions.Exponential(lam)
-        super(Exponential, self).__init__(torch_dist, *args, **kwargs)
-        self._param_shape = torch.Size(broadcast_shape(lam.size(), strict=True))
-
-    def batch_shape(self, x=None):
-        x_shape = [] if x is None else x.size()
-        shape = torch.Size(broadcast_shape(x_shape, self._param_shape, strict=True))
-        return shape[:-1]
-
-    def event_shape(self):
-        return self._param_shape[-1:]
+        x_shape = lam.size()
+        event_dim = 1
+        super(Exponential, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)

--- a/pyro/distributions/torch/gamma.py
+++ b/pyro/distributions/torch/gamma.py
@@ -13,13 +13,6 @@ class Gamma(TorchDistribution):
 
     def __init__(self, alpha, beta, *args, **kwargs):
         torch_dist = torch.distributions.Gamma(alpha, beta)
-        super(Gamma, self).__init__(torch_dist, *args, **kwargs)
-        self._param_shape = broadcast_shape(alpha.size(), beta.size(), strict=True)
-
-    def batch_shape(self, x=None):
-        x_shape = [] if x is None else x.size()
-        shape = torch.Size(broadcast_shape(x_shape, self._param_shape, strict=True))
-        return shape[:-1]
-
-    def event_shape(self):
-        return self._param_shape[-1:]
+        x_shape = torch.Size(broadcast_shape(alpha.size(), beta.size(), strict=True))
+        event_dim = 1
+        super(Gamma, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)

--- a/pyro/distributions/torch/normal.py
+++ b/pyro/distributions/torch/normal.py
@@ -13,13 +13,6 @@ class Normal(TorchDistribution):
 
     def __init__(self, mu, sigma, *args, **kwargs):
         torch_dist = torch.distributions.Normal(mu, sigma)
-        super(Normal, self).__init__(torch_dist, *args, **kwargs)
-        self._param_shape = torch.Size(broadcast_shape(mu.size(), sigma.size(), strict=True))
-
-    def batch_shape(self, x=None):
-        x_shape = [] if x is None else x.size()
-        shape = torch.Size(broadcast_shape(x_shape, self._param_shape, strict=True))
-        return shape[:-1]
-
-    def event_shape(self):
-        return self._param_shape[-1:]
+        x_shape = torch.Size(broadcast_shape(mu.size(), sigma.size(), strict=True))
+        event_dim = 1
+        super(Normal, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)

--- a/pyro/distributions/torch_wrapper.py
+++ b/pyro/distributions/torch_wrapper.py
@@ -3,25 +3,39 @@ from __future__ import absolute_import, division, print_function
 import torch
 
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import broadcast_shape, copy_docs_from
 
 
+@copy_docs_from(Distribution)
 class TorchDistribution(Distribution):
     """
     Compatibility wrapper around
     `torch.distributions.Distribution <http://pytorch.org/docs/master/_modules/torch/distributions.html#Distribution>`_
     """
 
-    def __init__(self, torch_dist, batch_size=None, log_pdf_mask=None, *args, **kwargs):
+    def __init__(self, torch_dist, x_shape, event_dim, batch_size=None, log_pdf_mask=None, *args, **kwargs):
         super(Distribution, self).__init__(*args, **kwargs)
         self.torch_dist = torch_dist
         self.log_pdf_mask = log_pdf_mask
-        self.sample_shape = torch.Size() if batch_size is None else torch.Size((batch_size,))
+        self._x_shape = x_shape
+        self._event_dim = event_dim
+        self._sample_shape = torch.Size() if batch_size is None else torch.Size((batch_size,))
+
+    def batch_shape(self, x=None):
+        x_shape = [] if x is None else x.size()
+        shape = torch.Size(broadcast_shape(x_shape, self._x_shape, strict=True))
+        event_start = len(shape) - self._event_dim
+        return shape[:event_start]
+
+    def event_shape(self):
+        event_start = len(self._x_shape) - self._event_dim
+        return self._x_shape[event_start:]
 
     def sample(self):
         if self.reparameterized:
-            return self.torch_dist.rsample(self.sample_shape)
+            return self.torch_dist.rsample(self._sample_shape)
         else:
-            return self.torch_dist.sample(self.sample_shape)
+            return self.torch_dist.sample(self._sample_shape)
 
     def batch_log_pdf(self, x):
         batch_log_pdf_shape = self.batch_shape(x) + (1,)

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -182,7 +182,7 @@ def softmax(x, dim=-1):
     return soft_max_nd.transpose(dim, len(input_size) - 1)
 
 
-def _get_clamping_buffer(tensor):
+def get_clamping_buffer(tensor):
     clamp_eps = 1e-6
     if isinstance(tensor, Variable):
         tensor = tensor.data
@@ -210,7 +210,7 @@ def get_probs_and_logits(ps=None, logits=None, is_multidimensional=True):
     """
     assert (ps is None) != (logits is None)
     if ps is not None:
-        eps = _get_clamping_buffer(ps)
+        eps = get_clamping_buffer(ps)
         ps_clamped = ps.clamp(min=eps, max=1 - eps)
     if is_multidimensional:
         if ps is None:

--- a/tests/common.py
+++ b/tests/common.py
@@ -197,6 +197,8 @@ def assert_equal(x, y, prec=1e-5, msg=''):
         else:
             assert_allclose(x, y, atol=prec, equal_nan=True)
     elif isinstance(x, numbers.Number) and isinstance(y, numbers.Number):
+        if not msg:
+            msg = '{} vs {}'.format(x, y)
         if prec == 0:
             assert x == y, msg
         else:


### PR DESCRIPTION
This adds a working implementation of `pyro.distributions.torch.Bernoulli`. It also simplifies individual torch wrappers by moving the `.batch_shape()` and `.event_shape()` methods up to the parent class `TorchDistribution`.

## Tested

- Ran `make test-torch-dist` against the `test-rsample` branch of PyTorch.