### PR TITLE
[Only for discussion] Explore possible ways to make Histogram faster

### DIFF
--- a/tests/infer/test_sampling.py
+++ b/tests/infer/test_sampling.py
@@ -93,7 +93,7 @@ class SearchTest(HMMSamplingTestCase):
         d, values = marginal._dist_and_values()
 
         tr_rets = []
-        for v in values:
+        for v in values.values():
             tr_rets.append(v.view(-1).item())
 
         assert len(tr_rets) == 4


### PR DESCRIPTION
While taking a look at why some sampling tests take so much time, I found that the source of the bottleneck is the `_eq` method that tries to repeatedly compare tensors. 

I replaced that by hashing the byte representation of the underlying `tensor.numpy()` arrays instead and that results in much faster tests. e.g. the `test_importance_guide` now finishes in 5 secs vs 341 secs earlier. I did some basic checks that seem to bear out, but I need to dig deeper into what guarantees we have by using this, and what bases it doesn't cover. Is something like this good enough for our use case? Can we do something more robust?

Note that there is currently an issue tracking hash functions for tensor data in PyTorch - https://github.com/pytorch/pytorch/issues/2569. 

cc. @eb8680 