### PR TITLE
Fix typo in tutorial intro_part_ii.ipynb

### DIFF
--- a/tutorial/source/intro_part_ii.ipynb
+++ b/tutorial/source/intro_part_ii.ipynb
@@ -183,7 +183,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# equivalent to pyro.condition(scale, data={\"measurement\": Variable(torch.ones(1))})\n",
+    "# equivalent to pyro.condition(scale, data={\"measurement\": Variable(torch.Tensor([9.5]))})\n",
     "def scale_obs(guess):\n",
     "    weight = pyro.sample(\"weight\", dist.Normal(guess, Variable(torch.ones(1))))\n",
     "     # here we attach an observation measurement == 9.5\n",


### PR DESCRIPTION
There is typo in `intro_part_ii.ipynb`.

I'm sorry if I misunderstand.
I'm a newbie and I'm enjoying the tutorial.