### PR TITLE
Fix node ordering after Trace.copy()

### DIFF
--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -23,6 +23,9 @@ def _warn_if_nan(name, value):
 class DiGraph(networkx.DiGraph):
     node_dict_factory = collections.OrderedDict
 
+    def fresh_copy(self):
+        return DiGraph()
+
 
 class Trace(object):
     """

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -20,6 +20,23 @@ from tests.common import assert_equal
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.parametrize("depth", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("graph_type", ["flat", "dense"])
+def test_iter_discrete_traces_order(depth, graph_type):
+
+    @config_enumerate
+    def model(depth):
+        for i in range(depth):
+            pyro.sample("x{}".format(i), dist.Bernoulli(0.5))
+
+    traces = list(iter_discrete_traces(graph_type, 0, model, depth))
+
+    assert len(traces) == 2 ** depth
+    for scale, trace in traces:
+        sites = [name for name, site in trace.nodes.items() if site["type"] == "sample"]
+        assert sites == ["x{}".format(i) for i in range(depth)]
+
+
 @pytest.mark.parametrize("graph_type", ["flat", "dense"])
 def test_iter_discrete_traces_scalar(graph_type):
     pyro.clear_param_store()


### PR DESCRIPTION
This fixes a node ordering bug introduced in #801, caused by the networkx bug https://github.com/networkx/networkx/issues/2889

## Tested

- added a regression test that fails before this PR and passes after