### PR TITLE
Fix performance regression in queue

### DIFF
--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -189,7 +189,7 @@ def do(fn, data):
                         hide=list(data.keys()))
 
 
-def queue(fn, queue, extend_fn=None, escape_fn=None, num_samples=-1):
+def queue(fn, queue, extend_fn=None, escape_fn=None, num_samples=None):
     """
     :param fn: a stochastic function (callable containing pyro primitive calls)
     :param queue: a queue data structure like multiprocessing.Queue to hold partial traces
@@ -209,6 +209,9 @@ def queue(fn, queue, extend_fn=None, escape_fn=None, num_samples=-1):
 
     if escape_fn is None:
         escape_fn = util.discrete_escape
+
+    if num_samples is None:
+        num_samples = -1
 
     def _fn(*args, **kwargs):
 

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import functools
 
+from six.moves import xrange
+
 from pyro.poutine import util
 
 # poutines
@@ -189,8 +191,8 @@ def do(fn, data):
                         hide=list(data.keys()))
 
 
-def queue(fn, queue, max_tries=None,
-          extend_fn=None, escape_fn=None, num_samples=None):
+def queue(fn, queue, max_tries=int(1e6),
+          extend_fn=None, escape_fn=None, num_samples=-1):
     """
     :param fn: a stochastic function (callable containing pyro primitive calls)
     :param queue: a queue data structure like multiprocessing.Queue to hold partial traces
@@ -206,21 +208,15 @@ def queue(fn, queue, max_tries=None,
     return a return value from a complete trace in the queue
     """
 
-    if max_tries is None:
-        max_tries = int(1e6)
-
     if extend_fn is None:
         extend_fn = util.enum_extend
 
     if escape_fn is None:
         escape_fn = util.discrete_escape
 
-    if num_samples is None:
-        num_samples = -1
-
     def _fn(*args, **kwargs):
 
-        for i in range(max_tries):
+        for i in xrange(max_tries):
             assert not queue.empty(), \
                 "trying to get() from an empty queue will deadlock"
 

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -255,11 +255,6 @@ class QueuePoutineDiscreteTest(TestCase):
 
         assert true_latents == set(tr_latents)
 
-    def test_queue_max_tries(self):
-        f = poutine.queue(self.model, queue=self.queue, max_tries=3)
-        with pytest.raises(ValueError):
-            f()
-
 
 class Model(nn.Module):
     def __init__(self):


### PR DESCRIPTION
Addresses #839

This attempts to fix a performance regression in #775 by removing `max_tries` logic from `queue` and using cheaper `max_tries` logic in `Sample` (the only place `max_tries` is be used).