### PR TITLE
Fix gpu placement bug in enum_discrete

### DIFF
--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -151,7 +151,7 @@ def torch_multinomial(input, num_samples, replacement=False):
     Does not support keyword argument `out`.
     """
     if input.is_cuda:
-        return torch_multinomial(input.cpu(), num_samples, replacement).cuda()
+        return torch.multinomial(input.cpu(), num_samples, replacement).cuda(input.get_device())
     else:
         return torch.multinomial(input, num_samples, replacement)
 

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import functools
+import math
 
 import torch
 from torch.autograd import Variable
@@ -44,9 +45,8 @@ def iter_discrete_traces(graph_type, fn, *args, **kwargs):
 
         # Scale trace by probability of discrete choices.
         log_pdf = full_trace.batch_log_pdf(site_filter=site_is_discrete)
-        if isinstance(log_pdf, float):
-            log_pdf = torch.Tensor([log_pdf])
-        if isinstance(log_pdf, torch.Tensor):
-            log_pdf = Variable(log_pdf)
-        scale = torch.exp(log_pdf.detach())
+        if isinstance(log_pdf, Variable):
+            scale = torch.exp(log_pdf.detach())
+        else:
+            scale = math.exp(log_pdf)
         yield scale, full_trace

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -101,7 +101,10 @@ class Trace_ELBO(object):
         for weight, model_trace, guide_trace, log_r in self._get_traces(model, guide, *args, **kwargs):
             elbo_particle = weight * 0
 
-            log_pdf = "batch_log_pdf" if (self.enum_discrete and weight.size(0) > 1) else "log_pdf"
+            if (self.enum_discrete and isinstance(weight, Variable) and weight.size(0) > 1):
+                log_pdf = "batch_log_pdf"
+            else:
+                log_pdf = "log_pdf"
             for name in model_trace.nodes.keys():
                 if model_trace.nodes[name]["type"] == "sample":
                     if model_trace.nodes[name]["is_observed"]:

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -4,6 +4,7 @@ import numbers
 import warnings
 
 import numpy as np
+from torch.autograd import Variable
 
 import pyro
 import pyro.poutine as poutine
@@ -137,7 +138,10 @@ class Trace_ELBO(object):
             elbo_particle = weight * 0
             surrogate_elbo_particle = weight * 0
             # compute elbo and surrogate elbo
-            log_pdf = "batch_log_pdf" if (self.enum_discrete and weight.size(0) > 1) else "log_pdf"
+            if (self.enum_discrete and isinstance(weight, Variable) and weight.size(0) > 1):
+                log_pdf = "batch_log_pdf"
+            else:
+                log_pdf = "log_pdf"
             for name, model_site in model_trace.nodes.items():
                 if model_site["type"] == "sample":
                     if model_site["is_observed"]:


### PR DESCRIPTION
Fixes #668 

This allows `enum_discrete` to return numbers rather than `Variables`. It's difficult to convert numbers to `Variable`s because it is difficult to determine what device the `Variable` should live on. 