### PR TITLE
Automatically import all standard torch distributions

### DIFF
--- a/docs/source/contrib.gp.rst
+++ b/docs/source/contrib.gp.rst
@@ -25,7 +25,7 @@ Kernels
     :member-order: bysource
     
 Likelihoods
--------
+-----------
 
 .. automodule:: pyro.contrib.gp.likelihoods.likelihood
     :members:

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -41,7 +41,7 @@ MultivariateNormal
     :show-inheritance:
 
 OMTMultivariateNormal
-------------------
+---------------------
 .. automodule:: pyro.distributions.omt_mvn
     :members:
     :undoc-members:

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -2,14 +2,12 @@ from __future__ import absolute_import, division, print_function
 
 from pyro.distributions.delta import Delta
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.omt_mvn import OMTMultivariateNormal
 from pyro.distributions.rejector import Rejector
-from pyro.distributions.torch import (Bernoulli, Beta, Binomial, Categorical, Cauchy, Dirichlet, Exponential, Gamma,
-                                      LogNormal, Multinomial, Normal, OneHotCategorical, Poisson,
-                                      TransformedDistribution, Uniform)
+from pyro.distributions.torch import *
 from pyro.distributions.torch.iaf import InverseAutoregressiveFlow
 from pyro.distributions.torch.multivariate_normal import MultivariateNormal
 from pyro.distributions.torch.sparse_multivariate_normal import SparseMultivariateNormal
 from pyro.distributions.torch_distribution import TorchDistribution
-from pyro.distributions.omt_mvn import OMTMultivariateNormal
 
 # flake8: noqa

--- a/pyro/distributions/torch/__init__.py
+++ b/pyro/distributions/torch/__init__.py
@@ -7,6 +7,8 @@ from torch.autograd import Variable
 
 from pyro.distributions.torch_distribution import TorchDistributionMixin
 
+__all__ = []  # Constructed below.
+
 # These distributions require custom wrapping.
 # TODO rename parameters so these can be imported automatically.
 
@@ -98,6 +100,8 @@ for _name, _Dist in torch.distributions.__dict__.items():
         continue
     if _Dist is torch.distributions.Distribution:
         continue
+
+    __all__.append(_name)
     if _name in dir():
         continue
 

--- a/pyro/distributions/torch/__init__.py
+++ b/pyro/distributions/torch/__init__.py
@@ -7,6 +7,9 @@ from torch.autograd import Variable
 
 from pyro.distributions.torch_distribution import TorchDistributionMixin
 
+# These distributions require custom wrapping.
+# TODO rename parameters so these can be imported automatically.
+
 
 class Bernoulli(torch.distributions.Bernoulli, TorchDistributionMixin):
     def __init__(self, ps=None, logits=None):
@@ -82,10 +85,25 @@ class Poisson(torch.distributions.Poisson, TorchDistributionMixin):
         super(Poisson, self).__init__(lam)
 
 
-class TransformedDistribution(torch.distributions.TransformedDistribution, TorchDistributionMixin):
-    pass
-
-
 class Uniform(torch.distributions.Uniform, TorchDistributionMixin):
     def __init__(self, a, b):
         super(Uniform, self).__init__(a, b)
+
+
+# Programmatically load all remaining distributions.
+for _name, _Dist in torch.distributions.__dict__.items():
+    if not isinstance(_Dist, type):
+        continue
+    if not issubclass(_Dist, torch.distributions.Distribution):
+        continue
+    if _Dist is torch.distributions.Distribution:
+        continue
+    if _name in dir():
+        continue
+
+    class _PyroDist(_Dist, TorchDistributionMixin):
+        pass
+
+    _PyroDist.__name__ = _name
+    locals()[_name] = _PyroDist
+    del _PyroDist, _name, _Dist


### PR DESCRIPTION
This adds a `for ... in torch.distributions.__dict_...` loop that automatcially wraps all available PyTorch distributions. Only `TransformedDistribution` is moved into this loop since most distributions require custom param renaming. However this PR does give Pyro access to all other PyTorch distributions e.g. `Geometric` and `Pareto`.

## Tested

- existing tests
- checked that documentation is correctly generated