### PR TITLE
Adding docker support for pyro

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ git clone git@github.com:uber/pyro.git
 cd pyro
 pip install .
 ```
+
+## Running Pyro from a Docker Container
+
+Refer to the instructions [here](docker/README.md).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,53 @@
+ARG base_img=ubuntu:16.04
+FROM ${base_img}
+
+# Optional args
+ARG cuda=0
+ARG python_version=2.7
+ARG pyro_branch=release
+ARG pytorch_branch=release
+ARG uid=1000
+ARG gid=1000
+
+# Configurable settings
+ENV USER_NAME pyromancer
+ENV CONDA_DIR /opt/conda
+ENV WORK_DIR /workspace
+ENV PATH ${CONDA_DIR}/bin:${PATH}
+
+COPY install.sh /install.sh
+
+# Install linux utils
+RUN apt-get update && apt-get install -y --no-install-recommends \
+         build-essential \
+         cmake \
+         git \
+         curl \
+         ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install conda
+RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p ${CONDA_DIR} && \
+    rm ~/miniconda.sh
+ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
+
+# Change to default user
+RUN groupadd -r --gid ${gid} ${USER_NAME}
+RUN useradd -r --create-home --shell /bin/bash --uid ${uid} --gid ${gid} ${USER_NAME}
+WORKDIR ${WORK_DIR}
+RUN chown ${USER_NAME} ${WORK_DIR} ${CONDA_DIR} -R
+USER ${USER_NAME}
+
+# Install python 2/3; and other packages
+RUN conda install -y python=${python_version} && \
+    conda install -y jupyter matplotlib
+
+# Install PyTorch and Pyro
+RUN bash /install.sh
+
+# Run Jupyter notebook
+# (Ref: http://jupyter-notebook.readthedocs.io/en/latest/public_server.html#docker-cmd)
+EXPOSE 8888
+CMD ["jupyter", "notebook", "--port=8888", "--no-browser", "--ip=0.0.0.0"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,123 @@
+.PHONY: help create-host-workspace build build-gpu run run-gpu notebook notebook-gpu
+
+DOCKER_FILE=Dockerfile
+BASE_IMG=ubuntu:16.04
+BASE_CUDA_IMG=nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
+DOCKER_CMD=docker
+DOCKER_GPU_CMD=nvidia-docker
+DOCKER_WORK_DIR=/workspace/shared
+HOST_WORK_DIR=${HOME}/workspace/pyro_docker
+UID=$(shell id -u)
+GID=$(shell id -g)
+USER=pyromancer
+
+# Optional args
+python_version?=2.7
+pytorch_branch?=release
+pyro_branch?=release
+cmd?=bash
+
+# Determine name of docker image
+build run notebook: img_prefix=pyro-cpu
+build-gpu run-gpu notebook-gpu: img_prefix=pyro-gpu
+
+ifeq ($(img), )
+	IMG_NAME=${img_prefix}-${pyro_branch}-${python_version}
+else
+	IMG_NAME=${img}
+endif
+
+help:
+	@fgrep -h "##" ${MAKEFILE_LIST} | fgrep -v fgrep | sed -e 's/##//'
+
+##
+##Available targets:
+##
+
+build: ##
+	## Build a docker image for running Pyro on a CPU.
+	## Requires nvidia-docker (https://github.com/NVIDIA/nvidia-docker).
+	## Args:
+	##   python_version: version of python to use. default - python 2.7
+	##   pytorch_branch: whether to build PyTorch from conda or from source
+	##   (git branch specified by pytorch_branch)
+	##     default - latest pytorch version on conda
+	##   pyro_branch: whether to use the released Pyro wheel or a git branch.
+	##     default - latest pyro-ppl wheel on pypi
+	##
+	${DOCKER_CMD} build -t ${IMG_NAME} \
+	--build-arg base_img=${BASE_IMG} \
+	--build-arg uid=${UID} \
+	--build-arg gid=${GID} \
+	--build-arg python_version=${python_version} \
+	--build-arg pytorch_branch=${pytorch_branch} \
+	--build-arg pyro_branch=${pyro_branch} -f ${DOCKER_FILE} .
+
+build-gpu: ##
+	## Build a docker image for running Pyro on a GPU.
+	## Requires nvidia-docker (https://github.com/NVIDIA/nvidia-docker).
+	## Args:
+	##   python_version: version of python to use. default - python 2.7
+	##   pytorch_branch: whether to build PyTorch from conda or from source
+	##   (git branch specified by pytorch_branch)
+	##     default - latest pytorch version on conda
+	##   pyro_branch: whether to use the released Pyro wheel or a git branch.
+	##     default - latest pyro-ppl wheel on pypi
+	##
+	${DOCKER_GPU_CMD} build -t ${IMG_NAME} \
+	--build-arg base_img=${BASE_CUDA_IMG} \
+	--build-arg uid=${UID} \
+	--build-arg gid=${GID} \
+	--build-arg cuda=1 \
+	--build-arg python_version=${python_version} \
+	--build-arg pytorch_branch=${pytorch_branch} \
+	--build-arg pyro_branch=${pyro_branch} -f ${DOCKER_FILE} .
+
+create-host-workspace: ##
+	## Create shared volume on the host for sharing files with the container.
+	##
+	mkdir -p ${HOST_WORK_DIR}
+
+run: create-host-workspace
+run: ##
+	## Start a Pyro CPU docker instance, and run the command `cmd`.
+	## Args:
+	##   img: use image name given by `img`.
+	##   cmd: command invoked on running a docker instance.
+	##     default - bash
+	##
+	docker run --init -it --user ${USER} \
+	-v ${HOST_WORK_DIR}:${DOCKER_WORK_DIR} \
+	${IMG_NAME} ${cmd}
+
+run-gpu: create-host-workspace
+run-gpu: ##
+	## Start a Pyro GPU docker instance, and run the command `cmd`.
+	## Args:
+	##   img: use image name given by `img`.
+	##   cmd: command invoked on running a docker instance.
+	##     default - bash
+	##
+	docker run --init --runtime=nvidia -it --user ${USER} \
+	-v ${HOST_WORK_DIR}:${DOCKER_WORK_DIR} \
+	${IMG_NAME} ${cmd}
+
+notebook: create-host-workspace
+notebook: ##
+	## Start a jupyter notebook on the Pyro CPU docker container.
+	## Args:
+	##   img: use image name given by `img`.
+	##
+	docker run --init -it -p 8888:8888 --user ${USER} \
+	-v ${HOST_WORK_DIR}:${DOCKER_WORK_DIR} \
+	${IMG_NAME}
+
+notebook-gpu: create-host-workspace
+notebook-gpu: ##
+	## Start a juptyer notebook on the Pyro GPU docker container.
+	## Args:
+	##   img: use image name given by `img`.
+	##
+	docker run --runtime=nvidia --init -it -p 8888:8888 --user ${USER} \
+	-v ${HOST_WORK_DIR}:${DOCKER_WORK_DIR} \
+	${IMG_NAME}

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,56 @@
+## Using Pyro Docker
+
+Some utilities for building docker images and running Pyro inside a Docker container are
+included in the `docker` directory. This includes a Dockerfile to build Pytorch and Pyro,
+with some common recipes included in the Makefile.
+ 
+Dependencies for building the docker images:
+ - **docker** (>= version 17.05)
+ - **nvidia-docker** Refer to the [readme](https://github.com/NVIDIA/nvidia-docker) for
+   installation.
+ 
+ 
+### Building Images
+
+The Makefile can be used to build CPU and CUDA images for Pyro and PyTorch. Some common
+options are as follows:
+
+ 1. **Source:** Uses the latest released package (conda package for PyTorch and PyPi wheel 
+    for Pyro) by default. However, both Pyro and PyTorch can be built from source from the
+    master branch or any other arbitrary branch specified by `pytorch_branch` and 
+    `pyro_branch`.
+ 2. **CPU / CUDA:** `make build` or `make build-gpu` can be used to specify whether the CPU
+    or the CUDA image is to be built. For building the CUDA image, *nvida-docker* is 
+    required. 
+ 3. **Python Version:** Python version can be specified via the argument `python_version`. 
+ 
+For example, the `make` command to build an image that uses Pyro's `dev` branch over
+PyTorch's `master` branch, using python 3.6 to run on a GPU, is as follows:
+
+```sh
+make build-gpu pyro_branch=dev pytorch_branch=master python_version=3.6
+```  
+
+This will build an image named `pyro-gpu-dev-3.6`. To spin up a docker container from this
+image, and run jupyter notebook on this, use the following `make` command:
+
+```sh
+make notebook-gpu img=pyro-gpu-dev-3.6
+```
+
+For help on the `make` commands available, run `make help`.
+
+### Running the Docker container
+
+Once the image is built, the docker container can be started via `docker run`, or 
+`docker run-gpu`. By default this starts a *bash* shell. One could start an *ipython* 
+shell instead by running `docker run cmd=ipython`. The image to be used can be 
+specified via the argument `img`. 
+
+To run a *jupyter notebook* use `docker notebook`, or `docker notebook-gpu`. This will 
+start a jupyter notebook server which can be accessed from the browser using the link 
+mentioned in the terminal. 
+
+Note that there is a shared volume between the container and the host system, with the 
+location `$DOCKER_WORK_DIR` on the container, and `$HOST_WORK_DIR` on the local system.
+These variables can be configured in the `Makefile`.

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -xe
+
+# 1. Install PyTorch
+# Use conda package if pytorch_branch = 'release'.
+# Else, install from source, using git branch `pytorch_branch`
+if [ ${pytorch_branch} = "release" ]
+then
+    conda install -y pytorch torchvision -c pytorch
+    if [ ${cuda} ]; then conda install -y cuda90 -c pytorch; fi
+else
+    conda install -y numpy pyyaml mkl setuptools cmake cffi
+    if [ ${cuda} ]; then conda install -y cuda90 -c pytorch; fi
+    git clone --recursive https://github.com/pytorch/pytorch.git
+    cd pytorch && git checkout ${pytorch_branch}
+    python setup.py install
+    cd ..
+fi
+
+
+# 2. Install Pyro
+# Use pypi wheel if pyro_branch = 'release'.
+# Else, install from source, using git branch `pyro_branch`
+if [ ${pyro_branch} = "release" ]
+then
+    pip install pyro-ppl
+else
+    conda install -y numpy pyyaml mkl setuptools cmake cffi
+    conda install -y -c soumith magma-cuda90
+    git clone https://github.com/uber/pyro.git
+    (cd pyro && git checkout ${pyro_branch} && pip install -e .)
+fi


### PR DESCRIPTION
This adds docker support for Pyro. This makes it simple to build Pyro over PyTorch using different configurations:
 - released conda/PyPi packages vs. building both from source using any git branch.
 - using python 2/3
 - using CPU/CUDA.

The Makefile has some common recipes to specify how to build the image. The documentation on building docker images and running them is in the [readme](https://github.com/neerajprad/pyro/tree/dockerfile/docker/README.md). It also makes it easy to run notebook or ipython terminal using the built image. To handle data sharing between the container and the user's host system, we use the same uid/guid while building the image and have a shared workspace that can be configured from the Makefile. This is to make it easy to share data / view results, etc.

Tested locally using different configurations. Since I have refactored this quite a bit, I will continue to test that things are working before getting this merged. 

### TODO:
While building PyTorch from source using CUDA 9, we get a few intermediate errors even though the build is finally successful, and functional. This still needs a bit more investigation.

Fixes #195