### PR TITLE
Fix event shape bug in ss_vae_M2.py

### DIFF
--- a/examples/ss_vae_M2.py
+++ b/examples/ss_vae_M2.py
@@ -1,26 +1,16 @@
 
 import torch
 import pyro
-import sys
 from torch.autograd import Variable
 import pyro.distributions as dist
 from utils.mnist_cached import MNISTCached, setup_data_loaders
 from pyro.infer import SVI
 from pyro.optim import Adam
 from pyro.nn import ClippedSoftmax, ClippedSigmoid
-from pyro.shim import parse_torch_version
 from utils.custom_mlp import MLP, Exp
 from utils.vae_plots import plot_conditional_samples_ssvae, mnist_test_tsne_ssvae
 from util import set_seed, print_and_log, mkdir_p
 import torch.nn as nn
-
-version_warning = '''
-11/02/2017: This example does not work with PyTorch 0.2, please install PyTorch 0.3.
-'''
-torch_version = parse_torch_version()
-if (torch_version < (0, 2, 1) and not torch_version[-1].startswith("+")):
-    print(version_warning)
-    sys.exit(0)
 
 
 class SSVAE(nn.Module):

--- a/examples/ss_vae_M2.py
+++ b/examples/ss_vae_M2.py
@@ -204,11 +204,11 @@ class SSVAE(nn.Module):
         # sample the handwriting style from the constant prior distribution
         prior_mu = Variable(torch.zeros([batch_size, self.z_dim]))
         prior_sigma = Variable(torch.ones([batch_size, self.z_dim]))
-        zs = pyro.sample("z", dist.normal, prior_mu, prior_sigma)
+        zs = pyro.sample("z", dist.normal, prior_mu, prior_sigma, extra_event_dims=1)
 
         # sample an image using the decoder
         mu = self.decoder.forward([zs, ys])
-        xs = pyro.sample("sample", dist.bernoulli, mu)
+        xs = pyro.sample("sample", dist.bernoulli, mu, extra_event_dims=1)
         return xs, mu
 
 

--- a/examples/ss_vae_M2.py
+++ b/examples/ss_vae_M2.py
@@ -119,7 +119,7 @@ class SSVAE(nn.Module):
             # sample the handwriting style from the constant prior distribution
             prior_mu = Variable(torch.zeros([batch_size, self.z_dim]))
             prior_sigma = Variable(torch.ones([batch_size, self.z_dim]))
-            zs = pyro.sample("z", dist.normal, prior_mu, prior_sigma)
+            zs = pyro.sample("z", dist.normal, prior_mu, prior_sigma, extra_event_dims=1)
 
             # if the label y (which digit to write) is supervised, sample from the
             # constant prior, otherwise, observe the value (i.e. score it against the constant prior)
@@ -134,7 +134,7 @@ class SSVAE(nn.Module):
             # parametrized distribution p(x|y,z) = bernoulli(decoder(y,z))
             # where `decoder` is a neural network
             mu = self.decoder.forward([zs, ys])
-            pyro.sample("x", dist.bernoulli, mu, obs=xs)
+            pyro.sample("x", dist.bernoulli, mu, extra_event_dims=1, obs=xs)
 
     def guide(self, xs, ys=None):
         """
@@ -161,7 +161,7 @@ class SSVAE(nn.Module):
             # sample (and score) the latent handwriting-style with the variational
             # distribution q(z|x,y) = normal(mu(x,y),sigma(x,y))
             mu, sigma = self.encoder_z.forward([xs, ys])
-            zs = pyro.sample("z", dist.normal, mu, sigma)   # noqa: F841
+            pyro.sample("z", dist.normal, mu, sigma, extra_event_dims=1)
 
     def classifier(self, xs):
         """

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,15 +2,14 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import sys
-from collections import OrderedDict
 from subprocess import check_call
 
 import pytest
 
 from tests.common import EXAMPLES_DIR, requires_cuda
 
-CPU_EXAMPLES = OrderedDict()
-CUDA_EXAMPLES = OrderedDict()
+CPU_EXAMPLES = []
+CUDA_EXAMPLES = []
 
 
 def discover_examples():
@@ -31,16 +30,24 @@ def discover_examples():
                 # Either this is not a main file, or we don't know how to run it cheaply.
                 continue
             example = os.path.relpath(path, EXAMPLES_DIR)
-            CPU_EXAMPLES[example] = args
+            CPU_EXAMPLES.append((example, args))
+            if '--enum-discrete' in text:
+                CPU_EXAMPLES.append((example, args + ['--enum-discrete']))
             if '--cuda' in text:
-                CUDA_EXAMPLES[example] = args + ['--cuda']
+                CUDA_EXAMPLES.append((example, args + ['--cuda']))
+    CPU_EXAMPLES.sort()
+    CUDA_EXAMPLES.sort()
 
 
 discover_examples()
 
 
+def make_ids(examples):
+    return ['{} {}'.format(example, ' '.join(args)) for example, args in examples]
+
+
 @pytest.mark.stage("test_examples")
-@pytest.mark.parametrize('example,args', CPU_EXAMPLES.items(), ids=list(CPU_EXAMPLES))
+@pytest.mark.parametrize('example,args', CPU_EXAMPLES, ids=make_ids(CPU_EXAMPLES))
 def test_cpu(example, args):
     example = os.path.join(EXAMPLES_DIR, example)
     check_call([sys.executable, example] + args)
@@ -48,7 +55,7 @@ def test_cpu(example, args):
 
 @requires_cuda
 @pytest.mark.stage("test_examples")
-@pytest.mark.parametrize('example,args', CUDA_EXAMPLES.items(), ids=list(CUDA_EXAMPLES))
+@pytest.mark.parametrize('example,args', CUDA_EXAMPLES, ids=make_ids(CUDA_EXAMPLES))
 def test_cuda(example, args):
     example = os.path.join(EXAMPLES_DIR, example)
     check_call([sys.executable, example] + args)


### PR DESCRIPTION
Fixes #725 

This updates ss_vae_M2 to use Pyro's new batching semantics after #710 

This PR also removes the obsolete version warning, since Pyro now requires PyTorch 0.4 or later.