### PR TITLE
Add tests for Reshape distribution; fix some bugs

### DIFF
--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -167,10 +167,10 @@ class Reshape(TorchDistribution):
         return self.base_dist.has_enumerate_support
 
     def sample(self, sample_shape=torch.Size()):
-        return self.base_dist.sample(self.sample_shape + sample_shape)
+        return self.base_dist.sample(sample_shape + self.sample_shape)
 
     def rsample(self, sample_shape=torch.Size()):
-        return self.base_dist.rsample(self.sample_shape + sample_shape)
+        return self.base_dist.rsample(sample_shape + self.sample_shape)
 
     def log_prob(self, value):
         return sum_rightmost(self.base_dist.log_prob(value), self.extra_event_dims)
@@ -194,8 +194,8 @@ class Reshape(TorchDistribution):
 
     @property
     def mean(self):
-        return self.base_dist.mean
+        return self.base_dist.mean.expand(self.batch_shape + self.event_shape)
 
     @property
     def variance(self):
-        return self.base_dist.variance
+        return self.base_dist.variance.expand(self.batch_shape + self.event_shape)

--- a/tests/distributions/test_reshape.py
+++ b/tests/distributions/test_reshape.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+import torch
+from torch.autograd import Variable
+
+from pyro.distributions.torch import Bernoulli
+
+
+@pytest.mark.parametrize('sample_dim,extra_event_dims',
+                         [(s, e) for s in range(4) for e in range(4 + s)])
+def test_reshape(sample_dim, extra_event_dims):
+    batch_dim = 3
+    batch_shape, event_shape = torch.Size((5, 4, 3)), torch.Size()
+    sample_shape = torch.Size((8, 7, 6))[3 - sample_dim:]
+    shape = sample_shape + batch_shape + event_shape
+
+    dist0 = Bernoulli(Variable(0.5 * torch.ones(batch_shape)))
+    dist = dist0.reshape(sample_shape, extra_event_dims)
+    sample = dist.sample()
+    log_prob = dist.log_prob(sample)
+    enum = dist.enumerate_support()
+
+    assert sample.shape == shape
+    assert dist.mean.shape == shape
+    assert dist.variance.shape == shape
+    assert log_prob.shape == shape[:sample_dim + batch_dim - extra_event_dims]
+    assert enum.shape == torch.Size((2,)) + shape
+
+
+@pytest.mark.parametrize('sample_dim,extra_event_dims',
+                         [(s, e) for s in range(3) for e in range(3 + s)])
+def test_reshape_reshape(sample_dim, extra_event_dims):
+    batch_dim = 2
+    batch_shape, event_shape = torch.Size((6, 5)), torch.Size((4, 3))
+    sample_shape = torch.Size((8, 7))[2 - sample_dim:]
+    shape = sample_shape + batch_shape + event_shape
+
+    dist0 = Bernoulli(Variable(0.5 * torch.ones(event_shape)))
+    dist1 = dist0.reshape(sample_shape=batch_shape, extra_event_dims=2)
+    assert dist1.event_shape == event_shape
+    assert dist1.batch_shape == batch_shape
+
+    dist = dist1.reshape(sample_shape, extra_event_dims)
+    sample = dist.sample()
+    log_prob = dist.log_prob(sample)
+    enum = dist.enumerate_support()
+
+    assert sample.shape == shape
+    assert dist.mean.shape == shape
+    assert dist.variance.shape == shape
+    assert log_prob.shape == shape[:sample_dim + batch_dim - extra_event_dims]
+    assert enum.shape == torch.Size((2,)) + shape


### PR DESCRIPTION
This adds unit tests for `.reshape(sample_shape, extra_event_dims)` and fixes three bugs:
- `.reshape(sample_shape2).reshape(sample_shape2)` is now applied in the correct order
- `.reshape(sample_shape).mean` now has the same shape as `...sample()`
- `.reshape(sample_shape).variance` now has the same shape as `...sample()`