### PR TITLE
Make cond_indep_stack a tuple (hence hashable)

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -74,7 +74,7 @@ def sample(name, fn, *args, **kwargs):
             "value": None,
             "infer": infer,
             "scale": 1.0,
-            "cond_indep_stack": [],
+            "cond_indep_stack": (),
             "done": False,
             "stop": False,
             "continuation": None
@@ -328,7 +328,7 @@ def param(name, *args, **kwargs):
             "kwargs": kwargs,
             "infer": {},
             "scale": 1.0,
-            "cond_indep_stack": [],
+            "cond_indep_stack": (),
             "value": None,
             "done": False,
             "stop": False,

--- a/pyro/poutine/indep_poutine.py
+++ b/pyro/poutine/indep_poutine.py
@@ -32,5 +32,6 @@ class IndepMessenger(Messenger):
         self.counter += 1
 
     def _process_message(self, msg):
-        msg["cond_indep_stack"].insert(0, CondIndepStackFrame(self.name, self.counter, self.vectorized, self.size))
+        frame = CondIndepStackFrame(self.name, self.counter, self.vectorized, self.size)
+        msg["cond_indep_stack"] = (frame,) + msg["cond_indep_stack"]
         return None

--- a/pyro/poutine/trace_poutine.py
+++ b/pyro/poutine/trace_poutine.py
@@ -21,7 +21,7 @@ def get_vectorized_map_data_info(trace):
         if site_is_subsample(node):
             continue
         if node["type"] in ("sample", "param"):
-            stack = tuple(node["cond_indep_stack"])
+            stack = node["cond_indep_stack"]
             vec_mds = [x for x in stack if x.vectorized]
             stack_dict[name] = vec_mds
 
@@ -29,7 +29,7 @@ def get_vectorized_map_data_info(trace):
         if site_is_subsample(node):
             continue
         if node["type"] in ("sample", "param"):
-            stack = tuple(node["cond_indep_stack"])
+            stack = node["cond_indep_stack"]
             vec_mds = [x for x in stack if x.vectorized]
             stack_dict[name] = vec_mds
             # check for nested vectorized map datas


### PR DESCRIPTION
This makes `site["cond_indep_stack"]` a tuple rather than a list.

## Why?

This makes `cond_indep_stack` hashable and therefore usable as keys in a dictionary. In #828 I'm converting `cond_indep_stack` to a tuple almost everywhere I use it. In an effort to simplify review of #828 I'm pulling out this change as an easy PR.