### PR TITLE
Support sample_shape arg in .log_prob, .score_parts, .enumerate_support

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -132,7 +132,7 @@ class _Subsample(Distribution):
             result = Variable(torch.randperm(self.size)[:self.subsample_size])
         return result.cuda() if self.use_cuda else result
 
-    def log_prob(self, x):
+    def log_prob(self, x, sample_shape=torch.Size()):
         # This is zero so that iarange can provide an unbiased estimate of
         # the non-subsampled log_prob.
         result = Variable(torch.zeros(1))

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -38,18 +38,15 @@ class Delta(Distribution):
         shape = sample_shape + self.v.size()
         return self.v.expand(shape)
 
-    def log_prob(self, x):
-        v = self.v
-        v = v.expand(broadcast_shape(self.shape(), x.size()))
+    def log_prob(self, x, sample_shape=torch.Size()):
+        v = self.v.expand(broadcast_shape(sample_shape + self.v.shape, x.shape))
         return torch.eq(x, v).float().log()
 
-    def enumerate_support(self, v=None):
+    def enumerate_support(self, sample_shape=torch.Size()):
         """
         Returns the delta distribution's support, as a tensor along the first dimension.
 
-        :param v: torch variable where each element of the tensor represents the point at
-            which the delta distribution is concentrated.
         :return: torch variable enumerating the support of the delta distribution.
         :rtype: torch.autograd.Variable.
         """
-        return Variable(self.v.data.unsqueeze(0))
+        return Variable(self.sample(sample_shape).data.unsqueeze(0))

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -170,7 +170,7 @@ class Distribution(object):
         raise NotImplementedError
 
     @abstractmethod
-    def log_prob(self, x):
+    def log_prob(self, x, sample_shape=torch.Size()):
         """
         Evaluates log probability densities for each of a batch of samples.
 
@@ -183,7 +183,7 @@ class Distribution(object):
         """
         raise NotImplementedError
 
-    def score_parts(self, x):
+    def score_parts(self, x, sample_shape=torch.Size()):
         """
         Computes ingredients for stochastic gradient estimators of ELBO.
 
@@ -196,7 +196,7 @@ class Distribution(object):
         :return: A `ScoreParts` object containing parts of the ELBO estimator.
         :rtype: ScoreParts
         """
-        log_pdf = self.log_prob(x)
+        log_pdf = self.log_prob(x, sample_shape)
         if self.reparameterized:
             return ScoreParts(log_pdf=log_pdf, score_function=0, entropy_term=log_pdf)
         else:
@@ -204,7 +204,7 @@ class Distribution(object):
             # See Roeder, Wu, Duvenaud (2017) "Sticking the Landing" https://arxiv.org/abs/1703.09194
             return ScoreParts(log_pdf=log_pdf, score_function=log_pdf, entropy_term=0)
 
-    def enumerate_support(self):
+    def enumerate_support(self, sample_shape=torch.Size()):
         """
         Returns a representation of the parametrized distribution's support,
         along the first dimension. This is implemented only by discrete

--- a/pyro/distributions/random_primitive.py
+++ b/pyro/distributions/random_primitive.py
@@ -48,16 +48,16 @@ class RandomPrimitive(Distribution):
     __call__ = sample
 
     def log_prob(self, x, *args, **kwargs):
-        kwargs.pop('sample_shape', None)
-        return self.dist_class(*args, **kwargs).log_prob(x)
+        sample_shape = kwargs.pop('sample_shape', torch.Size())
+        return self.dist_class(*args, **kwargs).log_prob(x, sample_shape)
 
     def score_parts(self, x, *args, **kwargs):
-        kwargs.pop('sample_shape', None)
-        return self.dist_class(*args, **kwargs).score_parts(x)
+        sample_shape = kwargs.pop('sample_shape', torch.Size())
+        return self.dist_class(*args, **kwargs).score_parts(x, sample_shape)
 
     def enumerate_support(self, *args, **kwargs):
-        kwargs.pop('sample_shape', None)
-        return self.dist_class(*args, **kwargs).enumerate_support()
+        sample_shape = kwargs.pop('sample_shape', torch.Size())
+        return self.dist_class(*args, **kwargs).enumerate_support(sample_shape)
 
     def analytic_mean(self, *args, **kwargs):
         kwargs.pop('sample_shape', None)

--- a/pyro/distributions/rejector.py
+++ b/pyro/distributions/rejector.py
@@ -56,10 +56,10 @@ class Rejector(Distribution):
                 done |= accept
         return x
 
-    def log_prob(self, x):
+    def log_prob(self, x, sample_shape=torch.Size()):
         return self._propose_batch_log_pdf(x) + self._log_prob_accept(x)
 
-    def score_parts(self, x):
+    def score_parts(self, x, sample_shape=torch.Size()):
         score_function = self._log_prob_accept(x)
-        log_pdf = self.log_prob(x)
+        log_pdf = self.log_prob(x, sample_shape)
         return ScoreParts(log_pdf, score_function, log_pdf)

--- a/pyro/distributions/testing/rejection_gamma.py
+++ b/pyro/distributions/testing/rejection_gamma.py
@@ -55,8 +55,8 @@ class RejectionStandardGamma(Rejector):
         log_prob_accept[y <= 0] = -float('inf')
         return log_prob_accept
 
-    def log_prob(self, x):
-        return self._standard_gamma.log_prob(x)
+    def log_prob(self, x, sample_shape=torch.Size()):
+        return self._standard_gamma.log_prob(x, sample_shape)
 
 
 @copy_docs_from(Gamma)
@@ -72,11 +72,11 @@ class RejectionGamma(Gamma):
     def sample(self, sample_shape=torch.Size()):
         return self._standard_gamma.sample(sample_shape) / self.beta
 
-    def log_prob(self, x):
-        return self._standard_gamma.log_prob(x * self.beta) + torch.log(self.beta)
+    def log_prob(self, x, sample_shape=torch.Size()):
+        return self._standard_gamma.log_prob(x * self.beta, sample_shape) + torch.log(self.beta)
 
-    def score_parts(self, x):
-        log_pdf, score_function, _ = self._standard_gamma.score_parts(x * self.beta)
+    def score_parts(self, x, sample_shape=torch.Size()):
+        log_pdf, score_function, _ = self._standard_gamma.score_parts(x * self.beta, sample_shape)
         log_pdf = log_pdf + torch.log(self.beta)
         return ScoreParts(log_pdf, score_function, log_pdf)
 
@@ -107,13 +107,13 @@ class ShapeAugmentedGamma(Gamma):
         self._unboost_x_cache = boosted_x, x
         return boosted_x
 
-    def score_parts(self, boosted_x=None):
+    def score_parts(self, boosted_x=None, sample_shape=torch.Size()):
         if boosted_x is None:
             boosted_x = self._unboost_x_cache[0]
         assert boosted_x is self._unboost_x_cache[0]
         x = self._unboost_x_cache[1]
-        _, score_function, _ = self._rejection_gamma.score_parts(x)
-        log_pdf = self.log_prob(boosted_x)
+        _, score_function, _ = self._rejection_gamma.score_parts(x, sample_shape)
+        log_pdf = self.log_prob(boosted_x, sample_shape)
         return ScoreParts(log_pdf, score_function, log_pdf)
 
 

--- a/pyro/distributions/torch/dirichlet.py
+++ b/pyro/distributions/torch/dirichlet.py
@@ -36,7 +36,7 @@ class Dirichlet(TorchDistribution):
         """
         return super(Dirichlet, self).sample(sample_shape)
 
-    def log_prob(self, x):
+    def log_prob(self, x, sample_shape=torch.Size()):
         """
         Evaluates log probability density over one or a batch of samples.
 
@@ -50,4 +50,4 @@ class Dirichlet(TorchDistribution):
         :return: log probability densities of each element in the batch.
         :rtype: torch.autograd.Variable of torch.Tensor of dimension 1.
         """
-        return super(Dirichlet, self).log_prob(x)
+        return super(Dirichlet, self).log_prob(x, sample_shape)


### PR DESCRIPTION
Addresses #752 

## Why?

@eb8680 convinced me that `sample_shape` should at least be an argument to `.enumerate_support()` since those methods return almost the same kind of object. Additionally, we want `**kwargs` to apply equally to `.sample()`, `.log_prob()` and `.score_parts()`, so for symmetry `sample_shape` should be supported. This makes some sense because `.log_prob()` and `.score_parts()` can conceivably `.expand()` their results by the given `.sample_shape` for proper broadcasting.

More immediately, this is required to replace `RandomPrimitive`s with `Distribution` objects in some of our tests.

## Tested

- [ ] Add tests for `.log_prob()`
- [ ] Add tests for `.score_parts()`
- [ ] Add tests for `.enumerate_support()`