### PR TITLE
add import division (py2 compatibility) in air example

### DIFF
--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -5,6 +5,7 @@ AIR applied to the multi-mnist data set [1].
 understanding with generative models." Advances in Neural Information
 Processing Systems. 2016.
 """
+from __future__ import division
 
 import math
 import os


### PR DESCRIPTION
i noticed the air example will report 0 accuracy on python 2.
```python
acc = counts.diag().sum() / X.size(0)  ## offending line
```
this fixes this