### PR TITLE
Use torch.distributions.kl_divergence() in Trace_ELBO

### DIFF
--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -18,6 +18,7 @@ from pyro.distributions.delta import Delta
 from pyro.distributions.distribution import Distribution  # noqa: F401
 from pyro.distributions.random_primitive import RandomPrimitive
 from pyro.distributions.rejector import Rejector  # noqa: F401
+from pyro.distributions.torch_wrapper import kl_divergence  # noqa: F401
 
 # distribution classes with working torch versions in torch.distributions
 from pyro.distributions.torch.bernoulli import Bernoulli

--- a/pyro/distributions/torch_wrapper.py
+++ b/pyro/distributions/torch_wrapper.py
@@ -51,3 +51,21 @@ class TorchDistribution(Distribution):
 
     def enumerate_support(self):
         return self.torch_dist.enumerate_support()
+
+
+def kl_divergence(p, q):
+    r"""
+    Compute Kullback-Leibler divergence :math:`KL(p \| q)` between two distributions.
+
+    :param Distribution p: a Pyro distribution.
+    :param Distribution q: a Pyro distribution.
+    :returns: a batch of KL divergences of shape ``batch_shape``
+    :rtype: torch.autograd.Variable:
+    :raises: NotImplementedError if the KL divergence has not been implemented.
+    """
+    if isinstance(p, TorchDistribution) and isinstance(q, TorchDistribution):
+        kl = torch.distributions.kl_divergence(p.torch_dist, q.torch_dist)
+        for _ in range(max(p.extra_event_dims, q.extra_event_dims)):
+            kl = kl.sum(-1)
+        return kl
+    raise NotImplementedError

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -52,7 +52,8 @@ class Trace_ELBO(object):
     """
     def __init__(self,
                  num_particles=1,
-                 enum_discrete=False):
+                 enum_discrete=False,
+                 use_analytic_kl=False):
         """
         :param num_particles: the number of particles/samples used to form the ELBO (gradient) estimators
         :param bool enum_discrete: whether to sum over discrete latent variables, rather than sample them
@@ -60,6 +61,7 @@ class Trace_ELBO(object):
         super(Trace_ELBO, self).__init__()
         self.num_particles = num_particles
         self.enum_discrete = enum_discrete
+        self.use_analytic_kl = use_analytic_kl
 
     def _get_traces(self, model, guide, *args, **kwargs):
         """
@@ -166,16 +168,17 @@ class Trace_ELBO(object):
                             guide_log_pdf = guide_log_pdf.sum()
 
                         # Try to use analytic computation.
-                        try:
-                            kl = kl_divergence(guide_site['fn'], model_site['fn'])
-                        except NotImplementedError:
-                            kl = None
-                        if kl is not None and (kl.data == kl.data).all():  # work around NAN bugs in PyTorch
-                            if not batched:
-                                kl = kl.sum()
-                            elbo_particle -= kl.data.sum()
-                            surrogate_elbo_particle -= kl
-                            continue
+                        if self.use_analytic_kl:
+                            try:
+                                kl = kl_divergence(guide_site['fn'], model_site['fn'])
+                            except NotImplementedError:
+                                kl = None
+                            if kl is not None and (kl.data == kl.data).all():  # work around NAN bugs in PyTorch
+                                if not batched:
+                                    kl = kl.sum()
+                                elbo_particle -= kl.data.sum()
+                                surrogate_elbo_particle -= kl
+                                continue
 
                         # Fall back to monte carlo estimate.
                         elbo_particle += model_log_pdf - guide_log_pdf

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -184,7 +184,7 @@ class TraceGraph_ELBO(object):
     [2] `Neural Variational Inference and Learning in Belief Networks`
         Andriy Mnih, Karol Gregor
     """
-    def __init__(self, num_particles=1, enum_discrete=False):
+    def __init__(self, num_particles=1, enum_discrete=False, use_analytic_kl=False):
         """
         :param num_particles: the number of particles (samples) used to form the estimator
         :param bool enum_discrete: whether to sum over discrete latent variables, rather than sample them
@@ -192,6 +192,8 @@ class TraceGraph_ELBO(object):
         super(TraceGraph_ELBO, self).__init__()
         self.num_particles = num_particles
         self.enum_discrete = enum_discrete
+        if use_analytic_kl:
+            raise NotImplementedError("https://github.com/uber/pyro/issues/688")
 
     def _get_traces(self, model, guide, *args, **kwargs):
         """


### PR DESCRIPTION
Closes #688 

This attempts to integrate @vishwakftw's `kl_divergence()` implementation into Pyro's `Trace_ELBO` inference algorithm.

`torch.distributions.kl_divergence()` currently has some numerical issues for extreme values of distributions; this is being addressed in https://github.com/probtorch/pytorch/issues/117