### PR TITLE
Clean up test markings

### DIFF
--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -93,8 +93,9 @@ TEST_CASES = [
         expected_precs=[2.0, 10000],
         mean_tol=0.05,
         std_tol=0.05,
-    ), marks=pytest.mark.skipif('CI' in os.environ and os.environ['CI'] == 'true',
-                                reason='Slow test - skip on CI')),
+    ), marks=[pytest.mark.xfail(reason="flaky"),
+              pytest.mark.skipif('CI' in os.environ and os.environ['CI'] == 'true',
+                                 reason='Slow test - skip on CI')]),
     pytest.param(*T(
         GaussianChain(dim=5, chain_len=9, num_obs=1),
         num_samples=3000,

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -171,7 +171,6 @@ class PoissonGammaTests(TestCase):
         self.log_alpha_n = torch.log(self.alpha_n)
         self.log_beta_n = torch.log(self.beta_n)
 
-    @pytest.mark.skipif(not dist.gamma.reparameterized, reason='not implemented')
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, 10000)
 
@@ -230,7 +229,6 @@ class ExponentialGammaTests(TestCase):
         self.log_alpha_n = torch.log(self.alpha_n)
         self.log_beta_n = torch.log(self.beta_n)
 
-    @pytest.mark.skipif(not dist.gamma.reparameterized, reason='not implemented')
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, 5000)
 
@@ -286,8 +284,6 @@ class BernoulliBetaTests(TestCase):
         self.log_alpha_n = torch.log(self.alpha_n)
         self.log_beta_n = torch.log(self.beta_n)
 
-    @pytest.mark.xfail(reason='low precision gradient?')
-    @pytest.mark.skipif(not dist.beta.reparameterized, reason='not implemented')
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, 10000)
 

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -233,7 +233,6 @@ class BernoulliBetaTests(TestCase):
         self.log_beta_n = torch.log(self.beta_n)
 
     @pytest.mark.xfail(reason='poorly-tuned Adam params?')
-    @pytest.mark.skipif(not dist.beta.reparameterized, reason='not implemented')
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, 3000, 0.95, 0.0007)
 
@@ -289,7 +288,6 @@ class PoissonGammaTests(TestCase):
         self.log_alpha_n = torch.log(self.alpha_n)
         self.log_beta_n = torch.log(self.beta_n)
 
-    @pytest.mark.skipif(not dist.gamma.reparameterized, reason='not implemented')
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, 8000, 0.95, 0.0007)
 
@@ -352,7 +350,6 @@ class ExponentialGammaTests(TestCase):
         self.log_beta_n = torch.log(self.beta_n)
 
     @pytest.mark.xfail(reason='poorly-tuned Adam params?')
-    @pytest.mark.skipif(not dist.gamma.reparameterized, reason='not implemented')
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, 8000, 0.95, 0.0007)
 


### PR DESCRIPTION
- Add an xfail for one failing HMC test (this is needed for `make test` to pass locally)
- Remove one xfail that was passing
- Remove skipifs now that we've moved to PyTorch distributions