### PR TITLE
remove overhead of trace copy

### DIFF
--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -64,7 +64,10 @@ class Trace(networkx.DiGraph):
         Identical to super(Trace, self).copy(), but preserves the type
         and the self.graph_type attribute
         """
-        return Trace(super(Trace, self).copy(), graph_type=self.graph_type)
+        trace = super(Trace, self).copy()
+        trace.graph_type = self.graph_type
+        trace.__class__ = Trace
+        return trace
 
     def log_pdf(self, site_filter=lambda name, site: True):
         """


### PR DESCRIPTION
This pull request removes some overhead of `Trace.copy()` method. In case we use a lot of `.get_trace` calls from trace_poutine, this reduces a portion amount of time.

For an experiment, I used `get_trace()` method for the fourth test of HMC. With the old `copy` behavior, it took 52s to run. With the current one, it took 48s.

Of course, the best solution is still to use `def get_trace(self): return self.trace` instead of `def get_trace(self): return self.trace.copy()` in the TraceMessenger class (46s for the above experiment). But I guess that it is intentional to use `copy()` there as default (why not `poutine.get_trace(*args, **kwargs).copy()` if we want to take a copy version)? In that case, this pull request is helpful.

cc @neerajprad 