### PR TITLE
Improve documentation for distributions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -172,7 +172,10 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'torch': ('http://pytorch.org/docs/master/', None),
+}
 
 # document class constructors (__init__ methods):
 """ comment out this functionality for now;

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -6,16 +6,22 @@ Distributions
    :maxdepth: 2
    :caption: Contents:
 
-Primitive Distributions
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
 PyTorch Distributions
----------------------
+~~~~~~~~~~~~~~~~~~~~~
+
+Most distributions in Pyro are thin wrappers around PyTorch distributions.
+For details on the PyTorch distribution interface, see
+:class:`torch.distributions.Distribution`.
+For differences between the Pyro and PyTorch interfaces, see
+:class:`pyro.distributions.torch_distribution.TorchDistributionMixin`.
 
 .. automodule:: pyro.distributions.torch
     :members:
     :undoc-members:
-    :show-inheritance:
+    :special-members: __call__
+
+Primitive Distributions
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Abstract Distribution
 ---------------------
@@ -23,6 +29,7 @@ Abstract Distribution
 .. automodule:: pyro.distributions.distribution
     :members:
     :undoc-members:
+    :special-members: __call__
     :show-inheritance:
 
 TorchDistribution
@@ -31,6 +38,7 @@ TorchDistribution
 .. automodule:: pyro.distributions.torch_distribution
     :members:
     :undoc-members:
+    :special-members: __call__
     :show-inheritance:
     :member-order: bysource
 

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -5,7 +5,6 @@ import numbers
 import torch
 from torch.autograd import Variable
 
-from pyro.distributions.distribution import Distribution
 from pyro.distributions.torch_distribution import TorchDistributionMixin
 
 # These distributions require custom wrapping.

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -126,5 +126,5 @@ __doc__ = '\n\n'.join([
     ----------------------------------------------------------------
     .. autoclass:: {0}
     '''.format(_name)
-    for _name in __all__
+    for _name in sorted(__all__)
 ])

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -36,7 +36,7 @@ class TorchDistributionMixin(Distribution):
     def __call__(self, sample_shape=torch.Size()):
         """
         Samples a random value.
-        
+
         This is reparameterized whenever possible, calling
         :meth:`~torch.distributions.Distribution.rsample` for reparameterized
         distributions and :meth:`~torch.distributions.Distribution.sample` for

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -18,15 +18,29 @@ class TorchDistributionMixin(Distribution):
     """
     @property
     def reparameterized(self):
+        """
+        :return: Whether this distribution is reparameterized, i.e. whether
+            this distribution implements :meth:`rsample`.
+        :rtype: bool
+        """
         return self.has_rsample
 
     @property
     def enumerable(self):
+        """
+        :return: Whether this distribution implements :meth:`enumerate_support`
+        :rtype: bool
+        """
         return self.has_enumerate_support
 
     def __call__(self, sample_shape=torch.Size()):
         """
-        Samples a random value. This is reparameterized whenever possible.
+        Samples a random value.
+        
+        This is reparameterized whenever possible, calling
+        :meth:`~torch.distributions.Distribution.rsample` for reparameterized
+        distributions and :meth:`~torch.distributions.Distribution.sample` for
+        non-reparameterized distributions.
 
         :param sample_shape: the size of the iid batch to be drawn from the
             distribution.
@@ -218,7 +232,7 @@ class ReshapedDistribution(TorchDistribution):
 class MaskedDistribution(TorchDistribution):
     """
     Masks a distribution by a zero-one tensor that is broadcastable to the
-    distributions ``batch_shape``.
+    distribution's ``batch_shape``.
 
     :param Variable mask: A zero-one valued float tensor.
     """


### PR DESCRIPTION
This makes a few improvements to our distributions documentation, as promised to @karalets .
- uses intersphinx to link to PyTorch documentation (master)
- adds all PyTorch distributions to the TOC
- adds the `__call__` method to sphinx documentation
- documents a couple properties

See the results at http://fritzo.org/temp/pyro/html/distributions.html