### PR TITLE
Fix DMM example with --num-iafs > 0

### DIFF
--- a/pyro/distributions/transformed_distribution.py
+++ b/pyro/distributions/transformed_distribution.py
@@ -55,8 +55,8 @@ class TransformedDistribution(Distribution):
             next_input = y
         return next_input
 
-    def shape(self, sample_shape=torch.Size(), *args, **kwargs):
-        return self.base_dist.shape(sample_shape, *args, **kwargs)
+    def shape(self, *args, **kwargs):
+        return self.base_dist.shape(*args, **kwargs)
 
     def batch_shape(self, *args, **kwargs):
         return self.base_dist.batch_shape(*args, **kwargs)

--- a/pyro/distributions/transformed_distribution.py
+++ b/pyro/distributions/transformed_distribution.py
@@ -55,7 +55,10 @@ class TransformedDistribution(Distribution):
             next_input = y
         return next_input
 
-    def batch_shape(self, x=None, *args, **kwargs):
+    def shape(self, sample_shape=torch.Size(), *args, **kwargs):
+        return self.base_dist.shape(sample_shape, *args, **kwargs)
+
+    def batch_shape(self, *args, **kwargs):
         return self.base_dist.batch_shape(*args, **kwargs)
 
     def event_shape(self, *args, **kwargs):
@@ -242,4 +245,4 @@ class InverseAutoregressiveFlow(Bijector):
         log_sigma = torch.log(sigma)
         if 'log_pdf_mask' in kwargs:
             log_sigma = log_sigma * kwargs['log_pdf_mask']
-        return log_sigma.sum(-1)
+        return log_sigma

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,10 +30,14 @@ def discover_examples():
                 # Either this is not a main file, or we don't know how to run it cheaply.
                 continue
             example = os.path.relpath(path, EXAMPLES_DIR)
+            # TODO: May be worth whitelisting the set of arguments to test
+            # for each example.
             CPU_EXAMPLES.append((example, args))
             for flag in ['--enum-discrete', '--aux-loss']:
                 if flag in text:
                     CPU_EXAMPLES.append((example, args + [flag]))
+            if '--num-iafs' in text:
+                CPU_EXAMPLES.append((example, args + ['--num-iafs=1']))
             if '--cuda' in text:
                 CUDA_EXAMPLES.append((example, args + ['--cuda']))
     CPU_EXAMPLES.sort()


### PR DESCRIPTION
We needed some shape fixes to TransformedDistribution to fix the DMM example with IAF. There is still the issue with NAN loss - #711 that seems to have been introduced much earlier (I checked until November 2017). 

Fixes #721.