### PR TITLE
Split TraceEnum_ELBO out of Trace_ELBO

### DIFF
--- a/examples/ss_vae_M2.py
+++ b/examples/ss_vae_M2.py
@@ -321,7 +321,8 @@ def run_inference_ss_vae(args):
     # set up the loss(es) for inference. wrapping the guide in config_enumerate builds the loss as a sum
     # by enumerating each class label for the sampled discrete categorical distribution in the model
     guide = config_enumerate(ss_vae.guide, args.enum_discrete)
-    loss_basic = SVI(ss_vae.model, guide, optimizer, loss="ELBO", max_iarange_nesting=1)
+    loss_basic = SVI(ss_vae.model, guide, optimizer, loss="ELBO",
+                     enum_discrete=True, max_iarange_nesting=1)
 
     # build a list of all losses considered
     losses = [loss_basic]

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -68,7 +68,7 @@ class Trace_ELBO(ELBO):
         elbo = 0.0
         # grab a trace from the generator
         for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
-            log_r = (model_trace.log_pdf() - guide_trace.log_pdf())
+            log_r = model_trace.log_pdf() - guide_trace.log_pdf()
             if not isinstance(log_r, numbers.Number):
                 log_r = log_r.detach()
 

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import numbers
 import warnings
 
 import pyro
@@ -67,7 +68,9 @@ class Trace_ELBO(ELBO):
         elbo = 0.0
         # grab a trace from the generator
         for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
-            log_r = (model_trace.log_pdf() - guide_trace.log_pdf()).detach()
+            log_r = (model_trace.log_pdf() - guide_trace.log_pdf())
+            if not isinstance(log_r, numbers.Number):
+                log_r = log_r.detach()
 
             elbo_particle = 0
             surrogate_elbo_particle = 0

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -1,17 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-import numbers
 import warnings
-
-import torch
 
 import pyro
 import pyro.poutine as poutine
-from pyro.distributions.util import is_identically_zero, sum_rightmost
+from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
-from pyro.infer.enum import iter_discrete_traces
-from pyro.infer.util import torch_backward, torch_data_sum, torch_sum
-from pyro.poutine.enumerate_poutine import EnumeratePoutine
 from pyro.poutine.util import prune_subsample_sites
 from pyro.util import check_model_guide_match, check_site_shape, is_nan
 
@@ -26,33 +20,24 @@ class Trace_ELBO(ELBO):
         runs the guide and runs the model against the guide with
         the result packaged as a trace generator
         """
-        # enable parallel enumeration
-        guide = EnumeratePoutine(guide, first_available_dim=self.max_iarange_nesting)
-
         for i in range(self.num_particles):
-            # iterate over a bag of traces, one trace per particle
-            for scale, guide_trace in iter_discrete_traces("flat", self.max_iarange_nesting, guide, *args, **kwargs):
-                model_trace = poutine.trace(poutine.replay(model, guide_trace),
-                                            graph_type="flat").get_trace(*args, **kwargs)
+            guide_trace = poutine.trace(guide).get_trace(*args, **kwargs)
+            model_trace = poutine.trace(poutine.replay(model, guide_trace)).get_trace(*args, **kwargs)
 
-                check_model_guide_match(model_trace, guide_trace)
-                guide_trace = prune_subsample_sites(guide_trace)
-                model_trace = prune_subsample_sites(model_trace)
+            check_model_guide_match(model_trace, guide_trace)
+            guide_trace = prune_subsample_sites(guide_trace)
+            model_trace = prune_subsample_sites(model_trace)
 
-                log_r = 0
-                model_trace.compute_batch_log_pdf()
-                for site in model_trace.nodes.values():
-                    if site["type"] == "sample":
-                        check_site_shape(site, self.max_iarange_nesting)
-                        log_r = log_r + sum_rightmost(site["batch_log_pdf"], self.max_iarange_nesting)
-                guide_trace.compute_score_parts()
-                for site in guide_trace.nodes.values():
-                    if site["type"] == "sample":
-                        check_site_shape(site, self.max_iarange_nesting)
-                        log_r = log_r - sum_rightmost(site["batch_log_pdf"], self.max_iarange_nesting)
+            model_trace.compute_batch_log_pdf()
+            guide_trace.compute_score_parts()
+            for site in model_trace.nodes.values():
+                if site["type"] == "sample":
+                    check_site_shape(site, self.max_iarange_nesting)
+            for site in guide_trace.nodes.values():
+                if site["type"] == "sample":
+                    check_site_shape(site, self.max_iarange_nesting)
 
-                weight = scale / self.num_particles
-                yield weight, model_trace, guide_trace, log_r
+            yield model_trace, guide_trace
 
     def loss(self, model, guide, *args, **kwargs):
         """
@@ -62,26 +47,9 @@ class Trace_ELBO(ELBO):
         Evaluates the ELBO with an estimator that uses num_particles many samples/particles.
         """
         elbo = 0.0
-        for weight, model_trace, guide_trace, log_r in self._get_traces(model, guide, *args, **kwargs):
-            elbo_particle = weight * 0
-            for name, model_site in model_trace.nodes.items():
-                if model_site["type"] == "sample":
-                    model_log_pdf = sum_rightmost(model_site["batch_log_pdf"], self.max_iarange_nesting)
-                    if model_site["is_observed"]:
-                        elbo_particle = elbo_particle + model_log_pdf
-                    else:
-                        guide_site = guide_trace.nodes[name]
-                        guide_log_pdf = sum_rightmost(guide_site["batch_log_pdf"], self.max_iarange_nesting)
-                        elbo_particle = elbo_particle + model_log_pdf - guide_log_pdf
-
-            # drop terms of weight zero to avoid nans
-            if isinstance(weight, numbers.Number):
-                if weight == 0.0:
-                    elbo_particle = torch.zeros_like(elbo_particle)
-            else:
-                elbo_particle[weight == 0] = 0.0
-
-            elbo += torch_data_sum(weight * elbo_particle)
+        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+            elbo_particle = (model_trace.log_pdf() - guide_trace.log_pdf()).item()
+            elbo += elbo_particle / self.num_particles
 
         loss = -elbo
         if is_nan(loss):
@@ -98,44 +66,32 @@ class Trace_ELBO(ELBO):
         """
         elbo = 0.0
         # grab a trace from the generator
-        for weight, model_trace, guide_trace, log_r in self._get_traces(model, guide, *args, **kwargs):
-            elbo_particle = weight * 0
-            surrogate_elbo_particle = weight * 0
+        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+            log_r = (model_trace.log_pdf() - guide_trace.log_pdf()).detach()
+
+            elbo_particle = 0
+            surrogate_elbo_particle = 0
             # compute elbo and surrogate elbo
             for name, model_site in model_trace.nodes.items():
                 if model_site["type"] == "sample":
-                    model_log_pdf = sum_rightmost(model_site["batch_log_pdf"], self.max_iarange_nesting)
+                    model_log_pdf = model_site["log_pdf"]
                     if model_site["is_observed"]:
-                        elbo_particle = elbo_particle + model_log_pdf
+                        elbo_particle = elbo_particle + model_log_pdf.item()
                         surrogate_elbo_particle = surrogate_elbo_particle + model_log_pdf
                     else:
                         guide_site = guide_trace.nodes[name]
                         guide_log_pdf, score_function_term, entropy_term = guide_site["score_parts"]
 
-                        guide_log_pdf = sum_rightmost(guide_log_pdf, self.max_iarange_nesting)
-                        elbo_particle = elbo_particle + model_log_pdf - guide_log_pdf
+                        elbo_particle = elbo_particle + model_log_pdf - guide_log_pdf.sum()
                         surrogate_elbo_particle = surrogate_elbo_particle + model_log_pdf
 
                         if not is_identically_zero(entropy_term):
-                            entropy_term = sum_rightmost(entropy_term, self.max_iarange_nesting)
-                            surrogate_elbo_particle -= entropy_term
+                            surrogate_elbo_particle -= entropy_term.sum()
 
                         if not is_identically_zero(score_function_term):
-                            score_function_term = sum_rightmost(score_function_term, self.max_iarange_nesting)
-                            surrogate_elbo_particle = surrogate_elbo_particle + log_r.detach() * score_function_term
+                            surrogate_elbo_particle = surrogate_elbo_particle + log_r * score_function_term.sum()
 
-            # drop terms of weight zero to avoid nans
-            if isinstance(weight, numbers.Number):
-                if weight == 0.0:
-                    elbo_particle = torch.zeros_like(elbo_particle)
-                    surrogate_elbo_particle = torch.zeros_like(surrogate_elbo_particle)
-            else:
-                weight_eq_zero = (weight == 0)
-                elbo_particle[weight_eq_zero] = 0.0
-                surrogate_elbo_particle[weight_eq_zero] = 0.0
-
-            elbo += torch_data_sum(weight * elbo_particle)
-            surrogate_elbo_particle = torch_sum(weight * surrogate_elbo_particle)
+            elbo += elbo_particle / self.num_particles
 
             # collect parameters to train from model and guide
             trainable_params = set(site["value"]
@@ -143,9 +99,9 @@ class Trace_ELBO(ELBO):
                                    for site in trace.nodes.values()
                                    if site["type"] == "param")
 
-            if trainable_params:
-                surrogate_loss_particle = -surrogate_elbo_particle
-                torch_backward(surrogate_loss_particle)
+            if trainable_params and getattr(surrogate_elbo_particle, 'requires_grad', False):
+                surrogate_loss_particle = -surrogate_elbo_particle / self.num_particles
+                surrogate_loss_particle.backward()
                 pyro.get_param_store().mark_params_active(trainable_params)
 
         loss = -elbo

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -1,0 +1,161 @@
+from __future__ import absolute_import, division, print_function
+
+import numbers
+import warnings
+
+import torch
+
+import pyro
+import pyro.poutine as poutine
+from pyro.distributions.util import is_identically_zero, sum_rightmost
+from pyro.infer.elbo import ELBO
+from pyro.infer.enum import iter_discrete_traces
+from pyro.infer.util import torch_data_sum, torch_sum
+from pyro.poutine.enumerate_poutine import EnumeratePoutine
+from pyro.poutine.util import prune_subsample_sites
+from pyro.util import check_model_guide_match, check_site_shape, is_nan
+
+
+class TraceEnum_ELBO(ELBO):
+    """
+    A trace implementation of ELBO-based SVI that supports enumeration
+    over discrete sample sites.
+
+    This implementation makes restricts the dependency
+    structure of the ``model`` and ``guide``:
+    Across :func:`~pyro.irange` and :func:`~pyro.iarange` blocks,
+    both dependency graphs should follow a tree structure. That is,
+    no variable outside of a block can depend on a variable in the block.
+    """
+
+    def _get_traces(self, model, guide, *args, **kwargs):
+        """
+        runs the guide and runs the model against the guide with
+        the result packaged as a trace generator
+        """
+        # enable parallel enumeration
+        guide = EnumeratePoutine(guide, first_available_dim=self.max_iarange_nesting)
+
+        for i in range(self.num_particles):
+            # iterate over a bag of traces, one trace per particle
+            for scale, guide_trace in iter_discrete_traces("flat", self.max_iarange_nesting, guide, *args, **kwargs):
+                model_trace = poutine.trace(poutine.replay(model, guide_trace),
+                                            graph_type="flat").get_trace(*args, **kwargs)
+
+                check_model_guide_match(model_trace, guide_trace)
+                guide_trace = prune_subsample_sites(guide_trace)
+                model_trace = prune_subsample_sites(model_trace)
+
+                log_r = 0
+                model_trace.compute_batch_log_pdf()
+                for site in model_trace.nodes.values():
+                    if site["type"] == "sample":
+                        check_site_shape(site, self.max_iarange_nesting)
+                        log_r = log_r + sum_rightmost(site["batch_log_pdf"], self.max_iarange_nesting)
+                guide_trace.compute_score_parts()
+                for site in guide_trace.nodes.values():
+                    if site["type"] == "sample":
+                        check_site_shape(site, self.max_iarange_nesting)
+                        log_r = log_r - sum_rightmost(site["batch_log_pdf"], self.max_iarange_nesting)
+
+                weight = scale / self.num_particles
+                yield weight, model_trace, guide_trace, log_r
+
+    def loss(self, model, guide, *args, **kwargs):
+        """
+        :returns: returns an estimate of the ELBO
+        :rtype: float
+
+        Evaluates the ELBO with an estimator that uses num_particles many samples/particles.
+        """
+        elbo = 0.0
+        for weight, model_trace, guide_trace, log_r in self._get_traces(model, guide, *args, **kwargs):
+            elbo_particle = weight * 0
+            for name, model_site in model_trace.nodes.items():
+                if model_site["type"] == "sample":
+                    model_log_pdf = sum_rightmost(model_site["batch_log_pdf"], self.max_iarange_nesting)
+                    if model_site["is_observed"]:
+                        elbo_particle = elbo_particle + model_log_pdf
+                    else:
+                        guide_site = guide_trace.nodes[name]
+                        guide_log_pdf = sum_rightmost(guide_site["batch_log_pdf"], self.max_iarange_nesting)
+                        elbo_particle = elbo_particle + model_log_pdf - guide_log_pdf
+
+            # drop terms of weight zero to avoid nans
+            if isinstance(weight, numbers.Number):
+                if weight == 0.0:
+                    elbo_particle = torch.zeros_like(elbo_particle)
+            else:
+                elbo_particle[weight == 0] = 0.0
+
+            elbo += torch_data_sum(weight * elbo_particle)
+
+        loss = -elbo
+        if is_nan(loss):
+            warnings.warn('Encountered NAN loss')
+        return loss
+
+    def loss_and_grads(self, model, guide, *args, **kwargs):
+        """
+        :returns: returns an estimate of the ELBO
+        :rtype: float
+
+        Computes the ELBO as well as the surrogate ELBO that is used to form the gradient estimator.
+        Performs backward on the latter. Num_particle many samples are used to form the estimators.
+        """
+        elbo = 0.0
+        # grab a trace from the generator
+        for weight, model_trace, guide_trace, log_r in self._get_traces(model, guide, *args, **kwargs):
+            elbo_particle = weight * 0
+            surrogate_elbo_particle = weight * 0
+            # compute elbo and surrogate elbo
+            for name, model_site in model_trace.nodes.items():
+                if model_site["type"] == "sample":
+                    model_log_pdf = sum_rightmost(model_site["batch_log_pdf"], self.max_iarange_nesting)
+                    if model_site["is_observed"]:
+                        elbo_particle = elbo_particle + model_log_pdf
+                        surrogate_elbo_particle = surrogate_elbo_particle + model_log_pdf
+                    else:
+                        guide_site = guide_trace.nodes[name]
+                        guide_log_pdf, score_function_term, entropy_term = guide_site["score_parts"]
+
+                        guide_log_pdf = sum_rightmost(guide_log_pdf, self.max_iarange_nesting)
+                        elbo_particle = elbo_particle + model_log_pdf - guide_log_pdf
+                        surrogate_elbo_particle = surrogate_elbo_particle + model_log_pdf
+
+                        if not is_identically_zero(entropy_term):
+                            entropy_term = sum_rightmost(entropy_term, self.max_iarange_nesting)
+                            surrogate_elbo_particle -= entropy_term
+
+                        if not is_identically_zero(score_function_term):
+                            score_function_term = sum_rightmost(score_function_term, self.max_iarange_nesting)
+                            surrogate_elbo_particle = surrogate_elbo_particle + log_r.detach() * score_function_term
+
+            # drop terms of weight zero to avoid nans
+            if isinstance(weight, numbers.Number):
+                if weight == 0.0:
+                    elbo_particle = torch.zeros_like(elbo_particle)
+                    surrogate_elbo_particle = torch.zeros_like(surrogate_elbo_particle)
+            else:
+                weight_eq_zero = (weight == 0)
+                elbo_particle[weight_eq_zero] = 0.0
+                surrogate_elbo_particle[weight_eq_zero] = 0.0
+
+            elbo += torch_data_sum(weight * elbo_particle)
+            surrogate_elbo_particle = torch_sum(weight * surrogate_elbo_particle)
+
+            # collect parameters to train from model and guide
+            trainable_params = set(site["value"]
+                                   for trace in (model_trace, guide_trace)
+                                   for site in trace.nodes.values()
+                                   if site["type"] == "param")
+
+            if trainable_params and getattr(surrogate_elbo_particle, 'requires_grad', False):
+                surrogate_loss_particle = -surrogate_elbo_particle
+                surrogate_loss_particle.backward()
+                pyro.get_param_store().mark_params_active(trainable_params)
+
+        loss = -elbo
+        if is_nan(loss):
+            warnings.warn('Encountered NAN loss')
+        return loss

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -21,7 +21,7 @@ class TraceEnum_ELBO(ELBO):
     A trace implementation of ELBO-based SVI that supports enumeration
     over discrete sample sites.
 
-    This implementation makes restricts the dependency
+    This implementation makes strong restrictions on the dependency
     structure of the ``model`` and ``guide``:
     Across :func:`~pyro.irange` and :func:`~pyro.iarange` blocks,
     both dependency graphs should follow a tree structure. That is,

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -456,7 +456,7 @@ def test_enum_discrete_single_ok():
         p = pyro.param("p", variable(0.5, requires_grad=True))
         pyro.sample("x", dist.Bernoulli(p))
 
-    assert_ok(model, config_enumerate(guide))
+    assert_ok(model, config_enumerate(guide), enum_discrete=True)
 
 
 def test_enum_discrete_single_single_ok():
@@ -471,7 +471,7 @@ def test_enum_discrete_single_single_ok():
         pyro.sample("x", dist.Bernoulli(p))
         pyro.sample("y", dist.Bernoulli(p))
 
-    assert_ok(model, config_enumerate(guide))
+    assert_ok(model, config_enumerate(guide), enum_discrete=True)
 
 
 def test_enum_discrete_irange_single_ok():
@@ -486,7 +486,7 @@ def test_enum_discrete_irange_single_ok():
         for i in pyro.irange("irange", 10, 5):
             pyro.sample("x_{}".format(i), dist.Bernoulli(p))
 
-    assert_ok(model, config_enumerate(guide))
+    assert_ok(model, config_enumerate(guide), enum_discrete=True)
 
 
 def test_iarange_enum_discrete_batch_ok():
@@ -501,7 +501,7 @@ def test_iarange_enum_discrete_batch_ok():
         with pyro.iarange("iarange", 10, 5) as ind:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
-    assert_ok(model, config_enumerate(guide))
+    assert_ok(model, config_enumerate(guide), enum_discrete=True)
 
 
 def test_iarange_enum_discrete_no_discrete_vars_ok():
@@ -518,7 +518,7 @@ def test_iarange_enum_discrete_no_discrete_vars_ok():
         with pyro.iarange("iarange", 10, 5) as ind:
             pyro.sample("x", dist.Normal(mu, sigma).reshape(sample_shape=[len(ind)]))
 
-    assert_ok(model, config_enumerate(guide))
+    assert_ok(model, config_enumerate(guide), enum_discrete=True)
 
 
 def test_no_iarange_enum_discrete_batch_error():
@@ -531,7 +531,7 @@ def test_no_iarange_enum_discrete_batch_error():
         p = pyro.param("p", variable(0.5, requires_grad=True))
         pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[5]))
 
-    assert_error(model, config_enumerate(guide))
+    assert_error(model, config_enumerate(guide), enum_discrete=True)
 
 
 @pytest.mark.parametrize('max_iarange_nesting', [0, 1, 2])
@@ -548,7 +548,7 @@ def test_enum_discrete_parallel_ok(max_iarange_nesting):
         x = pyro.sample("x", dist.Bernoulli(p))
         assert x.shape == torch.Size([2]) + iarange_shape
 
-    assert_ok(model, config_enumerate(guide, "parallel"),
+    assert_ok(model, config_enumerate(guide, "parallel"), enum_discrete=True,
               max_iarange_nesting=max_iarange_nesting)
 
 
@@ -564,7 +564,8 @@ def test_enum_discrete_parallel_nested_ok(max_iarange_nesting):
         assert x2.shape == torch.Size([2]) + iarange_shape + p2.shape
         assert x3.shape == torch.Size([3, 1]) + iarange_shape + p3.shape
 
-    assert_ok(model, config_enumerate(model, "parallel"), max_iarange_nesting=max_iarange_nesting)
+    assert_ok(model, config_enumerate(model, "parallel"), enum_discrete=True,
+              max_iarange_nesting=max_iarange_nesting)
 
 
 def test_enum_discrete_parallel_iarange_ok():
@@ -593,7 +594,8 @@ def test_enum_discrete_parallel_iarange_ok():
             assert x536.shape == torch.Size([6, 1, 1, 5, 3])  # noqa: E201
 
     enum_discrete = False
-    assert_ok(model, model, max_iarange_nesting=2)
+    assert_ok(model, model, enum_discrete=True, max_iarange_nesting=2)
 
     enum_discrete = True
-    assert_ok(model, config_enumerate(model, "parallel"), max_iarange_nesting=2)
+    assert_ok(model, config_enumerate(model, "parallel"), enum_discrete=True,
+              max_iarange_nesting=2)

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -50,8 +50,10 @@ def assert_warning(model, guide, **kwargs):
             logger.info(warning)
 
 
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_nonempty_model_empty_guide_ok(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_nonempty_model_empty_guide_ok(trace_graph, enum_discrete):
 
     def model():
         mu = Variable(torch.Tensor([0, 0]))
@@ -61,11 +63,13 @@ def test_nonempty_model_empty_guide_ok(trace_graph):
     def guide():
         pass
 
-    assert_ok(model, guide, trace_graph=trace_graph)
+    assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_empty_model_empty_guide_ok(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_empty_model_empty_guide_ok(trace_graph, enum_discrete):
 
     def model():
         pass
@@ -73,11 +77,13 @@ def test_empty_model_empty_guide_ok(trace_graph):
     def guide():
         pass
 
-    assert_ok(model, guide, trace_graph=trace_graph)
+    assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_variable_clash_in_model_error(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_variable_clash_in_model_error(trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -88,11 +94,13 @@ def test_variable_clash_in_model_error(trace_graph):
         p = pyro.param("p", variable(0.5, requires_grad=True))
         pyro.sample("x", dist.Bernoulli(p))
 
-    assert_error(model, guide, trace_graph=trace_graph)
+    assert_error(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_model_guide_dim_mismatch_error(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_model_guide_dim_mismatch_error(trace_graph, enum_discrete):
 
     def model():
         mu = Variable(torch.zeros(2))
@@ -104,11 +112,13 @@ def test_model_guide_dim_mismatch_error(trace_graph):
         sigma = pyro.param("sigma", Variable(torch.zeros(2, 1), requires_grad=True))
         pyro.sample("x", dist.Normal(mu, sigma))
 
-    assert_error(model, guide, trace_graph=trace_graph)
+    assert_error(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_model_guide_shape_mismatch_error(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_model_guide_shape_mismatch_error(trace_graph, enum_discrete):
 
     def model():
         mu = Variable(torch.zeros(1, 2))
@@ -120,11 +130,13 @@ def test_model_guide_shape_mismatch_error(trace_graph):
         sigma = pyro.param("sigma", Variable(torch.zeros(2, 1), requires_grad=True))
         pyro.sample("x", dist.Normal(mu, sigma))
 
-    assert_error(model, guide, trace_graph=trace_graph)
+    assert_error(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_variable_clash_in_guide_error(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_variable_clash_in_guide_error(trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -135,12 +147,14 @@ def test_variable_clash_in_guide_error(trace_graph):
         pyro.sample("x", dist.Bernoulli(p))
         pyro.sample("x", dist.Bernoulli(p))  # Should error here.
 
-    assert_error(model, guide, trace_graph=trace_graph)
+    assert_error(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_irange_ok(trace_graph, subsample_size):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_irange_ok(subsample_size, trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -152,11 +166,13 @@ def test_irange_ok(trace_graph, subsample_size):
         for i in pyro.irange("irange", 10, subsample_size):
             pyro.sample("x_{}".format(i), dist.Bernoulli(p))
 
-    assert_ok(model, guide, trace_graph=trace_graph)
+    assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_irange_variable_clash_error(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_irange_variable_clash_error(trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -170,12 +186,14 @@ def test_irange_variable_clash_error(trace_graph):
             # Each loop iteration should give the sample site a different name.
             pyro.sample("x", dist.Bernoulli(p))
 
-    assert_error(model, guide, trace_graph=trace_graph)
+    assert_error(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_iarange_ok(trace_graph, subsample_size):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_iarange_ok(subsample_size, trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -187,11 +205,13 @@ def test_iarange_ok(trace_graph, subsample_size):
         with pyro.iarange("iarange", 10, subsample_size) as ind:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
-    assert_ok(model, guide, trace_graph=trace_graph)
+    assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_iarange_no_size_ok(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_iarange_no_size_ok(trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -203,12 +223,14 @@ def test_iarange_no_size_ok(trace_graph):
         with pyro.iarange("iarange"):
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[10]))
 
-    assert_ok(model, guide, trace_graph=trace_graph)
+    assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_irange_irange_ok(trace_graph, subsample_size):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_irange_irange_ok(subsample_size, trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -222,12 +244,14 @@ def test_irange_irange_ok(trace_graph, subsample_size):
             for j in pyro.irange("irange_1", 10, subsample_size):
                 pyro.sample("x_{}_{}".format(i, j), dist.Bernoulli(p))
 
-    assert_ok(model, guide, trace_graph=trace_graph)
+    assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_irange_irange_swap_error(trace_graph, subsample_size):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_irange_irange_swap_error(subsample_size, trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -241,12 +265,14 @@ def test_irange_irange_swap_error(trace_graph, subsample_size):
             for i in pyro.irange("irange_0", 10, subsample_size):
                 pyro.sample("x_{}_{}".format(i, j), dist.Bernoulli(p))
 
-    assert_error(model, guide, trace_graph=trace_graph)
+    assert_error(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_irange_in_model_not_guide_ok(trace_graph, subsample_size):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_irange_in_model_not_guide_ok(subsample_size, trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -258,12 +284,14 @@ def test_irange_in_model_not_guide_ok(trace_graph, subsample_size):
         p = pyro.param("p", variable(0.5, requires_grad=True))
         pyro.sample("x", dist.Bernoulli(p))
 
-    assert_ok(model, guide, trace_graph=trace_graph)
+    assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_irange_in_guide_not_model_error(trace_graph, subsample_size):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_irange_in_guide_not_model_error(subsample_size, trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -275,7 +303,7 @@ def test_irange_in_guide_not_model_error(trace_graph, subsample_size):
             pass
         pyro.sample("x", dist.Bernoulli(p))
 
-    assert_error(model, guide, trace_graph=trace_graph)
+    assert_error(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
 @pytest.mark.xfail(reason="RaoBlackwellization checks in trace_poutine need to be fixed to catch this")
@@ -296,8 +324,10 @@ def test_iarange_irange_warning():
     assert_warning(model, guide, trace_graph=True)
 
 
-@pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
-def test_irange_iarange_ok(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_irange_iarange_ok(trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -311,11 +341,13 @@ def test_irange_iarange_ok(trace_graph):
             with pyro.iarange("iarange", 10, 5) as ind:
                 pyro.sample("x_{}".format(i), dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
-    assert_ok(model, guide, trace_graph=trace_graph)
+    assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize('trace_graph', [False, True])
-def test_nested_iarange_iarange_ok(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_nested_iarange_iarange_ok(trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5, requires_grad=True)
@@ -326,11 +358,13 @@ def test_nested_iarange_iarange_ok(trace_graph):
                 pyro.sample("y", dist.Bernoulli(p).reshape(sample_shape=[1, len(ind_outer)]))
                 pyro.sample("z", dist.Bernoulli(p).reshape(sample_shape=[len(ind_inner), len(ind_outer)]))
 
-    assert_ok(model, model, trace_graph=trace_graph)
+    assert_ok(model, model, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize('trace_graph', [False, True])
-def test_nested_iarange_iarange_dim_error_1(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_nested_iarange_iarange_dim_error_1(trace_graph, enum_discrete):
 
     def model():
         p = Variable(torch.Tensor([0.5]), requires_grad=True)
@@ -340,11 +374,13 @@ def test_nested_iarange_iarange_dim_error_1(trace_graph):
                 pyro.sample("y", dist.Bernoulli(p).reshape(sample_shape=[len(ind_inner)]))
                 pyro.sample("z", dist.Bernoulli(p).reshape(sample_shape=[len(ind_outer), len(ind_inner)]))
 
-    assert_error(model, model, trace_graph=trace_graph)
+    assert_error(model, model, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize('trace_graph', [False, True])
-def test_nested_iarange_iarange_dim_error_2(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_nested_iarange_iarange_dim_error_2(trace_graph, enum_discrete):
 
     def model():
         p = Variable(torch.Tensor([0.5]), requires_grad=True)
@@ -354,11 +390,13 @@ def test_nested_iarange_iarange_dim_error_2(trace_graph):
                 pyro.sample("y", dist.Bernoulli(p).reshape(sample_shape=[len(ind_outer)]))  # error here
                 pyro.sample("z", dist.Bernoulli(p).reshape(sample_shape=[len(ind_outer), len(ind_inner)]))
 
-    assert_error(model, model, trace_graph=trace_graph)
+    assert_error(model, model, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize('trace_graph', [False, True])
-def test_nested_iarange_iarange_dim_error_3(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_nested_iarange_iarange_dim_error_3(trace_graph, enum_discrete):
 
     def model():
         p = Variable(torch.Tensor([0.5]), requires_grad=True)
@@ -368,11 +406,13 @@ def test_nested_iarange_iarange_dim_error_3(trace_graph):
                 pyro.sample("y", dist.Bernoulli(p).reshape(sample_shape=[len(ind_inner)]))
                 pyro.sample("z", dist.Bernoulli(p).reshape(sample_shape=[len(ind_inner), 1]))  # error here
 
-    assert_error(model, model, trace_graph=trace_graph)
+    assert_error(model, model, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize('trace_graph', [False, True])
-def test_nested_iarange_iarange_dim_error_4(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_nested_iarange_iarange_dim_error_4(trace_graph, enum_discrete):
 
     def model():
         p = Variable(torch.Tensor([0.5]), requires_grad=True)
@@ -382,11 +422,13 @@ def test_nested_iarange_iarange_dim_error_4(trace_graph):
                 pyro.sample("y", dist.Bernoulli(p).reshape(sample_shape=[len(ind_inner)]))
                 pyro.sample("z", dist.Bernoulli(p).reshape(sample_shape=[len(ind_outer), len(ind_outer)]))  # error here
 
-    assert_error(model, model, trace_graph=trace_graph)
+    assert_error(model, model, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.parametrize('trace_graph', [False, True])
-def test_nonnested_iarange_iarange_ok(trace_graph):
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_nonnested_iarange_iarange_ok(trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5, requires_grad=True)
@@ -395,7 +437,7 @@ def test_nonnested_iarange_iarange_ok(trace_graph):
         with pyro.iarange("iarange_1", 11, 6) as ind2:
             pyro.sample("x1", dist.Bernoulli(p).reshape(sample_shape=[len(ind2)]))
 
-    assert_ok(model, model, trace_graph=trace_graph)
+    assert_ok(model, model, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
 def test_three_indep_iarange_at_different_depths_ok():

--- a/tutorial/source/gmm.ipynb
+++ b/tutorial/source/gmm.ipynb
@@ -113,7 +113,7 @@
    "outputs": [],
    "source": [
     "optim = pyro.optim.Adam({'lr': 0.2, 'betas': [0.9, 0.99]})\n",
-    "inference = SVI(model, config_enumerate(guide), optim, 'ELBO')"
+    "inference = SVI(model, config_enumerate(guide), optim, 'ELBO', enum_discrete=True)"
    ]
   },
   {

--- a/tutorial/source/ss-vae.ipynb
+++ b/tutorial/source/ss-vae.ipynb
@@ -225,7 +225,7 @@
     "\n",
     "This sum is usually implemented by hand, as in [1], but Pyro can automate this in many cases. To automatically sum out all discrete latent variables (here only ${\\bf y}$), we simply wrap the guide in `config_enumerate()`:\n",
     "```python\n",
-    "svi = SVI(model, config_enumerate(guide), optim, loss=\"ELBO\")\n",
+    "svi = SVI(model, config_enumerate(guide), optim, loss=\"ELBO\", enum_discrete=True)\n",
     "```\n",
     "In this mode of operation, each `svi.step(...)` computes a gradient term for each of the ten latent states of $y$. Although each step is thus $10\\times$ more expensive, we'll see that the lower-variance gradient estimate outweighs the additional cost.\n",
     "\n",


### PR DESCRIPTION
Addresses #847 

This PR:
1. renames `Trace_ELBO` to `TraceEnum_ELBO` (since it supports enumeration by default)
2. creates a new simple `Trace_ELBO` replicating old non-enumerating behavior
3. adds the `enum_discrete` flag back to `SVI`