### PR TITLE
Clean up docs: @copy_docs_from, GP docs

### DIFF
--- a/docs/source/contrib.gp.rst
+++ b/docs/source/contrib.gp.rst
@@ -1,4 +1,33 @@
+Gaussian Processes
+==================
+
+See the `Gaussian Processes tutorial <http://pyro.ai/examples/gp.html>`_ for an introduction.
+
 .. automodule:: pyro.contrib.gp
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+Kernels
+-------
+
+.. automodule:: pyro.contrib.gp.kernels.kernel
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+.. automodule:: pyro.contrib.gp.kernels.rbf
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+Models
+------
+
+.. automodule:: pyro.contrib.gp.models.gpr
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/primitive_dist.rst
+++ b/docs/source/primitive_dist.rst
@@ -6,4 +6,14 @@ Primitive Distributions
     :undoc-members:
     :show-inheritance:
 
+.. automodule:: pyro.distributions.torch_wrapper
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: pyro.distributions.random_primitive
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. include:: pyro.distributions.txt

--- a/pyro/contrib/gp/kernels/rbf.py
+++ b/pyro/contrib/gp/kernels/rbf.py
@@ -11,9 +11,9 @@ class RBF(Kernel):
     Implementation of Radial Basis Function kernel.
 
     By default, parameters will be `torch.nn.Parameter`s containing `torch.FloatTensor`s.
-        To cast them to the correct data type or GPU device, we can call methods such as
-        `.double()`, `.cuda(device=None)`,... See
-        `torch.nn.Module <http://pytorch.org/docs/master/nn.html#torch.nn.Module>`_ for more information.
+    To cast them to the correct data type or GPU device, we can call methods such as
+    `.double()`, `.cuda(device=None)`,... See
+    `torch.nn.Module <http://pytorch.org/docs/master/nn.html#torch.nn.Module>`_ for more information.
 
     :param int input_dim: Dimension of inputs for this kernel.
     :param torch.Tensor variance: Variance parameter of this kernel.

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from torch.autograd import Variable
 
 
-def copy_docs_from(source_class):
+def copy_docs_from(source_class, full_text=False):
     """
     Decorator to copy class and method docs from source to destin class.
     """
@@ -21,7 +21,11 @@ def copy_docs_from(source_class):
             source_attr = getattr(source_class, name, None)
             source_doc = getattr(source_attr, '__doc__', None)
             if source_doc and not getattr(destin_attr, '__doc__', None):
-                destin_attr.__doc__ = source_doc
+                if full_text or source_doc.startswith('See '):
+                    destin_attr.__doc__ = source_doc
+                else:
+                    destin_attr.__doc__ = 'See :meth:`{}.{}.{}`'.format(
+                        source_class.__module__, source_class.__name__, source_attr.__name__)
         return destin_class
 
     return decorator


### PR DESCRIPTION
- Use links rather than full copied text when using the `@copy_docs_from` decorator. I've followed this pattern from PyTorch, since it nicely prevents duplication.
- Hook up @fehiepsi 's GP documentation with our Sphinx docs. It now appears after `make docs`.