### PR TITLE
Fix decision rule in BlockPoutine

### DIFF
--- a/pyro/poutine/block_poutine.py
+++ b/pyro/poutine/block_poutine.py
@@ -49,7 +49,7 @@ class BlockPoutine(Poutine):
         1. msg["name"] in hide
         2. msg["type"] in hide_types
         3. msg["name"] not in expose and msg["type"] not in expose_types
-        4. hide_all == True
+        4. hide_all == True and hide, hide_types, and expose_types are all None
         """
         super(BlockPoutine, self).__init__(fn)
         # first, some sanity checks:
@@ -71,8 +71,12 @@ class BlockPoutine(Poutine):
         # hide_types and expose_types intersect?
         if hide_types is None:
             hide_types = []
+        else:
+            hide_all = False
         if expose_types is None:
             expose_types = []
+        else:
+            hide_all = False
         assert set(hide_types).isdisjoint(set(expose_types)), \
             "cannot hide and expose a site type"
 

--- a/pyro/poutine/block_poutine.py
+++ b/pyro/poutine/block_poutine.py
@@ -65,6 +65,9 @@ class BlockPoutine(Poutine):
 
         if expose is None:
             expose = []
+        else:
+            hide_all = True
+
         assert set(hide).isdisjoint(set(expose)), \
             "cannot hide and expose a site"
 
@@ -73,10 +76,12 @@ class BlockPoutine(Poutine):
             hide_types = []
         else:
             hide_all = False
+
         if expose_types is None:
             expose_types = []
         else:
-            hide_all = False
+            hide_all = True
+
         assert set(hide_types).isdisjoint(set(expose_types)), \
             "cannot hide and expose a site type"
 
@@ -97,7 +102,7 @@ class BlockPoutine(Poutine):
         1. msg["name"] in self.hide
         2. msg["type"] in self.hide_types
         3. msg["name"] not in self.expose and msg["type"] not in self.expose_types
-        4. self.hide_all == True
+        4. self.hide_all == True and hide, hide_types, and expose_types are all None
         """
         # handle observes
         if msg["type"] == "sample" and msg["is_observed"]:
@@ -105,11 +110,13 @@ class BlockPoutine(Poutine):
         else:
             msg_type = msg["type"]
 
+        is_not_exposed = (msg["name"] not in self.expose) and \
+                         (msg_type not in self.expose_types)
+
         # decision rule for hiding:
         if (msg["name"] in self.hide) or \
            (msg_type in self.hide_types) or \
-           ((msg["name"] not in self.expose) and
-            (msg_type not in self.expose_types) and self.hide_all):  # noqa: E129
+           (is_not_exposed and self.hide_all):  # noqa: E129
 
             return True
         # otherwise expose

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -185,6 +185,16 @@ class BlockPoutineTests(NormalNormalNormalPoutineTestCase):
                 assert name not in model_trace
                 assert name not in guide_trace
 
+    def test_block_tutorial_case(self):
+        model_trace = poutine.trace(self.model).get_trace()
+        guide_trace = poutine.trace(
+            poutine.block(self.guide, hide_types=["observe"])).get_trace()
+
+        assert "latent1" in model_trace
+        assert "latent1" in guide_trace
+        assert "obs" in model_trace
+        assert "obs" not in guide_trace
+
 
 class QueuePoutineDiscreteTest(TestCase):
 


### PR DESCRIPTION
`BlockPoutine` was incorrectly hiding sample sites when given `hide_types=["observe"]`, breaking the default guide in `infer.Importance`.  This fixes that bug and adds a test that would have caught it.

Fixes #619 