### PR TITLE
Deprecate dependency on scipy for main pyro-ppl package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     author_email='pyro@uber.com',
     install_requires=[
         'numpy>=1.7',
-        'scipy>=0.19.0',
         'cloudpickle>=0.3.1',
         'graphviz>=0.8',
         'networkx>=2.0.0',
@@ -56,6 +55,7 @@ setup(
             'pytest',
             'pytest-cov',
             'nbval',
+            'scipy>=0.19.0',
             # examples/tutorials
             'matplotlib',
             'visdom',


### PR DESCRIPTION
Since we are not using scipy in our distributions package anymore, this removes the dependency from core to test (tests and the gmm example still uses scipy).

Fixes #633.