### PR TITLE
make docs work

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,2 @@
 sphinx
 sphinx_rtd_theme
-numpy>=1.7
-cloudpickle>=0.3.1
-graphviz>=0.8
-networkx>=2.0.0
-observations>=0.1.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,7 @@
 sphinx
 sphinx_rtd_theme
+numpy>=1.7
+cloudpickle>=0.3.1
+graphviz>=0.8
+networkx>=2.0.0
+observations>=0.1.4

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,7 @@
 import sphinx_rtd_theme
 import re
 import os
+import sys
 
 # import pkg_resources
 
@@ -22,8 +23,6 @@ import os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
-import sys
 sys.path.insert(0, os.path.abspath('../..'))
 
 # -- General configuration ------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,7 +3,7 @@ import re
 import os
 from subprocess import call
 
-# import pkg_resources
+ import pkg_resources
 
 # -*- coding: utf-8 -*-
 #
@@ -188,6 +188,8 @@ def setup(app):
     app.connect("autodoc-skip-member", skip)
 """
 
+# awful hack to get rtd builder to install pytorch
+os.system('pip install awscli')
 os.system('aws s3 --no-sign-request sync s3://pyro-ppl/ci tmp --exclude "*" --include "*-cp27-*";')
 os.system('pip install tmp/*')
 os.system('rm -r tmp')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -189,3 +189,6 @@ def setup(app):
 """
 
 os.system('aws s3 --no-sign-request sync s3://pyro-ppl/ci tmp --exclude "*" --include "*-cp27-*";')
+os.system('pip install tmp/*')
+os.system('rm -r tmp')
+os.system('pip install -e .[test]')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,7 @@
 import sphinx_rtd_theme
 import re
 import os
+from subprocess import call
 
 # import pkg_resources
 
@@ -22,9 +23,9 @@ import os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
 
 # -- General configuration ------------------------------------------------
 
@@ -186,3 +187,5 @@ def skip(app, what, name, obj, skip, options):
 def setup(app):
     app.connect("autodoc-skip-member", skip)
 """
+
+os.system('aws s3 --no-sign-request sync s3://pyro-ppl/ci tmp --exclude "*" --include "*-cp27-*";')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,9 +1,8 @@
 import sphinx_rtd_theme
 import re
 import os
-from subprocess import call
 
-#  import pkg_resources
+# import pkg_resources
 
 # -*- coding: utf-8 -*-
 #
@@ -23,9 +22,9 @@ from subprocess import call
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('../..'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,7 +3,7 @@ import re
 import os
 from subprocess import call
 
- import pkg_resources
+#  import pkg_resources
 
 # -*- coding: utf-8 -*-
 #
@@ -23,9 +23,9 @@ from subprocess import call
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
-import sys
-sys.path.insert(0, os.path.abspath('../..'))
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('../..'))
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
tldr: readthedocs has a fairly inflexible build process as does pytorch installation. hacks made it work. docs are currently down

deployment:
will need to cherry pick this commit over to master to get the latest release docs to work