### PR TITLE
Use PyTorch master binaries from S3 for CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,16 @@ env:
         - PYTHONPATH=$PWD:$PYTHONPATH
 
 install:
-    # install pytorch and its dependencies
+    # download and install PyTorch wheel
+    - pip install --upgrade awscli
+    - mkdir -p tmp
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-          pip install http://download.pytorch.org/whl/cpu/torch-0.3.0.post4-cp27-cp27mu-linux_x86_64.whl;
+        aws s3 --no-sign-request sync s3://pyro-ppl/ci tmp --exclude "*" --include "*-cp27-*";
       else
-          pip install http://download.pytorch.org/whl/cpu/torch-0.3.0.post4-cp35-cp35m-linux_x86_64.whl;
+        aws s3 --no-sign-request sync s3://pyro-ppl/ci tmp --exclude "*" --include "*-cp36-*";
       fi
+    - pip install tmp/*
+    - rm -r tmp
     - pip install -e .[test]
     - pip freeze
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         aws s3 --no-sign-request sync s3://pyro-ppl/ci tmp --exclude "*" --include "*-cp27-*";
       else
-        aws s3 --no-sign-request sync s3://pyro-ppl/ci tmp --exclude "*" --include "*-cp36-*";
+        aws s3 --no-sign-request sync s3://pyro-ppl/ci tmp --exclude "*" --include "*-cp35-*";
       fi
     - pip install tmp/*
     - rm -r tmp

--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -222,8 +222,7 @@ class DMM(nn.Module):
 
         # if on gpu we need the fully broadcast view of the rnn initial state
         # to be in contiguous gpu memory
-        h_0_contig = self.h_0 if not self.use_cuda \
-            else self.h_0.expand(1, mini_batch.size(0), self.rnn.hidden_size).contiguous()
+        h_0_contig = self.h_0.expand(1, mini_batch.size(0), self.rnn.hidden_size).contiguous()
         # push the observed x's through the rnn;
         # rnn_output contains the hidden state at each time step
         rnn_output, _ = self.rnn(mini_batch_reversed, h_0_contig)

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,7 +20,8 @@ In particular, use the following instructions for building the binaries:
      docker run -it --ipc=host --rm -v $(pwd):/remote soumith/manylinux-cuda80:latest bash
      ```
  - Modify the `build_cpu.sh` script as follows:
-   - Remove all environment variables except for `NO_CUDA` and `CMAKE_LIBRARY_PATH`.
+   - Remove all environment variables declared in the beginning of the script, except for 
+     `NO_CUDA` and `CMAKE_LIBRARY_PATH`.
    - Instead of checking out the version tag through `git checkout tags/v${PYTORCH_BUILD_VERSION}`, 
      check out the commit/branch you would like to build.
  - We need to update `cmake` to version 3 to build PyTorch master:
@@ -30,7 +31,7 @@ In particular, use the following instructions for building the binaries:
      yum remove cmake 
      ln -s /usr/bin/cmake3 /usr/bin/cmake
      ```
- - Then run, `./build_cpu.sh` under the `directory`, which will create the required binaries 
+ - Then run, `./build_cpu.sh` under the `remote` folder, which will create the required binaries 
  in `/wheelhouse` directory.
  - Upload the binaries for python 2.7 (`torch*cp27mu*.whl`) and python 3.5 (`torch*cp35m*.whl`) 
    to the S3 bucket `s3://pyro-ppl/ci` with public read permissions.

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,28 +4,32 @@
 
 The Pyro development on `dev` branch may use the latest features that are not present in the 
 release version of PyTorch. As such, these features need to be tested against PyTorch's master 
-branch rather than the release which may be a few months older.
+branch rather than the release branch, which may be a few months older.
 
-For this, we need to build PyTorch binaries on a need-be basis, and upload them to the S3 bucket 
-`s3://pyro-ppl/ci`. We use the scripts in the [PyTorch builder](https://github.com/pytorch/builder) 
-repo for this. In particular, use the following instructions for building the binaries:
+For this, we need to build PyTorch binaries on a need-be basis, and upload them to an S3 bucket, 
+from which these binaries can be pulled in by CI machines to build Pyro's `dev` branch. Note that 
+to build small sized binaries, we remove all CUDA dependencies, but have statically linked MKL
+libraries which are not present on CI machines otherwise. 
+
+We use the scripts in the [PyTorch builder](https://github.com/pytorch/builder) repo for this. 
+In particular, use the following instructions for building the binaries:
  - Clone the [PyTorch builder](https://github.com/pytorch/builder) repo on your local system.
  - Under the `manywheel` directory, run a docker container:
-```sh
-cd manywheel
-docker run -it --ipc=host --rm -v $(pwd):/remote soumith/manylinux-cuda80:latest bash
-```
+       ```sh
+       cd manywheel
+       docker run -it --ipc=host --rm -v $(pwd):/remote soumith/manylinux-cuda80:latest bash
+       ```
  - Modify the `build_cpu.sh` script as follows:
    - Remove all environment variables except for `NO_CUDA` and `CMAKE_LIBRARY_PATH`.
    - Instead of checking out the version tag through `git checkout tags/v${PYTORCH_BUILD_VERSION}`, 
      check out the commit/branch you would like to build.
  - We need to update `cmake` to version 3 to build PyTorch master:
-```sh
-yum install epel-release
-yum install cmake3
-yum remove cmake 
-ln -s /usr/bin/cmake3 /usr/bin/cmake
-```
+       ```sh
+       yum install epel-release
+       yum install cmake3
+       yum remove cmake 
+       ln -s /usr/bin/cmake3 /usr/bin/cmake
+       ```
  - Then run, `./build_cpu.sh` under the `directory`, which will create the required binaries 
  in `/wheelhouse` directory.
  - Upload the binaries for python 2.7 (`torch*cp27mu*.whl`) and python 3.5 (`torch*cp35m*.whl`) 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,32 @@
+# Testing
+
+### Building PyTorch binaries for Travis CI
+
+The Pyro development on `dev` branch may use the latest features that are not present in the 
+release version of PyTorch. As such, these features need to be tested against PyTorch's master 
+branch rather than the release which may be a few months older.
+
+For this, we need to build PyTorch binaries on a need-be basis, and upload them to the S3 bucket 
+`s3://pyro-ppl/ci`. We use the scripts in the [PyTorch builder](https://github.com/pytorch/builder) 
+repo for this. In particular, use the following instructions for building the binaries:
+ - Clone the [PyTorch builder](https://github.com/pytorch/builder) repo on your local system.
+ - Under the `manywheel` directory, run a docker container:
+```sh
+cd manywheel
+docker run -it --ipc=host --rm -v $(pwd):/remote soumith/manylinux-cuda80:latest bash
+```
+ - Modify the `build_cpu.sh` script as follows:
+   - Remove all environment variables except for `NO_CUDA` and `CMAKE_LIBRARY_PATH`.
+   - Instead of checking out the version tag through `git checkout tags/v${PYTORCH_BUILD_VERSION}`, 
+     check out the commit/branch you would like to build.
+ - We need to update `cmake` to version 3 to build PyTorch master:
+```sh
+yum install epel-release
+yum install cmake3
+yum remove cmake 
+ln -s /usr/bin/cmake3 /usr/bin/cmake
+```
+ - Then run, `./build_cpu.sh` under the `directory`, which will create the required binaries 
+ in `/wheelhouse` directory.
+ - Upload the binaries to the S3 bucket `s3://pyro-ppl/ci` with public read permissions.
+ 

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,5 +28,6 @@ ln -s /usr/bin/cmake3 /usr/bin/cmake
 ```
  - Then run, `./build_cpu.sh` under the `directory`, which will create the required binaries 
  in `/wheelhouse` directory.
- - Upload the binaries to the S3 bucket `s3://pyro-ppl/ci` with public read permissions.
+ - Upload the binaries for python 2.7 (`torch*cp27mu*.whl`) and python 3.5 (`torch*cp35m*.whl`) 
+   to the S3 bucket `s3://pyro-ppl/ci` with public read permissions.
  

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,21 +15,21 @@ We use the scripts in the [PyTorch builder](https://github.com/pytorch/builder) 
 In particular, use the following instructions for building the binaries:
  - Clone the [PyTorch builder](https://github.com/pytorch/builder) repo on your local system.
  - Under the `manywheel` directory, run a docker container:
-       ```sh
-       cd manywheel
-       docker run -it --ipc=host --rm -v $(pwd):/remote soumith/manylinux-cuda80:latest bash
-       ```
+     ```sh
+     cd manywheel
+     docker run -it --ipc=host --rm -v $(pwd):/remote soumith/manylinux-cuda80:latest bash
+     ```
  - Modify the `build_cpu.sh` script as follows:
    - Remove all environment variables except for `NO_CUDA` and `CMAKE_LIBRARY_PATH`.
    - Instead of checking out the version tag through `git checkout tags/v${PYTORCH_BUILD_VERSION}`, 
      check out the commit/branch you would like to build.
  - We need to update `cmake` to version 3 to build PyTorch master:
-       ```sh
-       yum install epel-release
-       yum install cmake3
-       yum remove cmake 
-       ln -s /usr/bin/cmake3 /usr/bin/cmake
-       ```
+     ```sh
+     yum install epel-release
+     yum install cmake3
+     yum remove cmake 
+     ln -s /usr/bin/cmake3 /usr/bin/cmake
+     ```
  - Then run, `./build_cpu.sh` under the `directory`, which will create the required binaries 
  in `/wheelhouse` directory.
  - Upload the binaries for python 2.7 (`torch*cp27mu*.whl`) and python 3.5 (`torch*cp35m*.whl`) 


### PR DESCRIPTION
This allows us to run our CI tests against PyTorch's master branch. Thanks to https://github.com/pytorch/pytorch/issues/4178, I have removed the somewhat hacky docker code for building the binary. We can use the official script for generating these binaries, and the instructions for adapting the script are in the README. The binaries are uploaded to an S3 bucket (`pyro-ppl/ci`) and pulled in during the `install` step.

I needed to make a minor change to the dmm example as the rnn module now throws a runtime error instead of broadcasting the hidden units, as per my understanding. cc. @martinjankowiak 
<details>

```
Traceback (most recent call last):
  File "/home/travis/build/uber/pyro/examples/dmm/dmm.py", line 436, in <module>
    main(args)
  File "/home/travis/build/uber/pyro/examples/dmm/dmm.py", line 396, in main
    epoch_nll += process_minibatch(epoch, which_mini_batch, shuffled_indices)
  File "/home/travis/build/uber/pyro/examples/dmm/dmm.py", line 356, in process_minibatch
    mini_batch_seq_lengths, annealing_factor)
  File "/home/travis/build/uber/pyro/pyro/infer/svi.py", line 98, in step
    loss = self.loss_and_grads(self.model, self.guide, *args, **kwargs)
  File "/home/travis/build/uber/pyro/pyro/infer/elbo.py", line 65, in loss_and_grads
    return self.which_elbo.loss_and_grads(model, guide, *args, **kwargs)
  File "/home/travis/build/uber/pyro/pyro/infer/trace_elbo.py", line 136, in loss_and_grads
    for weight, model_trace, guide_trace, log_r in self._get_traces(model, guide, *args, **kwargs):
  File "/home/travis/build/uber/pyro/pyro/infer/trace_elbo.py", line 81, in _get_traces
    guide_trace = poutine.trace(guide).get_trace(*args, **kwargs)
  File "/home/travis/build/uber/pyro/pyro/poutine/trace_poutine.py", line 161, in get_trace
    self(*args, **kwargs)
  File "/home/travis/build/uber/pyro/pyro/poutine/trace_poutine.py", line 149, in __call__
    ret = super(TracePoutine, self).__call__(*args, **kwargs)
  File "/home/travis/build/uber/pyro/pyro/poutine/poutine.py", line 42, in __call__
    return self.fn(*args, **kwargs)
  File "/home/travis/build/uber/pyro/examples/dmm/dmm.py", line 229, in guide
    rnn_output, _ = self.rnn(mini_batch_reversed, h_0_contig)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/torch/nn/modules/module.py", line 357, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/torch/nn/modules/rnn.py", line 190, in forward
    self.check_forward_args(input, hx, batch_sizes)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/torch/nn/modules/rnn.py", line 162, in check_forward_args
    check_hidden_size(hidden, expected_hidden_size)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/torch/nn/modules/rnn.py", line 154, in check_hidden_size
    raise RuntimeError(msg.format(expected_hidden_size, tuple(hx.size())))
RuntimeError: Expected hidden size (1, 20, 600), got (1, 1, 600)
```

</details>

Fixes #670.