### PR TITLE
Fix profiling scripts after distributions refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,18 @@ jobs:
               - make lint
               #- make scrub;
               #  git diff-index --quiet HEAD
-        - stage: unit test
+        - stage: auxiliary modules
           python: 2.7
           env: STAGE=docs
-          script: 
+          script:
               - pip install -r docs/requirements.txt
               - make docs
         - python: 2.7
+          env: STAGE=profiler
+          script:
+              - python -m profiler.distributions
+        - stage: unit test
+          python: 2.7
           env: STAGE=unit
           script: pytest -vs --cov=pyro --stage unit --durations 20
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
         - python: 2.7
           env: STAGE=profiler
           script:
+              - pip install -e .[profile]
               - python -m profiler.distributions
         - stage: unit test
           python: 2.7


### PR DESCRIPTION
Due to distribution API changes, the profiling script was broken. This fixes the script to work with the changed API.