### PR TITLE
Add sparse multivariate normal distribution

### DIFF
--- a/docs/source/pyro.distributions.txt
+++ b/docs/source/pyro.distributions.txt
@@ -97,6 +97,13 @@ Poisson
     :undoc-members:
     :show-inheritance:
 
+SparseMultivariateNormal
+------------------------
+.. automodule:: pyro.distributions.sparse_multivariate_normal
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Uniform
 -------
 .. automodule:: pyro.distributions.torch.uniform

--- a/docs/source/pyro.distributions.txt
+++ b/docs/source/pyro.distributions.txt
@@ -15,7 +15,7 @@ Beta
 
 Binomial
 ---------
-.. automodule:: pyro.distributions.binomial
+.. automodule:: pyro.distributions.torch.binomial
     :members:
     :undoc-members:
     :show-inheritance:
@@ -92,14 +92,14 @@ OneHotCategorical
 
 Poisson
 --------
-.. automodule:: pyro.distributions.poisson
+.. automodule:: pyro.distributions.torch.poisson
     :members:
     :undoc-members:
     :show-inheritance:
 
 SparseMultivariateNormal
 ------------------------
-.. automodule:: pyro.distributions.sparse_multivariate_normal
+.. automodule:: pyro.distributions.torch.sparse_multivariate_normal
     :members:
     :undoc-members:
     :show-inheritance:

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -18,6 +18,7 @@ from pyro.distributions.delta import Delta
 from pyro.distributions.distribution import Distribution  # noqa: F401
 from pyro.distributions.random_primitive import RandomPrimitive
 from pyro.distributions.rejector import Rejector  # noqa: F401
+from pyro.distributions.sparse_multivariate_normal import SparseMultivariateNormal
 
 # distribution classes with working torch versions in torch.distributions
 from pyro.distributions.torch.bernoulli import Bernoulli
@@ -53,3 +54,4 @@ one_hot_categorical = RandomPrimitive(OneHotCategorical)
 poisson = RandomPrimitive(Poisson)
 uniform = RandomPrimitive(Uniform)
 multivariate_normal = RandomPrimitive(MultivariateNormal)
+sparse_multivariate_normal = RandomPrimitive(SparseMultivariateNormal)

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -18,7 +18,6 @@ from pyro.distributions.delta import Delta
 from pyro.distributions.distribution import Distribution  # noqa: F401
 from pyro.distributions.random_primitive import RandomPrimitive
 from pyro.distributions.rejector import Rejector  # noqa: F401
-from pyro.distributions.sparse_multivariate_normal import SparseMultivariateNormal
 
 # distribution classes with working torch versions in torch.distributions
 from pyro.distributions.torch.bernoulli import Bernoulli
@@ -35,6 +34,7 @@ from pyro.distributions.torch.multivariate_normal import MultivariateNormal
 from pyro.distributions.torch.normal import Normal
 from pyro.distributions.torch.one_hot_categorical import OneHotCategorical
 from pyro.distributions.torch.poisson import Poisson
+from pyro.distributions.torch.sparse_multivariate_normal import SparseMultivariateNormal
 from pyro.distributions.torch.uniform import Uniform
 
 # function aliases

--- a/pyro/distributions/sparse_multivariate_normal.py
+++ b/pyro/distributions/sparse_multivariate_normal.py
@@ -47,7 +47,7 @@ class SparseMultivariateNormal(Distribution):
 
         self.trace_term = trace_term if trace_term is not None else 0
         super(SparseMultivariateNormal, self).__init__(*args, **kwargs)
-        
+
     @property
     def mean(self):
         return self.loc

--- a/pyro/distributions/sparse_multivariate_normal.py
+++ b/pyro/distributions/sparse_multivariate_normal.py
@@ -1,0 +1,125 @@
+from __future__ import absolute_import, division, print_function
+
+import math
+
+import torch
+from torch.autograd import Variable
+from torch.distributions.utils import lazy_property
+
+from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import copy_docs_from, matrix_triangular_solve_compat
+
+
+@copy_docs_from(Distribution)
+class SparseMultivariateNormal(Distribution):
+    """
+    Sparse Multivariate Normal distribution.
+
+    Implements fast computation for log probability of Multivariate Normal distribution
+    when the covariance matrix has the form:
+        covariance_matrix = D + W.T @ W.
+    Here D is a diagonal vector and W is a matrix of size M x N. The computation will be
+    beneficial when M << N.
+
+    :param torch.autograd.Variable loc: Mean.
+        Must be in 1 dimensional of size N.
+    :param torch.autograd.Variable D_term: D term of covariance matrix.
+        Must be in 1 dimensional of size N.
+    :param torch.autograd.Variable W_term: W term of covariance matrix.
+        Must be in 2 dimensional of size M x N.
+    :param float trace_term: A optional term to be added into Mahalabonis term
+        according to p(y) = N(y|loc, cov).exp(-1/2 * trace_term).
+    """
+    reparameterized = True
+
+    def __init__(self, loc, D_term, W_term, trace_term=None, *args, **kwargs):
+        if loc.size() != D_term.size():
+            raise ValueError("Expected loc.size() == D_term.size(), but got {} vs {}".format(
+                loc.size(), D_term.size()))
+        if D_term.size(0) != W_term.size(1):
+            raise ValueError("The dimension of D_term must match the second dimension of W_term.")
+        if loc.dim() != 1 or D_term.dim() != 1 or W_term.dim() != 2:
+            raise ValueError("Loc, D_term, W_term must be 1D, 1D, 2D tensors respectively.")
+
+        self.loc = loc
+        self.covariance_matrix_D_term = D_term
+        self.covariance_matrix_W_term = W_term
+
+        self.trace_term = trace_term if trace_term is not None else 0
+        super(SparseMultivariateNormal, self).__init__(*args, **kwargs)
+
+    @lazy_property
+    def scale_triu(self):
+        # We use the following formula to increase the numerically computation stability
+        # when using Cholesky decomposition (see GPML section 3.4.3):
+        #     D + W.T @ W = D1/2 @ (I + D-1/2 @ W.T @ W @ D-1/2) @ D1/2
+        Dsqrt = self.covariance_matrix_D_term.sqrt()
+        A = self.covariance_matrix_W_term / Dsqrt
+        At_A = A.t().matmul(A)
+        Id = Variable(A.data.new([1])).expand(A.size(1)).diag()
+        K = Id + At_A
+        U = K.potrf()
+        return U * Dsqrt
+
+    def batch_shape(self, x=None):
+        event_dim = 1
+        loc = self.loc
+        if x is not None:
+            if x.size()[-event_dim] != loc.size()[-event_dim]:
+                raise ValueError("The event size for the data and distribution parameters must match.\n"
+                                 "Expected x.size()[-1] == self.loc.size()[-1], but got {} vs {}".format(
+                                     x.size(-1), loc.size(-1)))
+            try:
+                loc = self.loc.expand_as(x)
+            except RuntimeError as e:
+                raise ValueError("Parameter `loc` with shape {} is not broadcastable to "
+                                 "the data shape {}. \nError: {}".format(loc.size(), x.size(), str(e)))
+        return loc.size()[:-event_dim]
+
+    def event_shape(self):
+        event_dim = 1
+        return self.loc.size()[-event_dim:]
+
+    def sample(self, sample_shape=torch.Size()):
+        white = self.loc.new(sample_shape + self.loc.shape).normal_()
+        return self.loc + torch.matmul(white, self.scale_triu)
+
+    def batch_log_pdf(self, x):
+        batch_shape = self.batch_shape(x)
+        if batch_shape != torch.Size([]):
+            raise ValueError("Batch calculation of log probability is not supported "
+                             "for this distribution.")
+        delta = x - self.loc
+        logdet, mahalanobis_squared = self._compute_logdet_and_mahalanobis(
+            self.covariance_matrix_D_term, self.covariance_matrix_W_term, delta, self.trace_term)
+        normalization_const = 0.5 * (self.event_shape()[-1] * math.log(2 * math.pi) + logdet)
+        return -(normalization_const + 0.5 * mahalanobis_squared)
+
+    def analytic_mean(self):
+        return self.loc
+
+    def analytic_var(self):
+        return self.covariance_matrix_D_term + (self.covariance_matrix_W_term ** 2).sum(0)
+
+    def _compute_logdet_and_mahalanobis(self, D, W, y, trace_term=0):
+        """
+        Calculates log determinant and (squared) Mahalanobis term of covariance
+        matrix (D + Wt.W), where D is a diagonal matrix, based on the
+        "Woodbury matrix identity" and "matrix determinant lemma":
+            inv(D + Wt.W) = inv(D) - inv(D).Wt.inv(I + W.inv(D).Wt).W.inv(D)
+            log|D + Wt.W| = log|Id + Wt.inv(D).W| + log|D|
+        """
+        W_Dinv = W / D
+        Id = Variable(W.data.new([1])).expand(W.size(0)).diag()
+        K = Id + W_Dinv.matmul(W.t())
+        L = K.potrf(upper=False)
+        W_Dinv_y = W_Dinv.matmul(y)
+        Linv_W_Dinv_y = matrix_triangular_solve_compat(W_Dinv_y, L, upper=False)
+
+        logdet = 2 * L.diag().log().sum() + D.log().sum()
+
+        mahalanobis1 = (y * y / D).sum(-1)
+        mahalanobis2 = (Linv_W_Dinv_y * Linv_W_Dinv_y).sum()
+        mahalanobis_squared = mahalanobis1 - mahalanobis2 + trace_term
+
+        return logdet, mahalanobis_squared

--- a/pyro/distributions/sparse_multivariate_normal.py
+++ b/pyro/distributions/sparse_multivariate_normal.py
@@ -47,6 +47,14 @@ class SparseMultivariateNormal(Distribution):
 
         self.trace_term = trace_term if trace_term is not None else 0
         super(SparseMultivariateNormal, self).__init__(*args, **kwargs)
+        
+    @property
+    def mean(self):
+        return self.loc
+
+    @property
+    def variance(self):
+        return self.covariance_matrix_D_term + (self.covariance_matrix_W_term ** 2).sum(0)
 
     @lazy_property
     def scale_triu(self):
@@ -84,7 +92,7 @@ class SparseMultivariateNormal(Distribution):
         white = self.loc.new(sample_shape + self.loc.shape).normal_()
         return self.loc + torch.matmul(white, self.scale_triu)
 
-    def batch_log_pdf(self, x):
+    def log_prob(self, x):
         batch_shape = self.batch_shape(x)
         if batch_shape != torch.Size([]):
             raise ValueError("Batch calculation of log probability is not supported "
@@ -94,12 +102,6 @@ class SparseMultivariateNormal(Distribution):
             self.covariance_matrix_D_term, self.covariance_matrix_W_term, delta, self.trace_term)
         normalization_const = 0.5 * (self.event_shape()[-1] * math.log(2 * math.pi) + logdet)
         return -(normalization_const + 0.5 * mahalanobis_squared)
-
-    def analytic_mean(self):
-        return self.loc
-
-    def analytic_var(self):
-        return self.covariance_matrix_D_term + (self.covariance_matrix_W_term ** 2).sum(0)
 
     def _compute_logdet_and_mahalanobis(self, D, W, y, trace_term=0):
         """

--- a/pyro/distributions/torch/multivariate_normal.py
+++ b/pyro/distributions/torch/multivariate_normal.py
@@ -17,7 +17,7 @@ def _matrix_inverse_compat(matrix, matrix_chol):
         return torch.inverse(matrix)
     else:
         # Use the cheaper Cholesky based potri.
-        return torch.potri(matrix_chol)
+        return torch.potri(matrix_chol, upper=False)
 
 
 # TODO Move this upstream to PyTorch.
@@ -32,19 +32,27 @@ class TorchMultivariateNormal(torch.distributions.Distribution):
         batch_shape, event_shape = loc.shape[:-1], loc.shape[-1:]
         super(TorchMultivariateNormal, self).__init__(batch_shape, event_shape)
 
+    @property
+    def mean(self):
+        return self.loc
+
+    @property
+    def variance(self):
+        return self.covariance_matrix.diag()
+
     @lazy_property
-    def scale_triu(self):
-        return torch.potrf(self.covariance_matrix)
+    def scale_tril(self):
+        return torch.potrf(self.covariance_matrix, upper=False)
 
     def rsample(self, sample_shape=torch.Size()):
         white = self.loc.new(sample_shape + self.loc.shape).normal_()
-        return self.loc + torch.matmul(white, self.scale_triu)
+        return self.loc + torch.matmul(white, self.scale_tril.t())
 
     def log_prob(self, value):
         delta = value - self.loc
-        sigma_inverse = _matrix_inverse_compat(self.covariance_matrix, self.scale_triu)
+        sigma_inverse = _matrix_inverse_compat(self.covariance_matrix, self.scale_tril)
         normalization_const = ((0.5 * self.event_shape[-1]) * math.log(2 * math.pi) +
-                               self.scale_triu.diag().log().sum(-1))
+                               self.scale_tril.diag().log().sum(-1))
         mahalanobis_squared = (delta * torch.matmul(delta, sigma_inverse)).sum(-1)
         return -(normalization_const + 0.5 * mahalanobis_squared)
 

--- a/pyro/distributions/torch/sparse_multivariate_normal.py
+++ b/pyro/distributions/torch/sparse_multivariate_normal.py
@@ -4,14 +4,99 @@ import math
 
 import torch
 from torch.autograd import Variable
+from torch.distributions import constraints
 from torch.distributions.utils import lazy_property
 
-from pyro.distributions.distribution import Distribution
+from pyro.distributions.torch_wrapper import TorchDistribution
 from pyro.distributions.util import copy_docs_from, matrix_triangular_solve_compat
 
 
-@copy_docs_from(Distribution)
-class SparseMultivariateNormal(Distribution):
+class TorchSparseMultivariateNormal(torch.distributions.Distribution):
+    params = {"loc": constraints.real, "covariance_matrix_D_term": constraints.positive,
+              "scale_tril": constraints.lower_triangular}
+    support = constraints.real
+    has_rsample = True
+
+    def __init__(self, loc, D_term, W_term, trace_term=None):
+        if loc.size() != D_term.size():
+            raise ValueError("Expected loc.size() == D_term.size(), but got {} vs {}".format(
+                loc.size(), D_term.size()))
+        if D_term.size(0) != W_term.size(1):
+            raise ValueError("The dimension of D_term must match the second dimension of W_term.")
+        if loc.dim() != 1 or D_term.dim() != 1 or W_term.dim() != 2:
+            raise ValueError("Loc, D_term, W_term must be 1D, 1D, 2D tensors respectively.")
+
+        self.loc = loc
+        self.covariance_matrix_D_term = D_term
+        self.covariance_matrix_W_term = W_term
+        self.trace_term = trace_term if trace_term is not None else 0
+
+        batch_shape, event_shape = loc.shape[:-1], loc.shape[-1:]
+        super(TorchSparseMultivariateNormal, self).__init__(batch_shape, event_shape)
+
+    @property
+    def mean(self):
+        return self.loc
+
+    @property
+    def variance(self):
+        return self.covariance_matrix_D_term + (self.covariance_matrix_W_term ** 2).sum(0)
+
+    @lazy_property
+    def scale_tril(self):
+        # We use the following formula to increase the numerically computation stability
+        # when using Cholesky decomposition (see GPML section 3.4.3):
+        #     D + W.T @ W = D1/2 @ (I + D-1/2 @ W.T @ W @ D-1/2) @ D1/2
+        Dsqrt = self.covariance_matrix_D_term.sqrt()
+        A = self.covariance_matrix_W_term / Dsqrt
+        At_A = A.t().matmul(A)
+        N = A.size(1)
+        Id = Variable(torch.eye(N, N, out=A.data.new(N, N)))
+        K = Id + At_A
+        L = K.potrf(upper=False)
+        return Dsqrt.unsqueeze(1) * L
+
+    def rsample(self, sample_shape=torch.Size()):
+        white = self.loc.new(sample_shape + self.loc.shape).normal_()
+        return self.loc + torch.matmul(white, self.scale_tril.t())
+
+    def log_prob(self, value):
+        delta = value - self.loc
+        logdet, mahalanobis_squared = self._compute_logdet_and_mahalanobis(
+            self.covariance_matrix_D_term, self.covariance_matrix_W_term, delta, self.trace_term)
+        normalization_const = 0.5 * (self.event_shape()[-1] * math.log(2 * math.pi) + logdet)
+        return -(normalization_const + 0.5 * mahalanobis_squared)
+
+    def _compute_logdet_and_mahalanobis(self, D, W, y, trace_term=0):
+        """
+        Calculates log determinant and (squared) Mahalanobis term of covariance
+        matrix (D + Wt.W), where D is a diagonal matrix, based on the
+        "Woodbury matrix identity" and "matrix determinant lemma":
+            inv(D + Wt.W) = inv(D) - inv(D).Wt.inv(I + W.inv(D).Wt).W.inv(D)
+            log|D + Wt.W| = log|Id + Wt.inv(D).W| + log|D|
+        """
+        if y.dim() > 1:
+            raise ValueError("Batch calculation of log probability is not supported "
+                             "for this distribution.")
+        W_Dinv = W / D
+        M = W.size(0)
+        Id = torch.eye(M, M, out=Variable(W.data.new(M, M)))
+        K = Id + W_Dinv.matmul(W.t())
+        L = K.potrf(upper=False)
+        W_Dinv_y = W_Dinv.matmul(y)
+        Linv_W_Dinv_y = matrix_triangular_solve_compat(W_Dinv_y, L, upper=False)
+
+        logdet = 2 * L.diag().log().sum() + D.log().sum()
+
+        mahalanobis1 = (y * y / D).sum(-1)
+        mahalanobis2 = (Linv_W_Dinv_y * Linv_W_Dinv_y).sum()
+        mahalanobis_squared = mahalanobis1 - mahalanobis2 + trace_term
+
+        return logdet, mahalanobis_squared
+
+
+@copy_docs_from(TorchDistribution)
+class SparseMultivariateNormal(TorchDistribution):
     """
     Sparse Multivariate Normal distribution.
 
@@ -33,95 +118,5 @@ class SparseMultivariateNormal(Distribution):
     reparameterized = True
 
     def __init__(self, loc, D_term, W_term, trace_term=None, *args, **kwargs):
-        if loc.size() != D_term.size():
-            raise ValueError("Expected loc.size() == D_term.size(), but got {} vs {}".format(
-                loc.size(), D_term.size()))
-        if D_term.size(0) != W_term.size(1):
-            raise ValueError("The dimension of D_term must match the second dimension of W_term.")
-        if loc.dim() != 1 or D_term.dim() != 1 or W_term.dim() != 2:
-            raise ValueError("Loc, D_term, W_term must be 1D, 1D, 2D tensors respectively.")
-
-        self.loc = loc
-        self.covariance_matrix_D_term = D_term
-        self.covariance_matrix_W_term = W_term
-
-        self.trace_term = trace_term if trace_term is not None else 0
-        super(SparseMultivariateNormal, self).__init__(*args, **kwargs)
-
-    @property
-    def mean(self):
-        return self.loc
-
-    @property
-    def variance(self):
-        return self.covariance_matrix_D_term + (self.covariance_matrix_W_term ** 2).sum(0)
-
-    @lazy_property
-    def scale_triu(self):
-        # We use the following formula to increase the numerically computation stability
-        # when using Cholesky decomposition (see GPML section 3.4.3):
-        #     D + W.T @ W = D1/2 @ (I + D-1/2 @ W.T @ W @ D-1/2) @ D1/2
-        Dsqrt = self.covariance_matrix_D_term.sqrt()
-        A = self.covariance_matrix_W_term / Dsqrt
-        At_A = A.t().matmul(A)
-        Id = Variable(A.data.new([1])).expand(A.size(1)).diag()
-        K = Id + At_A
-        U = K.potrf()
-        return U * Dsqrt
-
-    def batch_shape(self, x=None):
-        event_dim = 1
-        loc = self.loc
-        if x is not None:
-            if x.size()[-event_dim] != loc.size()[-event_dim]:
-                raise ValueError("The event size for the data and distribution parameters must match.\n"
-                                 "Expected x.size()[-1] == self.loc.size()[-1], but got {} vs {}".format(
-                                     x.size(-1), loc.size(-1)))
-            try:
-                loc = self.loc.expand_as(x)
-            except RuntimeError as e:
-                raise ValueError("Parameter `loc` with shape {} is not broadcastable to "
-                                 "the data shape {}. \nError: {}".format(loc.size(), x.size(), str(e)))
-        return loc.size()[:-event_dim]
-
-    def event_shape(self):
-        event_dim = 1
-        return self.loc.size()[-event_dim:]
-
-    def sample(self, sample_shape=torch.Size()):
-        white = self.loc.new(sample_shape + self.loc.shape).normal_()
-        return self.loc + torch.matmul(white, self.scale_triu)
-
-    def log_prob(self, x):
-        batch_shape = self.batch_shape(x)
-        if batch_shape != torch.Size([]):
-            raise ValueError("Batch calculation of log probability is not supported "
-                             "for this distribution.")
-        delta = x - self.loc
-        logdet, mahalanobis_squared = self._compute_logdet_and_mahalanobis(
-            self.covariance_matrix_D_term, self.covariance_matrix_W_term, delta, self.trace_term)
-        normalization_const = 0.5 * (self.event_shape()[-1] * math.log(2 * math.pi) + logdet)
-        return -(normalization_const + 0.5 * mahalanobis_squared)
-
-    def _compute_logdet_and_mahalanobis(self, D, W, y, trace_term=0):
-        """
-        Calculates log determinant and (squared) Mahalanobis term of covariance
-        matrix (D + Wt.W), where D is a diagonal matrix, based on the
-        "Woodbury matrix identity" and "matrix determinant lemma":
-            inv(D + Wt.W) = inv(D) - inv(D).Wt.inv(I + W.inv(D).Wt).W.inv(D)
-            log|D + Wt.W| = log|Id + Wt.inv(D).W| + log|D|
-        """
-        W_Dinv = W / D
-        Id = Variable(W.data.new([1])).expand(W.size(0)).diag()
-        K = Id + W_Dinv.matmul(W.t())
-        L = K.potrf(upper=False)
-        W_Dinv_y = W_Dinv.matmul(y)
-        Linv_W_Dinv_y = matrix_triangular_solve_compat(W_Dinv_y, L, upper=False)
-
-        logdet = 2 * L.diag().log().sum() + D.log().sum()
-
-        mahalanobis1 = (y * y / D).sum(-1)
-        mahalanobis2 = (Linv_W_Dinv_y * Linv_W_Dinv_y).sum()
-        mahalanobis_squared = mahalanobis1 - mahalanobis2 + trace_term
-
-        return logdet, mahalanobis_squared
+        torch_dist = TorchSparseMultivariateNormal(loc, D_term, W_term, trace_term)
+        super(SparseMultivariateNormal, self).__init__(torch_dist, *args, **kwargs)

--- a/pyro/distributions/torch/sparse_multivariate_normal.py
+++ b/pyro/distributions/torch/sparse_multivariate_normal.py
@@ -64,7 +64,7 @@ class TorchSparseMultivariateNormal(torch.distributions.Distribution):
         delta = value - self.loc
         logdet, mahalanobis_squared = self._compute_logdet_and_mahalanobis(
             self.covariance_matrix_D_term, self.covariance_matrix_W_term, delta, self.trace_term)
-        normalization_const = 0.5 * (self.event_shape()[-1] * math.log(2 * math.pi) + logdet)
+        normalization_const = 0.5 * (self.event_shape[-1] * math.log(2 * math.pi) + logdet)
         return -(normalization_const + 0.5 * mahalanobis_squared)
 
     def _compute_logdet_and_mahalanobis(self, D, W, y, trace_term=0):

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -256,3 +256,18 @@ def get_clamped_probs(ps=None, logits=None, is_multidimensional=True):
     if is_multidimensional:
         ps /= ps.sum(-1, True)
     return ps
+
+
+def matrix_triangular_solve_compat(b, A, upper=True):
+    """
+    Computes the solution to the linear equation AX = b,
+    where A is a triangular matrix.
+
+    :param b: A 1D or 2D tensor of size N or N x C.
+    :param A: A 2D tensor of size N X N.
+    :param upper: A flag if A is a upper triangular matrix or not.
+    """
+    if A.requires_grad or A.is_cuda:
+        return A.inverse().matmul(b)
+    else:
+        return b.trtrs(A, upper=upper)[0].view(b.size())

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -106,7 +106,7 @@ continuous_dists = [
                 {'loc': [2.0, 1.0], 'D_term': [0.5, 0.5], 'W_term': [[1.0, 0.5]],
                  'test_data': [[2.0, 1.0], [9.0, 3.4]]},
             ],
-            scipy_arg_fn=lambda loc, D_term, W_term:
+            scipy_arg_fn=lambda loc, D_term=None, W_term=None:
                 ((), {"mean": np.array(loc), "cov": np.array([[1.5, 0.5], [0.5, 0.75]])}),
             prec=0.01,
             min_samples=500000),

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -103,11 +103,10 @@ continuous_dists = [
     Fixture(pyro_dist=(dist.sparse_multivariate_normal, SparseMultivariateNormal),
             scipy_dist=sp.multivariate_normal,
             examples=[
-                {'loc': [2.0, 1.0], 'covariance_matrix_D_term': [0.5, 0.5],
-                 'covariance_matrix_W_term': [[1.0, 0.5]],
+                {'loc': [2.0, 1.0], 'D_term': [0.5, 0.5], 'W_term': [[1.0, 0.5]],
                  'test_data': [[2.0, 1.0], [9.0, 3.4]]},
             ],
-            scipy_arg_fn=lambda loc, covariance_matrix_D_term=None, covariance_matrix_W_term=None:
+            scipy_arg_fn=lambda loc, D_term, W_term:
                 ((), {"mean": np.array(loc), "cov": np.array([[1.5, 0.5], [0.5, 0.75]])}),
             prec=0.01,
             min_samples=500000),

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -9,7 +9,7 @@ import scipy.stats as sp
 import pyro.distributions as dist
 from pyro.distributions import (Bernoulli, Beta, Binomial, Categorical, Cauchy, Dirichlet, Exponential, Gamma,
                                 Multinomial, MultivariateNormal, LogNormal, Normal, OneHotCategorical, Poisson,
-                                Uniform)
+                                SparseMultivariateNormal, Uniform)
 from tests.distributions.dist_fixture import Fixture
 
 continuous_dists = [
@@ -96,8 +96,19 @@ continuous_dists = [
                  'test_data': [[2.0, 1.0], [9.0, 3.4]]},
             ],
             # This hack seems to be the best option right now, as 'sigma' is not handled well by get_scipy_batch_logpdf
-            scipy_arg_fn=lambda loc, covariance_matrix=None, scale_triu=None:
+            scipy_arg_fn=lambda loc, covariance_matrix=None:
                 ((), {"mean": np.array(loc), "cov": np.array([[1.0, 0.5], [0.5, 1.0]])}),
+            prec=0.01,
+            min_samples=500000),
+    Fixture(pyro_dist=(dist.sparse_multivariate_normal, SparseMultivariateNormal),
+            scipy_dist=sp.multivariate_normal,
+            examples=[
+                {'loc': [2.0, 1.0], 'covariance_matrix_D_term': [0.5, 0.5],
+                 'covariance_matrix_W_term': [[1.0, 0.5]],
+                 'test_data': [[2.0, 1.0], [9.0, 3.4]]},
+            ],
+            scipy_arg_fn=lambda loc, covariance_matrix_D_term=None, covariance_matrix_W_term=None:
+                ((), {"mean": np.array(loc), "cov": np.array([[1.5, 0.5], [0.5, 0.75]])}),
             prec=0.01,
             min_samples=500000),
     Fixture(pyro_dist=(dist.dirichlet, Dirichlet),

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -91,6 +91,8 @@ def test_score_errors_event_dim_mismatch(dist):
         if len(d.event_shape(**dist_params)) > 0:
             if dist.get_test_distribution_name() == 'MultivariateNormal':
                 pytest.skip('MultivariateNormal does not do shape validation in log_prob.')
+            if dist.get_test_distribution_name() == 'SparseMultivariateNormal':
+                pytest.skip('SparseMultivariateNormal does not do shape validation in log_prob.')
             with pytest.raises((ValueError, RuntimeError)):
                 d.log_prob(test_data_wrong_dims, **dist_params)
 

--- a/tests/distributions/test_sparse_multivariate_normal.py
+++ b/tests/distributions/test_sparse_multivariate_normal.py
@@ -8,7 +8,7 @@ from pyro.distributions import MultivariateNormal, SparseMultivariateNormal
 from tests.common import assert_equal
 
 
-def test_scale_triu():
+def test_scale_tril():
     loc = Variable(torch.Tensor([1, 2, 1, 2, 0]))
     D = Variable(torch.Tensor([1, 2, 3, 4, 5]))
     W = Variable(torch.Tensor([[1, -1, 2, 3, 4], [2, 3, 1, 2, 4]]))
@@ -17,7 +17,7 @@ def test_scale_triu():
     mvn = MultivariateNormal(loc, cov)
     sparse_mvn = SparseMultivariateNormal(loc, D, W)
 
-    assert_equal(mvn.torch_dist.scale_triu, sparse_mvn.scale_triu)
+    assert_equal(mvn.torch_dist.scale_tril, sparse_mvn.scale_tril)
 
 
 def test_log_prob():
@@ -39,6 +39,7 @@ def test_variance():
     W = Variable(torch.Tensor([[3, -1, 3, 3, 4], [2, 3, 1, 3, 4]]))
     cov = D.diag() + W.t().matmul(W)
 
+    mvn = MultivariateNormal(loc, cov)
     sparse_mvn = SparseMultivariateNormal(loc, D, W)
 
-    assert_equal(sparse_mvn.variance, cov.diag())
+    assert_equal(mvn.variance, sparse_mvn.variance)

--- a/tests/distributions/test_sparse_multivariate_normal.py
+++ b/tests/distributions/test_sparse_multivariate_normal.py
@@ -8,7 +8,7 @@ from pyro.distributions import MultivariateNormal, SparseMultivariateNormal
 from tests.common import assert_equal
 
 
-def test_scaleu():
+def test_scale_triu():
     loc = Variable(torch.Tensor([1, 2, 1, 2, 0]))
     D = Variable(torch.Tensor([1, 2, 3, 4, 5]))
     W = Variable(torch.Tensor([[1, -1, 2, 3, 4], [2, 3, 1, 2, 4]]))
@@ -20,7 +20,7 @@ def test_scaleu():
     assert_equal(mvn.torch_dist.scale_triu, sparse_mvn.scale_triu)
 
 
-def test_batch_log_pdf():
+def test_log_prob():
     loc = Variable(torch.Tensor([2, 1, 1, 2, 2]))
     D = Variable(torch.Tensor([1, 2, 3, 1, 3]))
     W = Variable(torch.Tensor([[1, -1, 2, 2, 4], [2, 1, 1, 2, 6]]))
@@ -30,10 +30,10 @@ def test_batch_log_pdf():
     mvn = MultivariateNormal(loc, cov)
     sparse_mvn = SparseMultivariateNormal(loc, D, W)
 
-    assert_equal(mvn.batch_log_pdf(x), sparse_mvn.batch_log_pdf(x))
+    assert_equal(mvn.log_prob(x), sparse_mvn.log_prob(x))
 
 
-def test_analytic_var():
+def test_variance():
     loc = Variable(torch.Tensor([1, 1, 1, 2, 0]))
     D = Variable(torch.Tensor([1, 2, 2, 4, 5]))
     W = Variable(torch.Tensor([[3, -1, 3, 3, 4], [2, 3, 1, 3, 4]]))
@@ -42,4 +42,6 @@ def test_analytic_var():
     mvn = MultivariateNormal(loc, cov)
     sparse_mvn = SparseMultivariateNormal(loc, D, W)
 
-    assert_equal(mvn.analytic_var(), sparse_mvn.analytic_var())
+    # TODO: enable this test when MultivariateNormal distribution support
+    # variance method
+    # assert_equal(mvn.variance(), sparse_mvn.variance())

--- a/tests/distributions/test_sparse_multivariate_normal.py
+++ b/tests/distributions/test_sparse_multivariate_normal.py
@@ -17,7 +17,7 @@ def test_scale_tril():
     mvn = MultivariateNormal(loc, cov)
     sparse_mvn = SparseMultivariateNormal(loc, D, W)
 
-    assert_equal(mvn.torch_dist.scale_tril, sparse_mvn.scale_tril)
+    assert_equal(mvn.torch_dist.scale_tril, sparse_mvn.torch_dist.scale_tril)
 
 
 def test_log_prob():
@@ -42,4 +42,4 @@ def test_variance():
     mvn = MultivariateNormal(loc, cov)
     sparse_mvn = SparseMultivariateNormal(loc, D, W)
 
-    assert_equal(mvn.variance, sparse_mvn.variance)
+    assert_equal(mvn.torch_dist.variance, sparse_mvn.torch_dist.variance)

--- a/tests/distributions/test_sparse_multivariate_normal.py
+++ b/tests/distributions/test_sparse_multivariate_normal.py
@@ -39,9 +39,6 @@ def test_variance():
     W = Variable(torch.Tensor([[3, -1, 3, 3, 4], [2, 3, 1, 3, 4]]))
     cov = D.diag() + W.t().matmul(W)
 
-    mvn = MultivariateNormal(loc, cov)
     sparse_mvn = SparseMultivariateNormal(loc, D, W)
 
-    # TODO: enable this test when MultivariateNormal distribution support
-    # variance method
-    # assert_equal(mvn.variance(), sparse_mvn.variance())
+    assert_equal(sparse_mvn.variance, cov.diag())

--- a/tests/distributions/test_sparse_multivariate_normal.py
+++ b/tests/distributions/test_sparse_multivariate_normal.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+from torch.autograd import Variable
+
+from pyro.distributions import MultivariateNormal, SparseMultivariateNormal
+
+from tests.common import assert_equal
+
+
+def test_scaleu():
+    loc = Variable(torch.Tensor([1, 2, 1, 2, 0]))
+    D = Variable(torch.Tensor([1, 2, 3, 4, 5]))
+    W = Variable(torch.Tensor([[1, -1, 2, 3, 4], [2, 3, 1, 2, 4]]))
+    cov = D.diag() + W.t().matmul(W)
+
+    mvn = MultivariateNormal(loc, cov)
+    sparse_mvn = SparseMultivariateNormal(loc, D, W)
+
+    assert_equal(mvn.torch_dist.scale_triu, sparse_mvn.scale_triu)
+
+
+def test_batch_log_pdf():
+    loc = Variable(torch.Tensor([2, 1, 1, 2, 2]))
+    D = Variable(torch.Tensor([1, 2, 3, 1, 3]))
+    W = Variable(torch.Tensor([[1, -1, 2, 2, 4], [2, 1, 1, 2, 6]]))
+    x = Variable(torch.Tensor([2, 3, 4, 1, 7]))
+    cov = D.diag() + W.t().matmul(W)
+
+    mvn = MultivariateNormal(loc, cov)
+    sparse_mvn = SparseMultivariateNormal(loc, D, W)
+
+    assert_equal(mvn.batch_log_pdf(x), sparse_mvn.batch_log_pdf(x))
+
+
+def test_analytic_var():
+    loc = Variable(torch.Tensor([1, 1, 1, 2, 0]))
+    D = Variable(torch.Tensor([1, 2, 2, 4, 5]))
+    W = Variable(torch.Tensor([[3, -1, 3, 3, 4], [2, 3, 1, 3, 4]]))
+    cov = D.diag() + W.t().matmul(W)
+
+    mvn = MultivariateNormal(loc, cov)
+    sparse_mvn = SparseMultivariateNormal(loc, D, W)
+
+    assert_equal(mvn.analytic_var(), sparse_mvn.analytic_var())


### PR DESCRIPTION
To simplify the review for #722, which is almost finished, I move part of that pull request which adds a SparseMultivariateNormal distribution to here.

This pull request implements a "sparse" (fast calculation) for log prob of a Multivariate Normal distribution whose covariance matrix has the form D + W.T @ W. Here D is a diagonal matrix and W is a matrix of size `M x N` (in the sparse situation: M << N). 