### PR TITLE
Added check and test for betas parameter for Adam Optimizer

### DIFF
--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -11,8 +11,13 @@ def Adam(optim_args):
     """
     A wrapper for torch.optim.Adam
     """
-    return PyroOptim(torch.optim.Adam, optim_args)
+    return PyroOptim(torch.optim.Adam, optim_args, _adam_checker)
 
+def _adam_checker(optim_args):
+    assert (optim_args['betas'][0] >= 0.0 and optim_args['betas'][0] < 1.0 \
+        if 'betas' in optim_args.keys() else True), "Invalid beta parameter at index 0: %f" % optim_args['betas'][0]
+    assert (optim_args['betas'][1] >= 0.0 and optim_args['betas'][1] < 1.0 \
+        if 'betas' in optim_args.keys() else True), "Invalid beta parameter at index 1: %f" % optim_args['betas'][1]
 
 def Adadelta(optim_args):
     """

--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -13,11 +13,14 @@ def Adam(optim_args):
     """
     return PyroOptim(torch.optim.Adam, optim_args, _adam_checker)
 
+
 def _adam_checker(optim_args):
-    assert (optim_args['betas'][0] >= 0.0 and optim_args['betas'][0] < 1.0 \
-        if 'betas' in optim_args.keys() else True), "Invalid beta parameter at index 0: %f" % optim_args['betas'][0]
-    assert (optim_args['betas'][1] >= 0.0 and optim_args['betas'][1] < 1.0 \
-        if 'betas' in optim_args.keys() else True), "Invalid beta parameter at index 1: %f" % optim_args['betas'][1]
+    if 'betas' in optim_args.keys():
+        if optim_args['betas'][0] < 0.0 or optim_args['betas'][0] >= 1.0:
+            raise ValueError("Invalid beta parameter at index 0: {}".format(optim_args['betas'][0]))
+        if optim_args['betas'][1] < 0.0 or optim_args['betas'][1] >= 1.0:
+            raise ValueError("Invalid beta parameter at index 1: {}".format(optim_args['betas'][1]))
+
 
 def Adadelta(optim_args):
     """

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -14,7 +14,7 @@ class PyroOptim(object):
     :param optim_args: a dictionary of learning arguments for the optimizer or a callable that returns
         such dictionaries
     """
-    def __init__(self, optim_constructor, optim_args, checker=None):
+    def __init__(self, optim_constructor, optim_args, arg_checker=None):
         self.pt_optim_constructor = optim_constructor
 
         # must be callable or dict
@@ -31,7 +31,7 @@ class PyroOptim(object):
         self._state_waiting_to_be_consumed = {}
 
         # function to check that parameters are within bounds
-        self.checker = checker
+        self.arg_checker = arg_checker
 
     def __call__(self, params,  *args, **kwargs):
         """
@@ -117,8 +117,10 @@ class PyroOptim(object):
 
             # must be dictionary
             assert isinstance(opt_dict, dict), "per-param optim arg must return defaults dictionary"
-            if self.checker: self.checker(opt_dict)
+            if self.arg_checker:
+                self.arg_checker(opt_dict)
             return opt_dict
         else:
-            if self.checker: self.checker(self.pt_optim_args)
+            if self.arg_checker:
+                self.arg_checker(self.pt_optim_args)
             return self.pt_optim_args

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -14,7 +14,7 @@ class PyroOptim(object):
     :param optim_args: a dictionary of learning arguments for the optimizer or a callable that returns
         such dictionaries
     """
-    def __init__(self, optim_constructor, optim_args):
+    def __init__(self, optim_constructor, optim_args, checker=None):
         self.pt_optim_constructor = optim_constructor
 
         # must be callable or dict
@@ -29,6 +29,9 @@ class PyroOptim(object):
 
         # any optimizer state that's waiting to be consumed (because that parameter hasn't been seen before)
         self._state_waiting_to_be_consumed = {}
+
+        # function to check that parameters are within bounds
+        self.checker = checker
 
     def __call__(self, params,  *args, **kwargs):
         """
@@ -114,6 +117,8 @@ class PyroOptim(object):
 
             # must be dictionary
             assert isinstance(opt_dict, dict), "per-param optim arg must return defaults dictionary"
+            if self.checker: self.checker(opt_dict)
             return opt_dict
         else:
+            if self.checker: self.checker(self.pt_optim_args)
             return self.pt_optim_args

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -75,3 +75,7 @@ class OptimTests(TestCase):
         free_param_unchanged = torch.equal(pyro.param(free_param).data, torch.zeros(1))
         fixed_param_unchanged = torch.equal(pyro.param(fixed_param).data, torch.zeros(1))
         assert fixed_param_unchanged and not free_param_unchanged
+        adam3 = optim.Adam({'betas' :(1.0, 0.9)})
+        svi3 = SVI(model, guide, adam3, loss="ELBO", trace_graph=True)
+        with self.assertRaisesRegexp(AssertionError, "Invalid beta parameter at index 0: 1.0"):
+            svi3.step()

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -75,7 +75,7 @@ class OptimTests(TestCase):
         free_param_unchanged = torch.equal(pyro.param(free_param).data, torch.zeros(1))
         fixed_param_unchanged = torch.equal(pyro.param(fixed_param).data, torch.zeros(1))
         assert fixed_param_unchanged and not free_param_unchanged
-        adam3 = optim.Adam({'betas' :(1.0, 0.9)})
+        adam3 = optim.Adam({'betas': (1.0, 0.9)})
         svi3 = SVI(model, guide, adam3, loss="ELBO", trace_graph=True)
-        with self.assertRaisesRegexp(AssertionError, "Invalid beta parameter at index 0: 1.0"):
+        with self.assertRaisesRegexp(ValueError, "Invalid beta parameter at index 0: 1.0"):
             svi3.step()


### PR DESCRIPTION
This PR adds a check to prevent division by zero errors and give users friendlier error messages when using the Adam optimizer.

Currently, if one specifies the beta value of the Adam optimizer as `1.0` for the first parameter, pyro fails with the error message, `ZeroDivisionError: float division by zero`. According to the definition of [Adam](https://arxiv.org/abs/1412.6980), beta values should be in the range \[0, 1\). 