### PR TITLE
Add stage marker to test_memory

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import gc
 
 import networkx as nx
+import pytest
 import torch
 from torch.autograd import Variable
 
@@ -12,6 +13,9 @@ from pyro import poutine
 from pyro.infer.svi import SVI
 from pyro.optim import Adam
 from pyro.poutine.trace import Trace
+
+
+pytestmark = pytest.mark.stage('unit')
 
 
 def count_objects_of_type(type_):


### PR DESCRIPTION
Currently these tests run for each of the build stages, throwing a `UserWarning` like `UserWarning: No stage associated with the test test_svi. Will run on each stage invocation.`.