### PR TITLE
Simplify ELBO plumbing

### DIFF
--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -1,27 +1,18 @@
 from __future__ import absolute_import, division, print_function
 
-from .trace_elbo import Trace_ELBO
-from .tracegraph_elbo import TraceGraph_ELBO
-
 
 class ELBO(object):
     """
-    :param num_particles: the number of particles (samples) used to form the ELBO estimator.
-    :param trace_graph: boolean. whether to keep track of dependency information when running the
-        model and guide. this information can be used to form a gradient estimator with lower variance
-        in the case that some of the random variables are non-reparameterized.
-        note: for a model with many random variables, keeping track of the dependency information
-        can be expensive. see the tutorial `SVI Part III <http://pyro.ai/examples/svi_part_iii.html>`_
-        for a discussion.
-    :param bool enum_discrete: whether to sum over discrete latent variables, rather than sample them.
-
-    `ELBO` is the top-level interface for stochastic variational inference via optimization of the
-    evidence lower bound. Most users will not interact with `ELBO` directly; instead they will interact
-    with `SVI`. `ELBO` dispatches to `Trace_ELBO` and `TraceGraph_ELBO`, where the internal
+    :class:`ELBO` is the top-level interface for stochastic variational
+    inference via optimization of the evidence lower bound. Most users will not
+    interact with :class:`ELBO` directly; instead they will interact with `SVI`.
+    `ELBO` dispatches to `Trace_ELBO` and `TraceGraph_ELBO`, where the internal
     implementations live.
 
-    .. warning:: `enum_discrete` is a bleeding edge feature.
-        see `SS-VAE <http://pyro.ai/examples/ss-vae.html>`_ for a discussion.
+    :param num_particles: The number of particles/samples used to form the ELBO
+        (gradient) estimators.
+    :param bool enum_discrete: Whether to sum over discrete latent variables,
+        rather than sample them.
 
     References
 
@@ -31,35 +22,30 @@ class ELBO(object):
     [2] `Black Box Variational Inference`,
     Rajesh Ranganath, Sean Gerrish, David M. Blei
     """
+
     def __init__(self,
                  num_particles=1,
-                 trace_graph=False,
                  enum_discrete=False):
-        super(ELBO, self).__init__()
         self.num_particles = num_particles
-        self.trace_graph = trace_graph
-        if self.trace_graph:
-            self.which_elbo = TraceGraph_ELBO(num_particles=num_particles, enum_discrete=enum_discrete)
+        self.enum_discrete = enum_discrete
+
+    @staticmethod
+    def make(trace_graph=False, **kwargs):
+        """
+        Factory to construct an ELBO implementation.
+
+        :param bool trace_graph: Whether to keep track of dependency
+            information when running the model and guide. This information can
+            be used to form a gradient estimator with lower variance in the
+            case that some of the random variables are non-reparameterized.
+            Note: for a model with many random variables, keeping track of the
+            dependency information can be expensive. See the tutorial
+            `SVI Part III <http://pyro.ai/examples/svi_part_iii.html>`_ for a
+            discussion.
+        """
+        if trace_graph:
+            from .tracegraph_elbo import TraceGraph_ELBO
+            return TraceGraph_ELBO(**kwargs)
         else:
-            self.which_elbo = Trace_ELBO(num_particles=num_particles, enum_discrete=enum_discrete)
-
-    def loss(self, model, guide, *args, **kwargs):
-        """
-        Evaluates the ELBO with an estimator that uses `num_particles` many samples/particles,
-        where `num_particles` is specified in the constructor.
-
-        :returns: returns an estimate of the ELBO
-        :rtype: float
-        """
-        return self.which_elbo.loss(model, guide, *args, **kwargs)
-
-    def loss_and_grads(self, model, guide, *args, **kwargs):
-        """
-        Computes the ELBO as well as the surrogate ELBO that is used to form the gradient estimator.
-        Performs backward on the latter. Num_particle many samples are used to form the estimators,
-        where `num_particles` is specified in the constructor.
-
-        :returns: returns an estimate of the ELBO
-        :rtype: float
-        """
-        return self.which_elbo.loss_and_grads(model, guide, *args, **kwargs)
+            from .trace_elbo import Trace_ELBO
+            return Trace_ELBO(**kwargs)

--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -28,7 +28,6 @@ class SVI(object):
                  optim,
                  loss,
                  loss_and_grads=None,
-                 *args,
                  **kwargs):
         self.model = model
         self.guide = guide
@@ -38,7 +37,7 @@ class SVI(object):
             assert loss in ["ELBO"], "The only built-in loss currently supported by SVI is ELBO"
 
             if loss == "ELBO":
-                self.ELBO = ELBO(*args, **kwargs)
+                self.ELBO = ELBO.make(**kwargs)
                 self.loss = self.ELBO.loss
                 self.loss_and_grads = self.ELBO.loss_and_grads
             else:

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -10,6 +10,7 @@ from torch.autograd import Variable
 import pyro
 import pyro.poutine as poutine
 from pyro.distributions.util import is_identically_zero
+from pyro.infer.elbo import ELBO
 from pyro.infer.enum import iter_discrete_traces
 from pyro.infer.util import torch_backward, torch_data_sum, torch_sum
 from pyro.poutine.util import prune_subsample_sites
@@ -42,20 +43,10 @@ def check_enum_discrete_can_run(model_trace, guide_trace):
                                for shape, (source, name) in sorted(shapes.items())])))
 
 
-class Trace_ELBO(object):
+class Trace_ELBO(ELBO):
     """
     A trace implementation of ELBO-based SVI
     """
-    def __init__(self,
-                 num_particles=1,
-                 enum_discrete=False):
-        """
-        :param num_particles: the number of particles/samples used to form the ELBO (gradient) estimators
-        :param bool enum_discrete: whether to sum over discrete latent variables, rather than sample them
-        """
-        super(Trace_ELBO, self).__init__()
-        self.num_particles = num_particles
-        self.enum_discrete = enum_discrete
 
     def _get_traces(self, model, guide, *args, **kwargs):
         """

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -9,6 +9,7 @@ import torch
 import pyro
 import pyro.poutine as poutine
 from pyro.distributions.util import is_identically_zero
+from pyro.infer.elbo import ELBO
 from pyro.infer.util import torch_backward, torch_data_sum
 from pyro.poutine.util import prune_subsample_sites
 from pyro.util import check_model_guide_match, detach_iterable, ng_zeros
@@ -164,7 +165,7 @@ def _compute_elbo_non_reparam(guide_trace, guide_vec_md_nodes,  #
     return surrogate_elbo, baseline_loss
 
 
-class TraceGraph_ELBO(object):
+class TraceGraph_ELBO(ELBO):
     """
     A TraceGraph implementation of ELBO-based SVI. The gradient estimator
     is constructed along the lines of reference [1] specialized to the case
@@ -181,14 +182,6 @@ class TraceGraph_ELBO(object):
     [2] `Neural Variational Inference and Learning in Belief Networks`
         Andriy Mnih, Karol Gregor
     """
-    def __init__(self, num_particles=1, enum_discrete=False):
-        """
-        :param num_particles: the number of particles (samples) used to form the estimator
-        :param bool enum_discrete: whether to sum over discrete latent variables, rather than sample them
-        """
-        super(TraceGraph_ELBO, self).__init__()
-        self.num_particles = num_particles
-        self.enum_discrete = enum_discrete
 
     def _get_traces(self, model, guide, *args, **kwargs):
         """


### PR DESCRIPTION
This refactors the `ELBO` wrapper class to be a base class + a static factory method.

## Why?

Before this PR we needed to plumb inference `*args, **kwargs`  through `SVI`, `ELBO`, and `Trace_ELBO`, and `TraceGraph_ELBO` and manually ensure that `Trace_ELBO` and `TraceGraph_ELBO` had the same constructors.

After this PR we pass an opaque `**kwargs` from `SVI` to `ELBO.make` and interpret these `**kwargs` in a single place, the base class constructor `ELBO.__init__()`. Note that `*args` are now disallowed; inference options must be specified by keyword.

The author made this change because it seemed overly difficult to add a new inference parameter.