### PR TITLE
Add NaiveDirichlet and NaiveBeta distributions for testing

### DIFF
--- a/pyro/distributions/testing/naive_dirichlet.py
+++ b/pyro/distributions/testing/naive_dirichlet.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+
+from pyro.distributions.torch.beta import Beta
+from pyro.distributions.torch.dirichlet import Dirichlet
+from pyro.distributions.torch.gamma import Gamma
+from pyro.distributions.util import copy_docs_from
+
+
+@copy_docs_from(Dirichlet)
+class NaiveDirichlet(Dirichlet):
+    """
+    Implementation of ``Dirichlet`` via ``Gamma``.
+
+    This naive implementation has stochastic reparameterized gradients, which
+    have higher variance than PyTorch's ``Dirichlet`` implementation.
+    """
+    def __init__(self, alpha):
+        super(NaiveDirichlet, self).__init__(alpha)
+        self._gamma = Gamma(alpha, torch.ones_like(alpha))
+
+    def sample(self, sample_shape=torch.Size()):
+        gammas = self._gamma.sample(sample_shape)
+        return gammas / gammas.sum(-1, True)
+
+
+@copy_docs_from(Beta)
+class NaiveBeta(Beta):
+    """
+    Implementation of ``Beta`` via ``Gamma``.
+
+    This naive implementation has stochastic reparameterized gradients, which
+    have higher variance than PyTorch's ``Beta`` implementation.
+    """
+    def __init__(self, alpha, beta):
+        super(NaiveBeta, self).__init__(alpha, beta)
+        alpha_beta = torch.stack([alpha, beta], -1)
+        self._gamma = Gamma(alpha_beta, torch.ones_like(alpha_beta))
+
+    def sample(self, sample_shape=torch.Size()):
+        gammas = self._gamma.sample(sample_shape)
+        probs = gammas / gammas.sum(-1, True)
+        return probs[..., 0]

--- a/pyro/distributions/testing/rejection_exponential.py
+++ b/pyro/distributions/testing/rejection_exponential.py
@@ -1,16 +1,18 @@
 from __future__ import absolute_import, division, print_function
 
+import torch
+
 from pyro.distributions import Exponential
 from pyro.distributions.rejector import Rejector
 from pyro.distributions.util import copy_docs_from
+from torch.distributions.utils import broadcast_all
 
 
 @copy_docs_from(Exponential)
 class RejectionExponential(Rejector):
     def __init__(self, rate, factor):
         assert (factor <= 1).all()
-        self.rate = rate
-        self.factor = factor
+        self.rate, self.factor = broadcast_all(rate, factor)
         propose = Exponential(self.factor * self.rate)
         log_scale = self.factor.log()
         super(RejectionExponential, self).__init__(propose, self.log_prob_accept, log_scale)
@@ -19,3 +21,9 @@ class RejectionExponential(Rejector):
         result = (self.factor - 1) * self.rate * x
         assert result.max() <= 0, result.max()
         return result
+
+    def batch_shape(self):
+        return self.rate.shape
+
+    def event_shape(self):
+        return torch.Size()

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -10,6 +10,9 @@ import pyro.distributions as dist
 from pyro.distributions import (Bernoulli, Beta, Binomial, Categorical, Cauchy, Dirichlet, Exponential, Gamma,
                                 Multinomial, MultivariateNormal, LogNormal, Normal, OneHotCategorical, Poisson,
                                 Uniform)
+from pyro.distributions.testing.naive_dirichlet import NaiveBeta, NaiveDirichlet
+from pyro.distributions.testing.rejection_exponential import RejectionExponential
+from pyro.distributions.testing.rejection_gamma import ShapeAugmentedGamma
 from tests.distributions.dist_fixture import Fixture
 
 continuous_dists = [
@@ -39,6 +42,19 @@ continuous_dists = [
                  'test_data': [[5.5], [3.2]]},
             ],
             scipy_arg_fn=lambda lam: ((), {"scale": 1.0 / np.array(lam)})),
+    Fixture(pyro_dist=(None, RejectionExponential),
+            scipy_dist=sp.expon,
+            examples=[
+                {'rate': [2.4], 'factor': [0.5],
+                 'test_data': [5.5]},
+                {'rate': [2.4, 5.5], 'factor': [0.5],
+                 'test_data': [[[5.5, 3.2]], [[5.5, 3.2]], [[5.5, 3.2]]]},
+                {'rate': [[2.4, 5.5]], 'factor': [0.5],
+                 'test_data': [[[5.5, 3.2]], [[5.5, 3.2]], [[5.5, 3.2]]]},
+                {'rate': [[2.4], [5.5]], 'factor': [0.5],
+                 'test_data': [[5.5], [3.2]]},
+            ],
+            scipy_arg_fn=lambda rate, factor: ((), {"scale": 1.0 / np.array(rate)})),
     Fixture(pyro_dist=(dist.gamma, Gamma),
             scipy_dist=sp.gamma,
             examples=[
@@ -50,7 +66,29 @@ continuous_dists = [
             ],
             scipy_arg_fn=lambda alpha, beta: ((np.array(alpha),),
                                               {"scale": 1.0 / np.array(beta)})),
+    Fixture(pyro_dist=(dist.gamma, ShapeAugmentedGamma),
+            scipy_dist=sp.gamma,
+            examples=[
+                {'alpha': [2.4], 'beta': [3.2],
+                 'test_data': [5.5]},
+                {'alpha': [[2.4, 2.4], [3.2, 3.2]], 'beta': [[2.4, 2.4], [3.2, 3.2]],
+                 'test_data': [[[5.5, 4.4], [5.5, 4.4]]]},
+                {'alpha': [[2.4], [2.4]], 'beta': [[3.2], [3.2]], 'test_data': [[5.5], [4.4]]}
+            ],
+            scipy_arg_fn=lambda alpha, beta: ((np.array(alpha),),
+                                              {"scale": 1.0 / np.array(beta)})),
     Fixture(pyro_dist=(dist.beta, Beta),
+            scipy_dist=sp.beta,
+            examples=[
+                {'alpha': [2.4], 'beta': [3.6],
+                 'test_data': [0.4]},
+                {'alpha': [[2.4, 2.4], [3.6, 3.6]], 'beta': [[2.5, 2.5], [2.5, 2.5]],
+                 'test_data': [[[5.5, 4.4], [5.5, 4.4]]]},
+                {'alpha': [[2.4], [3.7]], 'beta': [[3.6], [2.5]],
+                 'test_data': [[0.4], [0.6]]}
+            ],
+            scipy_arg_fn=lambda alpha, beta: ((np.array(alpha), np.array(beta)), {})),
+    Fixture(pyro_dist=(dist.beta, NaiveBeta),
             scipy_dist=sp.beta,
             examples=[
                 {'alpha': [2.4], 'beta': [3.6],
@@ -101,6 +139,17 @@ continuous_dists = [
             prec=0.01,
             min_samples=500000),
     Fixture(pyro_dist=(dist.dirichlet, Dirichlet),
+            scipy_dist=sp.dirichlet,
+            examples=[
+                {'alpha': [2.4, 3, 6],
+                 'test_data': [0.2, 0.45, 0.35]},
+                {'alpha': [2.4, 3, 6],
+                 'test_data': [[0.2, 0.45, 0.35], [0.2, 0.45, 0.35]]},
+                {'alpha': [[2.4, 3, 6], [3.2, 1.2, 0.4]],
+                 'test_data': [[0.2, 0.45, 0.35], [0.3, 0.4, 0.3]]}
+            ],
+            scipy_arg_fn=lambda alpha: ((alpha,), {})),
+    Fixture(pyro_dist=(dist.dirichlet, NaiveDirichlet),
             scipy_dist=sp.dirichlet,
             examples=[
                 {'alpha': [2.4, 3, 6],

--- a/tests/distributions/dist_fixture.py
+++ b/tests/distributions/dist_fixture.py
@@ -25,7 +25,7 @@ class Fixture(object):
                  expected_support=None,
                  test_data_indices=None,
                  batch_data_indices=None):
-        self.pyro_dist, self.pyro_dist_obj = pyro_dist
+        self.pyro_dist, self.pyro_dist_class = pyro_dist
         self.scipy_dist = scipy_dist
         self.dist_params, self.test_data = self._extract_fixture_data(examples)
         self.scipy_arg_fn = scipy_arg_fn
@@ -58,7 +58,7 @@ class Fixture(object):
         return len(self.test_data)
 
     def get_samples(self, num_samples, **dist_params):
-        return self.pyro_dist(sample_shape=torch.Size((num_samples,)), **dist_params)
+        return self.pyro_dist_class(**dist_params).sample(sample_shape=torch.Size((num_samples,)))
 
     def get_test_data(self, idx, wrap_tensor=True):
         if not wrap_tensor:
@@ -98,7 +98,7 @@ class Fixture(object):
         dist_params = self._convert_logits_to_ps(dist_params)
         test_data = self.get_test_data(idx, wrap_tensor=False)
         test_data_wrapped = self.get_test_data(idx)
-        shape = broadcast_shape(self.pyro_dist.shape(**dist_params_wrapped), test_data_wrapped.size())
+        shape = broadcast_shape(self.pyro_dist_class(**dist_params_wrapped).shape(), test_data_wrapped.size())
         batch_log_pdf = []
         for i in range(len(test_data)):
             batch_params = {}
@@ -143,8 +143,7 @@ class Fixture(object):
         return max(min_samples, min_computed_samples)
 
     def get_test_distribution_name(self):
-        pyro_dist_class = getattr(self.pyro_dist, 'dist_class', self.pyro_dist.__class__)
-        return pyro_dist_class.__name__
+        return self.pyro_dist_class.__name__
 
 
 def tensor_wrap(*args, **kwargs):

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -27,34 +27,36 @@ def _log_prob_shape(dist, x_size=torch.Size(), **dist_params):
 
 def test_batch_log_prob(dist):
     if dist.scipy_arg_fn is None:
-        pytest.skip('{}.log_pdf has no scipy equivalent'.format(dist.pyro_dist_obj.__name__))
-    d = dist.pyro_dist
+        pytest.skip('{}.log_pdf has no scipy equivalent'.format(dist.pyro_dist_class.__name__))
     for idx in dist.get_batch_data_indices():
         dist_params = dist.get_dist_params(idx)
+        d = dist.pyro_dist_class(**dist_params)
         test_data = dist.get_test_data(idx)
-        log_prob_sum_pyro = _unwrap_variable(d.log_prob(test_data, **dist_params)).sum()
+        log_prob_sum_pyro = _unwrap_variable(d.log_prob(test_data)).sum()
         log_prob_sum_np = np.sum(dist.get_scipy_batch_logpdf(-1))
         assert_equal(log_prob_sum_pyro, log_prob_sum_np)
 
 
 def test_sample_shape(dist):
     for idx in range(dist.get_num_test_data()):
+        if dist.pyro_dist is None:
+            continue  # stateful distributions cannot implement a function interface
         dist_params = dist.get_dist_params(idx)
         x_func = dist.pyro_dist.sample(**dist_params)
-        x_obj = dist.pyro_dist_obj(**dist_params).sample()
+        x_obj = dist.pyro_dist_class(**dist_params).sample()
         assert_equal(x_obj.size(), x_func.size())
 
 
 def test_batch_log_prob_shape(dist):
-    d = dist.pyro_dist
     for idx in range(dist.get_num_test_data()):
         dist_params = dist.get_dist_params(idx)
+        d = dist.pyro_dist_class(**dist_params)
         x = dist.get_test_data(idx)
         with xfail_if_not_implemented():
             # Get log_prob shape after broadcasting.
-            expected_shape = _log_prob_shape(d, x.size(), **dist_params)
-            log_p_func = d.log_prob(x, **dist_params)
-            log_p_obj = dist.pyro_dist_obj(**dist_params).log_prob(x)
+            expected_shape = _log_prob_shape(d, x.size())
+            log_p_func = d.log_prob(x)
+            log_p_obj = dist.pyro_dist_class(**dist_params).log_prob(x)
             # assert that the functional and object forms return
             # the same log_prob values.
             assert_equal(log_p_func.size(), log_p_obj.size())
@@ -64,46 +66,46 @@ def test_batch_log_prob_shape(dist):
 def test_log_prob_mask(dist):
     if dist.get_test_distribution_name() not in ('Normal', 'Bernoulli', 'Categorical', 'OneHotCategorical', 'Normal'):
         pytest.skip('Batch pdf masking not supported for the distribution.')
-    d = dist.pyro_dist
     for idx in range(dist.get_num_test_data()):
         dist_params = dist.get_dist_params(idx)
+        d = dist.pyro_dist_class(**dist_params)
         x = dist.get_test_data(idx)
         with xfail_if_not_implemented():
-            log_prob_shape = _log_prob_shape(d, **dist_params)
-            log_prob_shape_broadcasted = _log_prob_shape(d, x.size(), **dist_params)
+            log_prob_shape = _log_prob_shape(d)
+            log_prob_shape_broadcasted = _log_prob_shape(d, x.size())
             zeros_mask = ng_zeros(1)  # should be broadcasted to data dims
             ones_mask = ng_ones(log_prob_shape)  # should be broadcasted to data dims
             half_mask = ng_ones(1) * 0.5
-            batch_log_pdf = d.log_prob(x, **dist_params)
-            log_prob_zeros_mask = d.log_prob(x, log_pdf_mask=zeros_mask, **dist_params)
-            log_prob_ones_mask = d.log_prob(x, log_pdf_mask=ones_mask, **dist_params)
-            log_prob_half_mask = d.log_prob(x, log_pdf_mask=half_mask, **dist_params)
+            batch_log_pdf = d.log_prob(x)
+            log_prob_zeros_mask = dist.pyro_dist_class(log_pdf_mask=zeros_mask, **dist_params).log_prob(x)
+            log_prob_ones_mask = dist.pyro_dist_class(log_pdf_mask=ones_mask, **dist_params).log_prob(x)
+            log_prob_half_mask = dist.pyro_dist_class(log_pdf_mask=half_mask, **dist_params).log_prob(x)
             assert_equal(log_prob_ones_mask, batch_log_pdf)
             assert_equal(log_prob_zeros_mask, ng_zeros(log_prob_shape_broadcasted))
             assert_equal(log_prob_half_mask, 0.5 * batch_log_pdf)
 
 
 def test_score_errors_event_dim_mismatch(dist):
-    d = dist.pyro_dist
     for idx in dist.get_batch_data_indices():
         dist_params = dist.get_dist_params(idx)
-        test_data_wrong_dims = ng_ones(d.shape(**dist_params) + (1,))
-        if len(d.event_shape(**dist_params)) > 0:
+        d = dist.pyro_dist_class(**dist_params)
+        test_data_wrong_dims = ng_ones(d.shape() + (1,))
+        if len(d.event_shape()) > 0:
             if dist.get_test_distribution_name() == 'MultivariateNormal':
                 pytest.skip('MultivariateNormal does not do shape validation in log_prob.')
             with pytest.raises((ValueError, RuntimeError)):
-                d.log_prob(test_data_wrong_dims, **dist_params)
+                d.log_prob(test_data_wrong_dims)
 
 
 def test_score_errors_non_broadcastable_data_shape(dist):
-    d = dist.pyro_dist
     for idx in dist.get_batch_data_indices():
         dist_params = dist.get_dist_params(idx)
-        shape = d.shape(**dist_params)
+        d = dist.pyro_dist_class(**dist_params)
+        shape = d.shape()
         non_broadcastable_shape = (shape[0] + 1,) + shape[1:]
         test_data_non_broadcastable = ng_ones(non_broadcastable_shape)
         with pytest.raises((ValueError, RuntimeError)):
-            d.log_prob(test_data_non_broadcastable, **dist_params)
+            d.log_prob(test_data_non_broadcastable)
 
 
 # Distributions tests - discrete distributions
@@ -113,9 +115,8 @@ def test_enumerate_support(discrete_dist):
     expected_support_non_vec = discrete_dist.expected_support_non_vec
     if not expected_support:
         pytest.skip("enumerate_support not tested for distribution")
-    actual_support_non_vec = discrete_dist.pyro_dist.enumerate_support(
-        **discrete_dist.get_dist_params(0))
-    actual_support = discrete_dist.pyro_dist.enumerate_support(
-        **discrete_dist.get_dist_params(-1))
+    Dist = discrete_dist.pyro_dist_class
+    actual_support_non_vec = Dist(**discrete_dist.get_dist_params(0)).enumerate_support()
+    actual_support = Dist(**discrete_dist.get_dist_params(-1)).enumerate_support()
     assert_equal(actual_support.data, torch.Tensor(expected_support))
     assert_equal(actual_support_non_vec.data, torch.Tensor(expected_support_non_vec))

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -55,12 +55,13 @@ def test_batch_log_prob_shape(dist):
         with xfail_if_not_implemented():
             # Get log_prob shape after broadcasting.
             expected_shape = _log_prob_shape(d, x.size())
-            log_p_func = d.log_prob(x)
-            log_p_obj = dist.pyro_dist_class(**dist_params).log_prob(x)
+            log_p_obj = d.log_prob(x)
+            assert log_p_obj.size() == expected_shape
             # assert that the functional and object forms return
             # the same log_prob values.
-            assert_equal(log_p_func.size(), log_p_obj.size())
-            assert log_p_func.size() == expected_shape
+            if dist.pyro_dist is not None:
+                log_p_func = dist.pyro_dist.log_prob(x, **dist_params)
+                assert_equal(log_p_func, log_p_obj)
 
 
 def test_log_prob_mask(dist):


### PR DESCRIPTION
This adds two new distributions with noisy reparameterized gradients for testing. This also refactors our distribution tests a bit to allow testing of stateful distributions which cannot implement a functional form via `RandomPrimitive`. Distribution tests now include:
- `NaiveDirichlet`
- `NaiveBeta`
- `ShapeAugmentedGamma` which tests `Rejector`
- `RejectionExponential` which tests `Rejector`

This figure shows the difference between `Beta` "canonical" and `NaiveBeta` "reptrick":
![beta-motivation](https://user-images.githubusercontent.com/648532/35586968-2d3d90fa-05b1-11e8-8822-461cfa186b2d.png)