### PR TITLE
Prepare to drop RandomPrimitive in Trace methods

### DIFF
--- a/pyro/distributions/torch_wrapper.py
+++ b/pyro/distributions/torch_wrapper.py
@@ -53,3 +53,6 @@ class TorchDistribution(Distribution):
 
     def enumerate_support(self):
         return self.torch_dist.enumerate_support()
+
+    def _validate_log_prob_arg(self, value):
+        self.torch_dist._validate_log_prob_arg(value)

--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -7,7 +7,7 @@ import networkx
 import numpy as np
 from torch.autograd import Variable
 
-from pyro.distributions import RandomPrimitive
+from pyro.distributions.torch_wrapper import TorchDistribution
 
 
 def _warn_if_nan(name, value):
@@ -82,10 +82,10 @@ class Trace(networkx.DiGraph):
                     site_log_p = site["log_pdf"]
                 except KeyError:
                     args, kwargs = site["args"], site["kwargs"]
-                    if isinstance(site["fn"], RandomPrimitive):
-                        site_log_p = site["fn"].log_prob(site["value"], *args, **kwargs).sum() * site["scale"]
-                    else:
+                    if isinstance(site["fn"], TorchDistribution):
                         site_log_p = site["fn"].log_prob(site["value"]).sum() * site["scale"]
+                    else:
+                        site_log_p = site["fn"].log_prob(site["value"], *args, **kwargs).sum() * site["scale"]
                     site["log_pdf"] = site_log_p
                     _warn_if_nan(name, site_log_p)
                 log_p += site_log_p
@@ -105,10 +105,10 @@ class Trace(networkx.DiGraph):
                     site_log_p = site["batch_log_pdf"]
                 except KeyError:
                     args, kwargs = site["args"], site["kwargs"]
-                    if isinstance(site["fn"], RandomPrimitive):
-                        site_log_p = site["fn"].log_prob(site["value"], *args, **kwargs) * site["scale"]
-                    else:
+                    if isinstance(site["fn"], TorchDistribution):
                         site_log_p = site["fn"].log_prob(site["value"]) * site["scale"]
+                    else:
+                        site_log_p = site["fn"].log_prob(site["value"], *args, **kwargs) * site["scale"]
                     site["batch_log_pdf"] = site_log_p
                     site["log_pdf"] = site_log_p.sum()
                     _warn_if_nan(name, site["log_pdf"])
@@ -128,10 +128,10 @@ class Trace(networkx.DiGraph):
                     site["batch_log_pdf"]
                 except KeyError:
                     args, kwargs = site["args"], site["kwargs"]
-                    if isinstance(site["fn"], RandomPrimitive):
-                        site_log_p = site["fn"].log_prob(site["value"], *args, **kwargs) * site["scale"]
-                    else:
+                    if isinstance(site["fn"], TorchDistribution):
                         site_log_p = site["fn"].log_prob(site["value"]) * site["scale"]
+                    else:
+                        site_log_p = site["fn"].log_prob(site["value"], *args, **kwargs) * site["scale"]
                     site["batch_log_pdf"] = site_log_p
                     site["log_pdf"] = site_log_p.sum()
                     _warn_if_nan(name, site["log_pdf"])
@@ -144,10 +144,10 @@ class Trace(networkx.DiGraph):
             if site["type"] == "sample" and "score_parts" not in site:
                 # Note that ScoreParts overloads the multiplication operator
                 # to correctly scale each of its three parts.
-                if isinstance(site["fn"], RandomPrimitive):
-                    value = site["fn"].score_parts(site["value"], *site["args"], **site["kwargs"]) * site["scale"]
-                else:
+                if isinstance(site["fn"], TorchDistribution):
                     value = site["fn"].score_parts(site["value"]) * site["scale"]
+                else:
+                    value = site["fn"].score_parts(site["value"], *site["args"], **site["kwargs"]) * site["scale"]
                 site["score_parts"] = value
                 site["batch_log_pdf"] = value[0]
                 site["log_pdf"] = value[0].sum()

--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -5,8 +5,9 @@ import warnings
 
 import networkx
 import numpy as np
-
 from torch.autograd import Variable
+
+from pyro.distributions import RandomPrimitive
 
 
 def _warn_if_nan(name, value):
@@ -81,8 +82,10 @@ class Trace(networkx.DiGraph):
                     site_log_p = site["log_pdf"]
                 except KeyError:
                     args, kwargs = site["args"], site["kwargs"]
-                    site_log_p = site["fn"].log_prob(
-                        site["value"], *args, **kwargs).sum() * site["scale"]
+                    if isinstance(site["fn"], RandomPrimitive):
+                        site_log_p = site["fn"].log_prob(site["value"], *args, **kwargs).sum() * site["scale"]
+                    else:
+                        site_log_p = site["fn"].log_prob(site["value"]).sum() * site["scale"]
                     site["log_pdf"] = site_log_p
                     _warn_if_nan(name, site_log_p)
                 log_p += site_log_p
@@ -102,8 +105,10 @@ class Trace(networkx.DiGraph):
                     site_log_p = site["batch_log_pdf"]
                 except KeyError:
                     args, kwargs = site["args"], site["kwargs"]
-                    site_log_p = site["fn"].log_prob(
-                        site["value"], *args, **kwargs) * site["scale"]
+                    if isinstance(site["fn"], RandomPrimitive):
+                        site_log_p = site["fn"].log_prob(site["value"], *args, **kwargs) * site["scale"]
+                    else:
+                        site_log_p = site["fn"].log_prob(site["value"]) * site["scale"]
                     site["batch_log_pdf"] = site_log_p
                     site["log_pdf"] = site_log_p.sum()
                     _warn_if_nan(name, site["log_pdf"])
@@ -123,8 +128,10 @@ class Trace(networkx.DiGraph):
                     site["batch_log_pdf"]
                 except KeyError:
                     args, kwargs = site["args"], site["kwargs"]
-                    site_log_p = site["fn"].log_prob(
-                        site["value"], *args, **kwargs) * site["scale"]
+                    if isinstance(site["fn"], RandomPrimitive):
+                        site_log_p = site["fn"].log_prob(site["value"], *args, **kwargs) * site["scale"]
+                    else:
+                        site_log_p = site["fn"].log_prob(site["value"]) * site["scale"]
                     site["batch_log_pdf"] = site_log_p
                     site["log_pdf"] = site_log_p.sum()
                     _warn_if_nan(name, site["log_pdf"])
@@ -137,8 +144,10 @@ class Trace(networkx.DiGraph):
             if site["type"] == "sample" and "score_parts" not in site:
                 # Note that ScoreParts overloads the multiplication operator
                 # to correctly scale each of its three parts.
-                value = site["fn"].score_parts(
-                    site["value"], *site["args"], **site["kwargs"]) * site["scale"]
+                if isinstance(site["fn"], RandomPrimitive):
+                    value = site["fn"].score_parts(site["value"], *site["args"], **site["kwargs"]) * site["scale"]
+                else:
+                    value = site["fn"].score_parts(site["value"]) * site["scale"]
                 site["score_parts"] = value
                 site["batch_log_pdf"] = value[0]
                 site["log_pdf"] = value[0].sum()


### PR DESCRIPTION
Addresses #752 more cleanly than #753 

This introduces the assumption in Pyro that: if Pyro ever uses the `.log_prob()` or `.score_parts()` methods of a stochastic function, then that function agrees to follow the `Distribution` api. Specifically, `.log_prob()` and `.score_parts()` take a `sample` and no `sample_shape` or other `*args, **kwargs`.

A special exception is made for `RandomPrimitive` since that does not conform to the `Distribution` api; this exception will be removed as soon as `RandomPrimitive` is removed.

This PR is needed to replace `dist.normal` etc. with `dist.Normal` etc. in tests.