### PR TITLE
Default to n=1 in Multinomial distribution

### DIFF
--- a/pyro/distributions/torch/multinomial.py
+++ b/pyro/distributions/torch/multinomial.py
@@ -15,17 +15,19 @@ class Multinomial(TorchDistribution):
     Multinomial distribution.
 
     Distribution over counts for `n` independent `Categorical(ps)` trials.
+    Note that `n` need not be specified if only :meth:`log_pdf` is used, e.g.
+    if this distribution is used only in :meth:`pyro.observe` statements.
 
     This is often used in conjunction with `torch.nn.Softmax` to ensure
     probabilites `ps` are normalized.
 
     :param torch.autograd.Variable ps: Probabilities (real). Should be positive
         and should normalized over the rightmost axis.
-    :param int n: Number of trials. Should be positive.
+    :param int n: Optional number of trials. Should be positive.
     """
     enumerable = True
 
-    def __init__(self, ps, n, *args, **kwargs):
+    def __init__(self, ps, n=1, *args, **kwargs):
         if isinstance(n, Variable):
             n = n.data
         if not isinstance(n, numbers.Number):

--- a/pyro/distributions/torch/multinomial.py
+++ b/pyro/distributions/torch/multinomial.py
@@ -23,7 +23,9 @@ class Multinomial(TorchDistribution):
 
     :param torch.autograd.Variable ps: Probabilities (real). Should be positive
         and should normalized over the rightmost axis.
-    :param int n: Optional number of trials. Should be positive.
+    :param int n: Optional number of trials. Should be positive. Defaults to 1.
+        Note that this is ignored by `.log_pdf()` which infers a `n` from each
+        event.
     """
     enumerable = True
 

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -141,6 +141,8 @@ discrete_dists = [
     Fixture(pyro_dist=(dist.multinomial, Multinomial),
             scipy_dist=sp.multinomial,
             examples=[
+                {'ps': [0.1, 0.6, 0.3],
+                 'test_data': [0, 1, 0]},
                 {'ps': [0.1, 0.6, 0.3], 'n': [8],
                  'test_data': [2, 4, 2]},
                 {'ps': [0.1, 0.6, 0.3], 'n': [8],
@@ -148,7 +150,7 @@ discrete_dists = [
                 {'ps': [[0.1, 0.6, 0.3], [0.2, 0.4, 0.4]], 'n': [[8], [8]],
                  'test_data': [[2, 4, 2], [1, 4, 3]]}
             ],
-            scipy_arg_fn=lambda ps, n: ((n[0], np.array(ps)), {}),
+            scipy_arg_fn=lambda ps, n=[1]: ((n[0], np.array(ps)), {}),
             prec=0.05,
             min_samples=10000,
             is_discrete=True),


### PR DESCRIPTION
This sets a default value of 1 for the `n` argument of the Multinomial distribution. This is useful when the distribution appears in `pyro.observe` statements where `n` can be inferred from observations:
```py
pyro.sample("documents", dist.multinomial, probs, obs=word_counts)
```

This change makes it clearer that although `Multinomial.sample()` is only implemented for `n` an integer or constant `Tensor`, `Multinomial.log_pdf()` is implemented for heterogeneous `n` and is useful e.g. in observing word counts in documents of different length.