### PR TITLE
Add Parameterized module for GP

### DIFF
--- a/pyro/contrib/gp/__init__.py
+++ b/pyro/contrib/gp/__init__.py
@@ -23,7 +23,7 @@ class InducingPoints(nn.Module):
 
 class Parameterized(nn.Module):
     """
-    Parameterized module.
+    Parameterized class.
 
     This is a base class for other classes in this Gaussian Process module.
     """
@@ -49,7 +49,7 @@ class Parameterized(nn.Module):
         Sets a constraint to a parameter.
 
         :param str param: Name of a parameter.
-        :param torch.distributions.constraints.Constraint constraint: A pytorch constraint.
+        :param torch.distributions.constraints.Constraint constraint: A Pytorch constraint.
             See `Pytorch's docs
             <http://pytorch.org/docs/master/distributions.html#module-torch.distributions.constraints>`_
             for a list of constraints.
@@ -58,7 +58,7 @@ class Parameterized(nn.Module):
 
     def set_mode(self, mode):
         """
-        Sets mode for the module. `self.link_param(param)` method will used this mode to
+        Sets mode for the module. `self.register_param(param)` method will used this mode to
         decide its logic.
 
         :param str mode: Either "model" or "guide".

--- a/pyro/contrib/gp/__init__.py
+++ b/pyro/contrib/gp/__init__.py
@@ -26,12 +26,6 @@ class Parameterized(nn.Module):
     Parameterized module.
 
     This is a base class for other classes in this Gaussian Process module.
-    The method `set_prior(param, prior)` will be used to set priors to parameters.
-    The method `set_constraint(param, prior)` will be used to set constraints to parameters.
-    We use `set_mode(mode)` to interchange between "model" and guide" (default).
-    If a parameter has a prior, we will use Maximum A Posteriori (MAP) for its guide.
-    The method `link_param(param)` is used as a wrapper for `pyro.param()` or
-    `pyro.sample()` call.
     """
 
     def __init__(self):
@@ -42,17 +36,44 @@ class Parameterized(nn.Module):
         self._name = None
 
     def set_prior(self, param, prior):
+        """
+        Sets a prior to a parameter.
+
+        :param str param: Name of a parameter.
+        :param pyro.distributions.Distribution prior: A prior distribution for random variable `param`.
+        """
         self._priors[param] = prior
 
     def set_constraint(self, param, constraint):
+        """
+        Sets a constraint to a parameter.
+
+        :param str param: Name of a parameter.
+        :param torch.distributions.constraints.Constraint constraint: A pytorch constraint.
+            See `Pytorch's docs
+            <http://pytorch.org/docs/master/distributions.html#module-torch.distributions.constraints>`_
+            for a list of constraints.
+        """
         self._constraints[param] = constraint
 
     def set_mode(self, mode):
+        """
+        Sets mode for the module. `self.link_param(param)` method will used this mode to
+        decide its logic.
+
+        :param str mode: Either "model" or "guide".
+        """
         if mode not in ["model", "guide"]:
             raise ValueError("Mode should be either 'model' or 'guide', but got {}.".format(mode))
         self._mode = mode
 
-    def link_param(self, param):
+    def register_param(self, param):
+        """
+        Registers a parameter to Pyro. It can be seen as a wrapper for `pyro.param()` and
+        `pyro.sample()` calls.
+
+        :param str param: Name of a parameter.
+        """
         prior = self._priors[param] if param in self._priors else None
         if self._name is None:
             param_name = param

--- a/pyro/contrib/gp/__init__.py
+++ b/pyro/contrib/gp/__init__.py
@@ -1,9 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
+from torch.autograd import Variable
 import torch.nn as nn
 from torch.nn import Parameter
+from torch.distributions import transform_to
+
+import pyro
+import pyro.distributions as dist
 
 
+# TODO: remove this class
 class InducingPoints(nn.Module):
 
     def __init__(self, Xu, name="inducing_points"):
@@ -13,3 +19,56 @@ class InducingPoints(nn.Module):
 
     def forward(self):
         return self.inducing_points
+
+
+class Parameterized(nn.Module):
+
+    def __init__(self):
+        super(Parameterized, self).__init__()
+        self._priors = {}
+        self._constraints = {}
+        self._mode = "model"
+        self._name = ""
+
+    def set_prior(self, param, prior):
+        self._priors[param] = prior
+
+    def set_constraint(self, param, constraint):
+        self._constraints[param] = constraint
+
+    def set_mode(self, mode):
+        if mode not in ["model", "guide"]:
+            raise ValueError("Mode should be either 'model' or 'guide', but got {}.".format(mode))
+        self._mode = mode
+
+    def set_name(self, name):
+        self._name = name
+
+    def link_param(self, param):
+        prior = self._priors[param] if param in self._priors else None
+        if self._name == "":
+            param_name = param
+        else:
+            param_name = pyro.param_with_module_name(self._name, param)
+
+        if prior is None:
+            constraint = self._constraints[param] if param in self._constraints else None
+            tmp = getattr(self, param)
+            if constraint is None:
+                p = pyro.param(param_name, tmp)
+            else:
+                # TODO: use `constraint_to` inside `pyro.param(...)` when available
+                unconstrained_param_name = param_name + "_unconstrained"
+                unconstrained_param_0 = Variable(transform_to(constraint).inv(tmp).data.clone(),
+                                                 requires_grad=True)
+                p = transform_to(constraint)(pyro.param(unconstrained_param_name,
+                                                        unconstrained_param_0))
+        elif self._mode == "model":
+            p = pyro.sample(param_name, prior)
+        else:  # prior != None and mode = "guide"
+            MAP_param_name = param_name + "_MAP"
+            MAP_param_0 = Variable(prior.torch_dist.mean.data.clone(), requires_grad=True)
+            MAP_param = pyro.param(MAP_param_name, MAP_param_0)
+            p = pyro.sample(param_name, dist.Delta(MAP_param))
+
+        return p


### PR DESCRIPTION
This pull request adds a Parameterized class for GP module. With this class, we can remove "lengthy" blocks using `pyro.random_module(...)` in GP models. In addition, from now on, we can set `constraints` to parameters of any (kernel/model/likelihood) module by using `set_constraint(...)` method (as suggested by @fritzo at https://github.com/uber/pyro/issues/702#issuecomment-363473322).

I make this separated from https://github.com/uber/pyro/pull/747 for easy to have a discussion. While creating Likelihood module there, I don't want to repeatedly require `likelihood_prior`, `pyro.random_model("likelihood", self.likelihood, ...)`... as the way I did for `self.kernel` and `self.Xu`. With this pull request, the logic in `self.model` and `self.guide` will be controlled by using `self.kernel.set_mode("model")` and `self.kernel.set_model("guide")` e.g.!