### PR TITLE
Update torch distribution wrappers for Bernoulli and Categorical

### DIFF
--- a/pyro/distributions/torch/bernoulli.py
+++ b/pyro/distributions/torch/bernoulli.py
@@ -17,11 +17,5 @@ class Bernoulli(TorchDistribution):
         event_dim = 1
         super(Bernoulli, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)
 
-    def sample(self):
-        return super(Bernoulli, self).sample().type_as(self.torch_dist.probs)
-
-    def batch_log_pdf(self, x):
-        return super(Bernoulli, self).batch_log_pdf(x)
-
     def enumerate_support(self):
         return super(Bernoulli, self).enumerate_support().type_as(self.torch_dist.probs)

--- a/pyro/distributions/torch/bernoulli.py
+++ b/pyro/distributions/torch/bernoulli.py
@@ -4,7 +4,7 @@ import torch
 
 from pyro.distributions.bernoulli import Bernoulli as _Bernoulli
 from pyro.distributions.torch_wrapper import TorchDistribution
-from pyro.distributions.util import copy_docs_from, get_clamped_probs
+from pyro.distributions.util import copy_docs_from
 
 
 @copy_docs_from(_Bernoulli)
@@ -12,9 +12,8 @@ class Bernoulli(TorchDistribution):
     enumerable = True
 
     def __init__(self, ps=None, logits=None, *args, **kwargs):
-        ps = get_clamped_probs(ps, logits, is_multidimensional=False)
-        torch_dist = torch.distributions.Bernoulli(ps)
-        x_shape = ps.size()
+        torch_dist = torch.distributions.Bernoulli(probs=ps, logits=logits)
+        x_shape = ps.size() if ps is not None else logits.size()
         event_dim = 1
         super(Bernoulli, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)
 
@@ -22,7 +21,7 @@ class Bernoulli(TorchDistribution):
         return super(Bernoulli, self).sample().type_as(self.torch_dist.probs)
 
     def batch_log_pdf(self, x):
-        return super(Bernoulli, self).batch_log_pdf(x.long())
+        return super(Bernoulli, self).batch_log_pdf(x)
 
     def enumerate_support(self):
         return super(Bernoulli, self).enumerate_support().type_as(self.torch_dist.probs)

--- a/pyro/distributions/torch/categorical.py
+++ b/pyro/distributions/torch/categorical.py
@@ -4,7 +4,7 @@ import torch
 
 from pyro.distributions.categorical import Categorical as _Categorical
 from pyro.distributions.torch_wrapper import TorchDistribution
-from pyro.distributions.util import copy_docs_from, get_clamped_probs
+from pyro.distributions.util import copy_docs_from
 
 
 @copy_docs_from(_Categorical)
@@ -12,9 +12,9 @@ class Categorical(TorchDistribution):
     enumerable = True
 
     def __init__(self, ps=None, logits=None, *args, **kwargs):
-        ps = get_clamped_probs(ps, logits, is_multidimensional=True)
-        torch_dist = torch.distributions.Categorical(ps)
-        x_shape = ps.shape[:-1] + (1,)
+        torch_dist = torch.distributions.Categorical(probs=ps, logits=logits)
+        x_shape = ps.shape[:-1] + (1,) if ps is not None \
+            else logits.shape[:-1] + (1,)
         event_dim = 1
         super(Categorical, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)
 

--- a/pyro/distributions/torch/one_hot_categorical.py
+++ b/pyro/distributions/torch/one_hot_categorical.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
 import torch
-from torch.autograd import Variable
 
 from pyro.distributions.one_hot_categorical import OneHotCategorical as _OneHotCategorical
 from pyro.distributions.torch_wrapper import TorchDistribution
-from pyro.distributions.util import copy_docs_from, get_clamped_probs
+from pyro.distributions.util import copy_docs_from
 
 
 @copy_docs_from(_OneHotCategorical)
@@ -13,32 +12,22 @@ class OneHotCategorical(TorchDistribution):
     enumerable = True
 
     def __init__(self, ps=None, logits=None, *args, **kwargs):
-        ps = get_clamped_probs(ps, logits, is_multidimensional=True)
-        torch_dist = torch.distributions.Categorical(ps)  # TODO switch to OneHotCategorical
-        x_shape = ps.shape
+        torch_dist = torch.distributions.OneHotCategorical(probs=ps, logits=logits)
+        x_shape = ps.shape if ps is not None else logits.shape
         event_dim = 1
         super(OneHotCategorical, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)
 
     def sample(self):
-        ps = self.torch_dist.probs.data
-        zero = ps.new(self._sample_shape + ps.shape).zero_()
-        indices = super(OneHotCategorical, self).sample().data
-        if indices.dim() < zero.dim():
-            indices = indices.unsqueeze(-1)
-        one_hot = zero.scatter_(-1, indices, 1)
-        return Variable(one_hot)
+        return self.torch_dist.sample(self._sample_shape)
 
     def batch_log_pdf(self, x):
         batch_log_pdf_shape = self.batch_shape(x) + (1,)
-        log_pxs = self.torch_dist.log_prob(x.max(-1)[1])
+        log_pxs = self.torch_dist.log_prob(x)
         batch_log_pdf = log_pxs.view(batch_log_pdf_shape)
         if self.log_pdf_mask is not None:
             batch_log_pdf = batch_log_pdf * self.log_pdf_mask
         return batch_log_pdf
 
     def enumerate_support(self):
-        ps = self.torch_dist.probs.data
-        n = ps.shape[-1]
-        values = torch.eye(n, out=ps.new(n, n))
-        values = values.view((n,) + (1,) * (ps.dim() - 1) + (n,))
-        return Variable(values.expand((n,) + ps.shape))
+        values = self.torch_dist.enumerate_support()
+        return values.view(self.event_shape() + self._x_shape)

--- a/pyro/distributions/torch/one_hot_categorical.py
+++ b/pyro/distributions/torch/one_hot_categorical.py
@@ -17,9 +17,6 @@ class OneHotCategorical(TorchDistribution):
         event_dim = 1
         super(OneHotCategorical, self).__init__(torch_dist, x_shape, event_dim, *args, **kwargs)
 
-    def sample(self):
-        return self.torch_dist.sample(self._sample_shape)
-
     def batch_log_pdf(self, x):
         batch_log_pdf_shape = self.batch_shape(x) + (1,)
         log_pxs = self.torch_dist.log_prob(x)


### PR DESCRIPTION
Updates the Bernoulli and Categorical wrappers after [pytorch/pytorch#4448](https://github.com/pytorch/pytorch/pull/4448).

 - Updates the wrappers for categorical and bernoulli to use logits directly.
 - Updates `one_hot_categorical` to directly use the corresponding torch distribution instead of wrapping over `categorical`.

Testing - ran unit tests with `make test-torch-dist` locally.
  