### PR TITLE
Fix ss_vae_M2.py --aux-loss; add to tests

### DIFF
--- a/examples/ss_vae_M2.py
+++ b/examples/ss_vae_M2.py
@@ -188,11 +188,8 @@ class SSVAE(nn.Module):
             # similar to the NIPS 14 paper (Kingma et al).
             if ys is not None:
                 alpha = self.encoder_y.forward(xs)
-                pyro.sample("y_aux",
-                            dist.one_hot_categorical,
-                            alpha,
-                            log_pdf_mask=self.aux_loss_multiplier,
-                            obs=ys)
+                with pyro.poutine.scale(None, self.aux_loss_multiplier):
+                    pyro.sample("y_aux", dist.one_hot_categorical, alpha, obs=ys)
 
     def guide_classify(self, xs, ys=None):
         """

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -31,8 +31,9 @@ def discover_examples():
                 continue
             example = os.path.relpath(path, EXAMPLES_DIR)
             CPU_EXAMPLES.append((example, args))
-            if '--enum-discrete' in text:
-                CPU_EXAMPLES.append((example, args + ['--enum-discrete']))
+            for flag in ['--enum-discrete', '--aux-loss']:
+                if flag in text:
+                    CPU_EXAMPLES.append((example, args + [flag]))
             if '--cuda' in text:
                 CUDA_EXAMPLES.append((example, args + ['--cuda']))
     CPU_EXAMPLES.sort()


### PR DESCRIPTION
Fixes #731 

This was caused by a hack that used `log_pdf_mask` to scale the loss, rather than `pyro.poutine.scale()`.

## Tested

- added a regression test