### PR TITLE
Implement ShapeAugmentedBeta and ShapeAugmentedDirichlet

### DIFF
--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -12,7 +12,7 @@ from pyro.distributions import (Bernoulli, Beta, Binomial, Categorical, Cauchy, 
                                 SparseMultivariateNormal, Uniform)
 from pyro.distributions.testing.naive_dirichlet import NaiveBeta, NaiveDirichlet
 from pyro.distributions.testing.rejection_exponential import RejectionExponential
-from pyro.distributions.testing.rejection_gamma import ShapeAugmentedGamma
+from pyro.distributions.testing.rejection_gamma import ShapeAugmentedBeta, ShapeAugmentedDirichlet, ShapeAugmentedGamma
 from tests.distributions.dist_fixture import Fixture
 
 continuous_dists = [
@@ -99,6 +99,17 @@ continuous_dists = [
                  'test_data': [[0.4], [0.6]]}
             ],
             scipy_arg_fn=lambda alpha, beta: ((np.array(alpha), np.array(beta)), {})),
+    Fixture(pyro_dist=(dist.beta, ShapeAugmentedBeta),
+            scipy_dist=sp.beta,
+            examples=[
+                {'alpha': [2.4], 'beta': [3.6],
+                 'test_data': [0.4]},
+                {'alpha': [[2.4, 2.4], [3.6, 3.6]], 'beta': [[2.5, 2.5], [2.5, 2.5]],
+                 'test_data': [[[5.5, 4.4], [5.5, 4.4]]]},
+                {'alpha': [[2.4], [3.7]], 'beta': [[3.6], [2.5]],
+                 'test_data': [[0.4], [0.6]]}
+            ],
+            scipy_arg_fn=lambda alpha, beta: ((np.array(alpha), np.array(beta)), {})),
     Fixture(pyro_dist=(dist.lognormal, LogNormal),
             scipy_dist=sp.lognorm,
             examples=[
@@ -160,6 +171,17 @@ continuous_dists = [
             ],
             scipy_arg_fn=lambda alpha: ((alpha,), {})),
     Fixture(pyro_dist=(dist.dirichlet, NaiveDirichlet),
+            scipy_dist=sp.dirichlet,
+            examples=[
+                {'alpha': [2.4, 3, 6],
+                 'test_data': [0.2, 0.45, 0.35]},
+                {'alpha': [2.4, 3, 6],
+                 'test_data': [[0.2, 0.45, 0.35], [0.2, 0.45, 0.35]]},
+                {'alpha': [[2.4, 3, 6], [3.2, 1.2, 0.4]],
+                 'test_data': [[0.2, 0.45, 0.35], [0.3, 0.4, 0.3]]}
+            ],
+            scipy_arg_fn=lambda alpha: ((alpha,), {})),
+    Fixture(pyro_dist=(dist.dirichlet, ShapeAugmentedDirichlet),
             scipy_dist=sp.dirichlet,
             examples=[
                 {'alpha': [2.4, 3, 6],

--- a/tests/distributions/test_rejector.py
+++ b/tests/distributions/test_rejector.py
@@ -117,6 +117,7 @@ def test_shape_augmented_gamma_elbo(alpha, beta):
     assert_equal(actual[0] / scale[0], expected[0] / scale[0], prec=0.05, msg='bad grad for alpha')
     assert_equal(actual[1] / scale[1], expected[1] / scale[1], prec=0.05, msg='bad grad for beta')
 
+
 @pytest.mark.parametrize('alpha', [0.5, 1.0, 4.0])
 @pytest.mark.parametrize('beta', [0.5, 1.0, 4.0])
 def test_shape_augmented_beta(alpha, beta):
@@ -129,8 +130,7 @@ def test_shape_augmented_beta(alpha, beta):
     (cost + cost.detach() * dist.score_parts(z)[1]).backward()
     mean_alpha_grad = alphas.grad.data.mean()
     mean_beta_grad = betas.grad.data.mean()
-    tot = alpha + beta
-    expected_alpha_grad = beta / tot ** 2
-    expected_beta_grad = -alpha / tot ** 2
+    expected_alpha_grad = beta / (alpha + beta) ** 2
+    expected_beta_grad = -alpha / (alpha + beta) ** 2
     assert_equal(mean_alpha_grad, expected_alpha_grad, prec=0.01, msg='bad grad for alpha')
     assert_equal(mean_beta_grad, expected_beta_grad, prec=0.01, msg='bad grad for beta')

--- a/tests/distributions/test_rejector.py
+++ b/tests/distributions/test_rejector.py
@@ -7,6 +7,7 @@ from torch.autograd import Variable, grad
 from pyro.distributions import Exponential, Gamma
 from pyro.distributions.testing.rejection_exponential import RejectionExponential
 from pyro.distributions.testing.rejection_gamma import RejectionGamma, RejectionStandardGamma, ShapeAugmentedGamma
+from pyro.distributions.testing.rejection_gamma import ShapeAugmentedBeta
 from tests.common import assert_equal
 
 
@@ -115,3 +116,21 @@ def test_shape_augmented_gamma_elbo(alpha, beta):
     scale = [(1 + abs(g)) for g in expected]
     assert_equal(actual[0] / scale[0], expected[0] / scale[0], prec=0.05, msg='bad grad for alpha')
     assert_equal(actual[1] / scale[1], expected[1] / scale[1], prec=0.05, msg='bad grad for beta')
+
+@pytest.mark.parametrize('alpha', [0.5, 1.0, 4.0])
+@pytest.mark.parametrize('beta', [0.5, 1.0, 4.0])
+def test_shape_augmented_beta(alpha, beta):
+    num_samples = 10000
+    alphas = Variable(torch.Tensor([alpha]).expand(num_samples, 1), requires_grad=True)
+    betas = Variable(torch.Tensor([beta]).expand(num_samples, 1), requires_grad=True)
+    dist = ShapeAugmentedBeta(alphas, betas)  # implemented using Rejector
+    z = dist.sample()
+    cost = z.sum()
+    (cost + cost.detach() * dist.score_parts(z)[1]).backward()
+    mean_alpha_grad = alphas.grad.data.mean()
+    mean_beta_grad = betas.grad.data.mean()
+    tot = alpha + beta
+    expected_alpha_grad = beta / tot ** 2
+    expected_beta_grad = -alpha / tot ** 2
+    assert_equal(mean_alpha_grad, expected_alpha_grad, prec=0.01, msg='bad grad for alpha')
+    assert_equal(mean_beta_grad, expected_beta_grad, prec=0.01, msg='bad grad for beta')


### PR DESCRIPTION
These two distributions with noisy reparameterized gradients are useful for testing SVI algorithms.