### PR TITLE
Prevent off by one bug while generating MCMC samples

### DIFF
--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -41,7 +41,7 @@ class MCMC(TracePosterior):
         trace = self.kernel.initial_trace()
         self.logger.info('Starting MCMC using kernel - {} ...'.format(self.kernel.__class__.__name__))
         logging_interval = int(math.ceil((self.warmup_steps + self.num_samples) / 20))
-        while self._t <= self.warmup_steps + self.num_samples:
+        while self._t < self.warmup_steps + self.num_samples:
             self._t += 1
             if self._t % logging_interval == 0:
                 self.logger.info('Iteration: {}.'.format(self._t))

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -48,11 +48,13 @@ def normal_normal_model(data):
 def test_mcmc_interface():
     data = Variable(torch.Tensor([1.0]))
     kernel = PriorKernel(normal_normal_model)
-    mcmc = MCMC(kernel=kernel, num_samples=800)
+    mcmc = MCMC(kernel=kernel, num_samples=800, warmup_steps=100)
     marginal = Marginal(mcmc)
+    dist, values = marginal._dist_and_values(data)
+    assert_equal(len(values), 800)
     samples = []
-    for _ in range(400):
-        samples.append(marginal.sample(data))
+    for _ in range(600):
+        samples.append(values[dist.sample().data[0]])
     sample_mean = torch.mean(torch.stack(samples), 0)
     sample_std = torch.std(torch.stack(samples), 0)
     assert_equal(sample_mean.data, torch.Tensor([0.0]), prec=0.08)


### PR DESCRIPTION
We are generating 1 more sample than `num_samples` in MCMC currently. This fixes the bug, and adds an assertion for this off-by-one bug.