### PR TITLE
Do not create gid for OSX in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG pyro_branch=release
 ARG pytorch_branch=release
 ARG uid=1000
 ARG gid=1000
-ARG ostype=linux
+ARG ostype=Linux
 
 # Configurable settings
 ENV USER_NAME pyromancer
@@ -35,7 +35,7 @@ RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-la
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
 # Change to default user
-RUN bash -c 'if [ ${ostype} == linux ]; then groupadd -r --gid ${gid} ${USER_NAME}; fi && \
+RUN bash -c 'if [ ${ostype} == Linux ]; then groupadd -r --gid ${gid} ${USER_NAME}; fi && \
     useradd -r --create-home --shell /bin/bash --uid ${uid} --gid ${gid} ${USER_NAME}'
 WORKDIR ${WORK_DIR}
 RUN chown ${USER_NAME} ${WORK_DIR} ${CONDA_DIR} -R

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ ARG pyro_branch=release
 ARG pytorch_branch=release
 ARG uid=1000
 ARG gid=1000
+ARG ostype=linux
 
 # Configurable settings
 ENV USER_NAME pyromancer
@@ -34,8 +35,8 @@ RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-la
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
 # Change to default user
-RUN groupadd -r --gid ${gid} ${USER_NAME}
-RUN useradd -r --create-home --shell /bin/bash --uid ${uid} --gid ${gid} ${USER_NAME}
+RUN bash -c 'if [ ${ostype} == linux ]; then groupadd -r --gid ${gid} ${USER_NAME}; fi && \
+    useradd -r --create-home --shell /bin/bash --uid ${uid} --gid ${gid} ${USER_NAME}'
 WORKDIR ${WORK_DIR}
 RUN chown ${USER_NAME} ${WORK_DIR} ${CONDA_DIR} -R
 USER ${USER_NAME}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -27,6 +27,13 @@ else
 	IMG_NAME=${img}
 endif
 
+# Determine OS type
+ifeq ($(findstring ${OSTYPE}, darwin),)
+	OS=osx
+else
+	OS=linux
+endif
+
 help:
 	@fgrep -h "##" ${MAKEFILE_LIST} | fgrep -v fgrep | sed -e 's/##//'
 
@@ -49,6 +56,7 @@ build: ##
 	--build-arg base_img=${BASE_IMG} \
 	--build-arg uid=${UID} \
 	--build-arg gid=${GID} \
+	--build-arg ostype=${OS} \
 	--build-arg python_version=${python_version} \
 	--build-arg pytorch_branch=${pytorch_branch} \
 	--build-arg pyro_branch=${pyro_branch} -f ${DOCKER_FILE} .
@@ -68,6 +76,7 @@ build-gpu: ##
 	--build-arg base_img=${BASE_CUDA_IMG} \
 	--build-arg uid=${UID} \
 	--build-arg gid=${GID} \
+	--build-arg ostype=${OS} \
 	--build-arg cuda=1 \
 	--build-arg python_version=${python_version} \
 	--build-arg pytorch_branch=${pytorch_branch} \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,6 +9,7 @@ DOCKER_WORK_DIR=/workspace/shared
 HOST_WORK_DIR=${HOME}/workspace/pyro_docker
 UID=$(shell id -u)
 GID=$(shell id -g)
+OSTYPE=$(shell uname)
 USER=pyromancer
 
 # Optional args
@@ -27,12 +28,6 @@ else
 	IMG_NAME=${img}
 endif
 
-# Determine OS type
-ifeq ($(findstring ${OSTYPE}, darwin),)
-	OS=osx
-else
-	OS=linux
-endif
 
 help:
 	@fgrep -h "##" ${MAKEFILE_LIST} | fgrep -v fgrep | sed -e 's/##//'
@@ -56,7 +51,7 @@ build: ##
 	--build-arg base_img=${BASE_IMG} \
 	--build-arg uid=${UID} \
 	--build-arg gid=${GID} \
-	--build-arg ostype=${OS} \
+	--build-arg ostype=${OSTYPE} \
 	--build-arg python_version=${python_version} \
 	--build-arg pytorch_branch=${pytorch_branch} \
 	--build-arg pyro_branch=${pyro_branch} -f ${DOCKER_FILE} .
@@ -76,7 +71,7 @@ build-gpu: ##
 	--build-arg base_img=${BASE_CUDA_IMG} \
 	--build-arg uid=${UID} \
 	--build-arg gid=${GID} \
-	--build-arg ostype=${OS} \
+	--build-arg ostype=${OSTYPE} \
 	--build-arg cuda=1 \
 	--build-arg python_version=${python_version} \
 	--build-arg pytorch_branch=${pytorch_branch} \

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,6 +40,10 @@ make notebook-gpu img=pyro-gpu-dev-3.6
 
 For help on the `make` commands available, run `make help`.
 
+**NOTE (Mac Users)**: Please increase the memory available to the Docker application
+via *Preferences --> Advanced* from 2GB (default) to at least 4GB prior to building the
+docker image (specially for building PyTorch from source).
+
 ### Running the Docker container
 
 Once the image is built, the docker container can be started via `docker run`, or 


### PR DESCRIPTION
The docker `build` command currently fails on OSX for the `groupadd` command, complaining that the `gid` already exists. This only runs this command for linux. Also added a note for OSX users to allocate more memory to Docker before trying to build PyTorch from source.

Fixes #700.