### PR TITLE
Using torch.tensor API in distributions module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install .
 
 For recent features you can install Pyro from source.
 
-First install a recent PyTorch, currently PyTorch commit `05269b5`.
+First install a recent PyTorch, currently PyTorch commit `8327982`.
 ```sh
 git clone git@github.com:pytorch/pytorch
 cd pytorch

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import torch
-from torch.autograd import Variable
 
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.util import broadcast_shape
@@ -15,7 +14,7 @@ class Delta(TorchDistribution):
     its support. Delta distribution parameterized by a random choice should not
     be used with MCMC based inference, as doing so produces incorrect results.
 
-    :param torch.autograd.Variable v: The single support element.
+    :param torch.Tensor v: The single support element.
     """
     has_rsample = True
     has_enumerate_support = True
@@ -23,8 +22,6 @@ class Delta(TorchDistribution):
 
     def __init__(self, v, *args, **kwargs):
         self.v = v
-        if not isinstance(self.v, Variable):
-            self.v = Variable(self.v)
         super(Delta, self).__init__(*args, **kwargs)
 
     @property
@@ -44,12 +41,12 @@ class Delta(TorchDistribution):
         """
         Returns the delta distribution's support, as a tensor along the first dimension.
 
-        :param v: torch variable where each element of the tensor represents the point at
+        :param v: torch tensor where each element of the tensor represents the point at
             which the delta distribution is concentrated.
-        :return: torch variable enumerating the support of the delta distribution.
-        :rtype: torch.autograd.Variable.
+        :return: torch tensor enumerating the support of the delta distribution.
+        :rtype: torch.Tensor.
         """
-        return Variable(self.v.data.unsqueeze(0))
+        return torch.tensor(self.v.data.unsqueeze(0))
 
     @property
     def mean(self):

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -37,11 +37,11 @@ class Distribution(object):
         """
         Samples a random value (just an alias for ``.sample(*args, **kwargs)``).
 
-        For tensor distributions, the returned Variable should have the same ``.size()`` as the
+        For tensor distributions, the returned tensor should have the same ``.size()`` as the
         parameters.
 
         :return: A random value.
-        :rtype: torch.autograd.Variable
+        :rtype: torch.Tensor
         """
         return self.sample(*args, **kwargs)
 
@@ -50,7 +50,7 @@ class Distribution(object):
         """
         Samples a random value.
 
-        For tensor distributions, the returned Variable should have the same ``.size()`` as the
+        For tensor distributions, the returned tensor should have the same ``.size()`` as the
         parameters, unless otherwise noted.
 
         :param sample_shape: the size of the iid batch to be drawn from the
@@ -58,7 +58,7 @@ class Distribution(object):
         :type sample_shape: torch.Size
         :return: A random value or batch of random values (if parameters are
             batched). The shape of the result should be ``self.size()``.
-        :rtype: torch.autograd.Variable
+        :rtype: torch.Tensor
         """
         raise NotImplementedError
 
@@ -67,12 +67,12 @@ class Distribution(object):
         """
         Evaluates log probability densities for each of a batch of samples.
 
-        :param torch.autograd.Variable x: A single value or a batch of values
+        :param torch.Tensor x: A single value or a batch of values
             batched along axis 0.
         :return: log probability densities as a one-dimensional
-            :class:`~torch.autograd.Variable` with same batch size as value and
+            :class:`~torch.Tensor` with same batch size as value and
             params. The shape of the result should be ``self.batch_size``.
-        :rtype: torch.autograd.Variable
+        :rtype: torch.Tensor
         """
         raise NotImplementedError
 
@@ -85,7 +85,7 @@ class Distribution(object):
         distributions should override this method to compute correct
         `.score_function` and `.entropy_term` parts.
 
-        :param torch.autograd.Variable x: A single value or batch of values.
+        :param torch.Tensor x: A single value or batch of values.
         :return: A `ScoreParts` object containing parts of the ELBO estimator.
         :rtype: ScoreParts
         """

--- a/pyro/distributions/multivariate_normal.py
+++ b/pyro/distributions/multivariate_normal.py
@@ -26,8 +26,8 @@ class MultivariateNormal(TorchDistribution):
     A distribution over vectors in which all the elements have a joint Gaussian
     density.
 
-    :param torch.autograd.Variable loc: Mean.
-    :param torch.autograd.Variable covariance_matrix: Covariance matrix.
+    :param torch.Tensor loc: Mean.
+    :param torch.Tensor covariance_matrix: Covariance matrix.
         Must be symmetric and positive semidefinite.
     """
     params = {"loc": constraints.real, "scale_tril": constraints.lower_triangular}

--- a/pyro/distributions/omt_mvn.py
+++ b/pyro/distributions/omt_mvn.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import torch
-from torch.autograd import Function, variable
+from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 
@@ -17,8 +17,8 @@ class OMTMultivariateNormal(MultivariateNormal):
     A distribution over vectors in which all the elements have a joint Gaussian
     density.
 
-    :param torch.autograd.Variable loc: Mean.
-    :param torch.autograd.Variable scale_tril: Cholesky of Covariance matrix.
+    :param torch.Tensor loc: Mean.
+    :param torch.Tensor scale_tril: Cholesky of Covariance matrix.
     """
     params = {"loc": constraints.real, "scale_tril": constraints.lower_triangular}
 
@@ -53,7 +53,7 @@ class _OMTMVNSample(Function):
         g = grad_output
         loc_grad = sum_leftmost(grad_output, -1)
 
-        identity = torch.eye(dim, out=variable(g.new(dim, dim)))
+        identity = torch.eye(dim, out=torch.tensor(g.new(dim, dim)))
         R_inv = torch.trtrs(identity, L.t(), transpose=False, upper=True)[0]
 
         z_ja = z.unsqueeze(-1)

--- a/pyro/distributions/sparse_multivariate_normal.py
+++ b/pyro/distributions/sparse_multivariate_normal.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import math
 
 import torch
-from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.distributions.utils import lazy_property
 
@@ -23,11 +22,11 @@ class SparseMultivariateNormal(TorchDistribution):
     Here D is a diagonal vector and ``W`` is a matrix of size ``M x N``. The
     computation will be beneficial when ``M << N``.
 
-    :param torch.autograd.Variable loc: Mean.
+    :param torch.Tensor loc: Mean.
         Must be in 1 dimensional of size N.
-    :param torch.autograd.Variable D_term: D term of covariance matrix.
+    :param torch.Tensor D_term: D term of covariance matrix.
         Must be in 1 dimensional of size N.
-    :param torch.autograd.Variable W_term: W term of covariance matrix.
+    :param torch.Tensor W_term: W term of covariance matrix.
         Must be in 2 dimensional of size M x N.
     :param float trace_term: A optional term to be added into Mahalabonis term
         according to p(y) = N(y|loc, cov).exp(-1/2 * trace_term).
@@ -71,7 +70,7 @@ class SparseMultivariateNormal(TorchDistribution):
         A = self.covariance_matrix_W_term / Dsqrt
         At_A = A.t().matmul(A)
         N = A.size(1)
-        Id = Variable(torch.eye(N, N, out=A.data.new(N, N)))
+        Id = torch.eye(N, N, out=A.data.new(N, N))
         K = Id + At_A
         L = K.potrf(upper=False)
         return Dsqrt.unsqueeze(1) * L
@@ -98,7 +97,7 @@ class SparseMultivariateNormal(TorchDistribution):
         """
         W_Dinv = W / D
         M = W.size(0)
-        Id = torch.eye(M, M, out=Variable(W.data.new(M, M)))
+        Id = torch.eye(M, M, out=torch.tensor(W.data.new(M, M)))
         K = Id + W_Dinv.matmul(W.t())
         L = K.potrf(upper=False)
         if y.dim() == 1:

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import numbers
 
 import torch
-from torch.autograd import Variable
 
 from pyro.distributions.torch_distribution import TorchDistributionMixin
 
@@ -60,12 +59,10 @@ class LogNormal(torch.distributions.LogNormal, TorchDistributionMixin):
 
 class Multinomial(torch.distributions.Multinomial, TorchDistributionMixin):
     def __init__(self, ps, n=1):
-        if isinstance(n, Variable):
-            n = n.data
         if not isinstance(n, numbers.Number):
             if n.max() != n.min():
                 raise NotImplementedError('inhomogeneous n is not supported')
-            n = n.view(-1)[0]
+            n = n.data.view(-1)[0]
         n = int(n)
         super(Multinomial, self).__init__(n, probs=ps)
 

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -50,7 +50,7 @@ class TorchDistributionMixin(Distribution):
         :type sample_shape: torch.Size
         :return: A random value or batch of random values (if parameters are
             batched). The shape of the result should be `self.shape()`.
-        :rtype: torch.autograd.Variable
+        :rtype: torch.Tensor
         """
         return self.rsample(sample_shape) if self.has_rsample else self.sample(sample_shape)
 
@@ -98,7 +98,7 @@ class TorchDistributionMixin(Distribution):
         Masks a distribution by a zero-one tensor that is broadcastable to the
         distributions :attr:`~torch.distributions.distribution.Distribution.batch_shape`.
 
-        :param Variable mask: A zero-one valued float tensor.
+        :param torch.Tensor mask: A zero-one valued float tensor.
         :return: A masked copy of this distribution.
         :rtype: :class:`MaskedDistribution`
         """
@@ -119,8 +119,8 @@ class TorchDistribution(torch.distributions.Distribution, TorchDistributionMixin
 
     .. note::
 
-        Parameters and data should be of type :class:`~torch.autograd.Variable`
-        and all methods return type :class:`~torch.autograd.Variable` unless
+        Parameters and data should be of type :class:`~torch.Tensor`
+        and all methods return type :class:`~torch.Tensor` unless
         otherwise noted.
 
     **Tensor Shapes**:
@@ -252,7 +252,7 @@ class MaskedDistribution(TorchDistribution):
     Masks a distribution by a zero-one tensor that is broadcastable to the
     distribution's :attr:`~torch.distributions.distribution.Distribution.batch_shape`.
 
-    :param Variable mask: A zero-one valued float tensor.
+    :param torch.Tensor mask: A zero-one valued float tensor.
     """
     def __init__(self, base_dist, mask):
         if broadcast_shape(mask.shape, base_dist.batch_shape) != base_dist.batch_shape:

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -4,7 +4,6 @@ import numbers
 
 import torch
 import torch.nn.functional as F
-from torch.autograd import Variable
 
 
 def copy_docs_from(source_class, full_text=False):
@@ -48,7 +47,7 @@ def copy_docs_from(source_class, full_text=False):
 def is_identically_zero(x):
     """
     Check if argument is exactly the number zero. True for the number zero;
-    false for other numbers; false for :class:`~torch.autograd.Variable`s.
+    false for other numbers; false for :class:`~torch.Tensor`s.
     """
     return isinstance(x, numbers.Number) and x == 0
 
@@ -56,7 +55,7 @@ def is_identically_zero(x):
 def is_identically_one(x):
     """
     Check if argument is exactly the number one. True for the number one;
-    false for other numbers; false for :class:`~torch.autograd.Variable`s.
+    false for other numbers; false for :class:`~torch.Tensor`s.
     """
     return isinstance(x, numbers.Number) and x == 1
 
@@ -98,7 +97,7 @@ def sum_rightmost(value, dim):
     If ``dim`` is -2, all but the leftmost 2 dimensions are summed out.
     etc.
 
-    :param torch.autograd.Variable value: A tensor of ``.dim()`` at least ``dim``.
+    :param torch.Tensor value: A tensor of ``.dim()`` at least ``dim``.
     :param int dim: The number of rightmost dims to sum out.
     """
     if isinstance(value, numbers.Number):
@@ -130,7 +129,7 @@ def sum_leftmost(value, dim):
         assert sum_leftmost(x, 1).shape == (3, 4)
         assert sum_leftmost(x, -1).shape == (4,)
 
-    :param torch.autograd.Variable value: A tensor
+    :param torch.Tensor value: A tensor
     :param int dim: Specifies the number of dims to sum out
     """
     if isinstance(value, numbers.Number):
@@ -235,8 +234,6 @@ def softmax(x, dim=-1):
 
 def _get_clamping_buffer(tensor):
     clamp_eps = 1e-6
-    if isinstance(tensor, Variable):
-        tensor = tensor.data
     if isinstance(tensor, (torch.DoubleTensor, torch.cuda.DoubleTensor)):
         clamp_eps = 1e-15
     return clamp_eps

--- a/tests/distributions/dist_fixture.py
+++ b/tests/distributions/dist_fixture.py
@@ -4,7 +4,6 @@ import math
 
 import numpy as np
 import torch
-from torch.autograd import Variable
 
 from pyro.distributions.util import get_probs_and_logits, broadcast_shape
 
@@ -72,7 +71,7 @@ class Fixture(object):
 
     def _convert_logits_to_ps(self, dist_params):
         if 'logits' in dist_params:
-            logits = Variable(torch.Tensor(dist_params.pop('logits')))
+            logits = torch.tensor(dist_params.pop('logits'))
             is_multidimensional = self.get_test_distribution_name() != 'Bernoulli'
             ps, _ = get_probs_and_logits(logits=logits, is_multidimensional=is_multidimensional)
             dist_params['ps'] = list(ps.detach().cpu().numpy())
@@ -149,11 +148,11 @@ class Fixture(object):
 def tensor_wrap(*args, **kwargs):
     tensor_list, tensor_map = [], {}
     for arg in args:
-        wrapped_arg = Variable(torch.Tensor(arg)) if isinstance(arg, list) else arg
+        wrapped_arg = torch.tensor(arg) if isinstance(arg, list) else arg
         tensor_list.append(wrapped_arg)
     for k in kwargs:
         kwarg = kwargs[k]
-        wrapped_kwarg = Variable(torch.Tensor(kwarg)) if isinstance(kwarg, list) else kwarg
+        wrapped_kwarg = torch.tensor(kwarg) if isinstance(kwarg, list) else kwarg
         tensor_map[k] = wrapped_kwarg
     if args and not kwargs:
         return tensor_list

--- a/tests/distributions/test_categorical.py
+++ b/tests/distributions/test_categorical.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 import scipy.stats as sp
 import torch
-from torch.autograd import Variable
 
 import pyro.distributions as dist
 from tests.common import assert_equal
@@ -19,22 +18,22 @@ class TestCategorical(TestCase):
 
     def setUp(self):
         n = 1
-        self.ps = Variable(torch.Tensor([0.1, 0.6, 0.3]))
-        self.batch_ps = Variable(torch.Tensor([[0.1, 0.6, 0.3], [0.2, 0.4, 0.4]]))
-        self.n = Variable(torch.Tensor([n]))
-        self.test_data = Variable(torch.Tensor([2]))
+        self.ps = torch.tensor([0.1, 0.6, 0.3])
+        self.batch_ps = torch.tensor([[0.1, 0.6, 0.3], [0.2, 0.4, 0.4]])
+        self.n = torch.tensor([n])
+        self.test_data = torch.tensor([2])
         self.analytic_mean = n * self.ps
-        one = Variable(torch.ones(3))
+        one = torch.ones(3)
         self.analytic_var = n * torch.mul(self.ps, one.sub(self.ps))
 
         # Discrete Distribution
-        self.d_ps = Variable(torch.Tensor([[0.2, 0.3, 0.5], [0.1, 0.1, 0.8]]))
-        self.d_test_data = Variable(torch.Tensor([[0], [5]]))
+        self.d_ps = torch.tensor([[0.2, 0.3, 0.5], [0.1, 0.1, 0.8]])
+        self.d_test_data = torch.tensor([[0], [5]])
 
         self.n_samples = 50000
 
-        self.support_non_vec = torch.Tensor([0, 1, 2])
-        self.support = torch.Tensor([[0, 0], [1, 1], [2, 2]])
+        self.support_non_vec = torch.tensor([0, 1, 2])
+        self.support = torch.tensor([[0, 0], [1, 1], [2, 2]])
 
     def test_log_pdf(self):
         log_px_torch = dist.Categorical(self.ps).log_prob(self.test_data).sum().item()
@@ -74,7 +73,7 @@ def ps(request):
 
 
 def modify_params_using_dims(ps, dim):
-    return Variable(torch.Tensor(wrap_nested(ps, dim-1)))
+    return torch.tensor(wrap_nested(ps, dim-1))
 
 
 def test_support_dims(dim, ps):

--- a/tests/distributions/test_delta.py
+++ b/tests/distributions/test_delta.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 
 import numpy as np
 import torch
-from torch.autograd import Variable
 
 import pyro.distributions as dist
 from tests.common import assert_equal
@@ -12,13 +11,13 @@ from tests.common import assert_equal
 
 class TestDelta(TestCase):
     def setUp(self):
-        self.v = Variable(torch.Tensor([3]))
-        self.vs = Variable(torch.Tensor([[0], [1], [2], [3]]))
+        self.v = torch.tensor([3])
+        self.vs = torch.tensor([[0], [1], [2], [3]])
         self.vs_expanded = self.vs.expand(4, 3)
-        self.test_data = Variable(torch.Tensor([[3], [3], [3]]))
-        self.batch_test_data_1 = Variable(torch.arange(0, 4).unsqueeze(1).expand(4, 3))
-        self.batch_test_data_2 = Variable(torch.arange(4, 8).unsqueeze(1).expand(4, 3))
-        self.batch_test_data_3 = Variable(torch.Tensor([[3], [3], [3], [3]]))
+        self.test_data = torch.tensor([[3], [3], [3]])
+        self.batch_test_data_1 = torch.arange(0, 4).unsqueeze(1).expand(4, 3)
+        self.batch_test_data_2 = torch.arange(4, 8).unsqueeze(1).expand(4, 3)
+        self.batch_test_data_3 = torch.Tensor([[3], [3], [3], [3]])
         self.expected_support = [[[0], [1], [2], [3]]]
         self.expected_support_non_vec = [[3]]
         self.analytic_mean = 3
@@ -52,5 +51,5 @@ class TestDelta(TestCase):
         actual_support_non_vec = dist.Delta(self.v).enumerate_support()
         assert len(actual_support) == 1
         assert len(actual_support_non_vec) == 1
-        assert_equal(actual_support.data, torch.Tensor(self.expected_support))
-        assert_equal(actual_support_non_vec.data, torch.Tensor(self.expected_support_non_vec))
+        assert_equal(actual_support.data, torch.tensor(self.expected_support))
+        assert_equal(actual_support_non_vec.data, torch.tensor(self.expected_support_non_vec))

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -8,10 +8,6 @@ from pyro.distributions.util import broadcast_shape
 from tests.common import assert_equal, xfail_if_not_implemented
 
 
-def _unwrap_variable(x):
-    return x.detach().cpu().numpy()
-
-
 def _log_prob_shape(dist, x_size=torch.Size()):
     event_dims = len(dist.event_shape)
     expected_shape = broadcast_shape(dist.shape(), x_size, strict=True)
@@ -29,7 +25,7 @@ def test_batch_log_prob(dist):
         dist_params = dist.get_dist_params(idx)
         d = dist.pyro_dist(**dist_params)
         test_data = dist.get_test_data(idx)
-        log_prob_sum_pyro = _unwrap_variable(d.log_prob(test_data)).sum()
+        log_prob_sum_pyro = d.log_prob(test_data).sum().item()
         log_prob_sum_np = np.sum(dist.get_scipy_batch_logpdf(-1))
         assert_equal(log_prob_sum_pyro, log_prob_sum_np)
 

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -5,7 +5,6 @@ import pytest
 import torch
 
 from pyro.distributions.util import broadcast_shape
-from pyro.util import ng_ones
 from tests.common import assert_equal, xfail_if_not_implemented
 
 
@@ -51,7 +50,7 @@ def test_score_errors_event_dim_mismatch(dist):
     for idx in dist.get_batch_data_indices():
         dist_params = dist.get_dist_params(idx)
         d = dist.pyro_dist(**dist_params)
-        test_data_wrong_dims = ng_ones(d.shape() + (1,))
+        test_data_wrong_dims = torch.ones(d.shape() + (1,))
         if len(d.event_shape) > 0:
             if dist.get_test_distribution_name() == 'MultivariateNormal':
                 pytest.skip('MultivariateNormal does not do shape validation in log_prob.')
@@ -67,7 +66,7 @@ def test_score_errors_non_broadcastable_data_shape(dist):
         d = dist.pyro_dist(**dist_params)
         shape = d.shape()
         non_broadcastable_shape = (shape[0] + 1,) + shape[1:]
-        test_data_non_broadcastable = ng_ones(non_broadcastable_shape)
+        test_data_non_broadcastable = torch.ones(non_broadcastable_shape)
         with pytest.raises((ValueError, RuntimeError)):
             d.log_prob(test_data_non_broadcastable)
 
@@ -82,5 +81,5 @@ def test_enumerate_support(discrete_dist):
     Dist = discrete_dist.pyro_dist
     actual_support_non_vec = Dist(**discrete_dist.get_dist_params(0)).enumerate_support()
     actual_support = Dist(**discrete_dist.get_dist_params(-1)).enumerate_support()
-    assert_equal(actual_support.data, torch.Tensor(expected_support))
-    assert_equal(actual_support_non_vec.data, torch.Tensor(expected_support_non_vec))
+    assert_equal(actual_support.data, torch.tensor(expected_support))
+    assert_equal(actual_support_non_vec.data, torch.tensor(expected_support_non_vec))

--- a/tests/distributions/test_iaf.py
+++ b/tests/distributions/test_iaf.py
@@ -5,7 +5,6 @@ from unittest import TestCase
 import numpy as np
 import pytest
 import torch
-from torch.autograd import Variable
 
 from pyro.distributions.iaf import InverseAutoregressiveFlow
 from pyro.nn import AutoRegressiveNN
@@ -24,7 +23,7 @@ class InverseAutoregressiveFlowTests(TestCase):
         def nonzero(x):
             return torch.sign(torch.abs(x))
 
-        x = Variable(torch.randn(1, input_dim))
+        x = torch.randn(1, input_dim)
         iaf_x = iaf(x)
         analytic_ldt = iaf.log_abs_det_jacobian(x, iaf_x).data.sum()
 
@@ -32,7 +31,7 @@ class InverseAutoregressiveFlowTests(TestCase):
             for k in range(input_dim):
                 epsilon_vector = torch.zeros(1, input_dim)
                 epsilon_vector[0, j] = self.epsilon
-                iaf_x_eps = iaf(x + Variable(epsilon_vector))
+                iaf_x_eps = iaf(x + epsilon_vector)
                 delta = (iaf_x_eps - iaf_x) / self.epsilon
                 jacobian[j, k] = float(delta[0, k].data.sum())
 
@@ -71,10 +70,10 @@ class AutoRegressiveNNTests(TestCase):
         for output_index in range(multiplier):
             for j in range(input_dim):
                 for k in range(input_dim):
-                    x = Variable(torch.randn(1, input_dim))
+                    x = torch.randn(1, input_dim)
                     epsilon_vector = torch.zeros(1, input_dim)
                     epsilon_vector[0, j] = self.epsilon
-                    delta = (arn(x + Variable(epsilon_vector)) - arn(x)) / self.epsilon
+                    delta = (arn(x + epsilon_vector) - arn(x)) / self.epsilon
                     jacobian[j, k] = float(delta[0, k + output_index * input_dim])
 
             permutation = arn.get_permutation()

--- a/tests/distributions/test_mask.py
+++ b/tests/distributions/test_mask.py
@@ -2,16 +2,16 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 import torch
-from torch.autograd import Variable, variable
+from torch import tensor
 
 from pyro.distributions.torch import Bernoulli
 from tests.common import assert_equal
 
 
 def checker_mask(shape):
-    mask = variable(0)
+    mask = tensor(0)
     for size in shape:
-        mask = mask.unsqueeze(-1) + Variable(torch.arange(size))
+        mask = mask.unsqueeze(-1) + torch.arange(size)
     return mask.fmod(2)
 
 

--- a/tests/distributions/test_omt_mvn.py
+++ b/tests/distributions/test_omt_mvn.py
@@ -5,7 +5,6 @@ import pytest
 import numpy as np
 
 import torch
-from torch.autograd import Variable
 
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
 from pyro.distributions import MultivariateNormal
@@ -26,11 +25,11 @@ def analytic_grad(L11=1.0, L22=1.0, L21=1.0, omega1=1.0, omega2=1.0):
 @pytest.mark.parametrize('omega1', [0.5, 0.9])
 @pytest.mark.parametrize('sample_shape', [torch.Size([1000, 1000]), torch.Size([100000])])
 def test_mean_gradient(sample_shape, L21, omega1, L11, L22=0.8, L33=0.9, omega2=0.75):
-    omega = Variable(torch.Tensor([omega1, omega2, 0.0]))
-    mu = Variable(torch.zeros(3), requires_grad=True)
+    omega = torch.tensor([omega1, omega2, 0.0])
+    mu = torch.zeros(3, requires_grad=True)
     zero_vec = [0.0, 0.0, 0.0]
-    off_diag = Variable(torch.Tensor([zero_vec, [L21, 0.0, 0.0], zero_vec]), requires_grad=True)
-    L = Variable(torch.diag(torch.Tensor([L11, L22, L33]))) + off_diag
+    off_diag = torch.tensor([zero_vec, [L21, 0.0, 0.0], zero_vec], requires_grad=True)
+    L = torch.diag(torch.tensor([L11, L22, L33])) + off_diag
 
     dist = OMTMultivariateNormal(mu, L)
     z = dist.rsample(sample_shape)
@@ -47,10 +46,10 @@ def test_mean_gradient(sample_shape, L21, omega1, L11, L22=0.8, L33=0.9, omega2=
 
 
 def test_log_prob():
-    loc = Variable(torch.Tensor([2, 1, 1, 2, 2]))
-    D = Variable(torch.Tensor([1, 2, 3, 1, 3]))
-    W = Variable(torch.Tensor([[1, -1, 2, 2, 4], [2, 1, 1, 2, 6]]))
-    x = Variable(torch.Tensor([2, 3, 4, 1, 7]))
+    loc = torch.tensor([2, 1, 1, 2, 2])
+    D = torch.tensor([1, 2, 3, 1, 3])
+    W = torch.tensor([[1, -1, 2, 2, 4], [2, 1, 1, 2, 6]])
+    x = torch.tensor([2, 3, 4, 1, 7])
     L = D.diag() + torch.tril(W.t().matmul(W))
     cov = torch.mm(L, L.t())
 

--- a/tests/distributions/test_one_hot_categorical.py
+++ b/tests/distributions/test_one_hot_categorical.py
@@ -5,7 +5,6 @@ from unittest import TestCase
 import numpy as np
 import pytest
 import torch
-from torch.autograd import Variable
 
 import pyro.distributions as dist
 from tests.common import assert_equal
@@ -18,30 +17,30 @@ class TestOneHotCategorical(TestCase):
 
     def setUp(self):
         n = 1
-        self.ps = Variable(torch.Tensor([0.1, 0.6, 0.3]))
-        self.batch_ps = Variable(torch.Tensor([[0.1, 0.6, 0.3], [0.2, 0.4, 0.4]]))
-        self.n = Variable(torch.Tensor([n]))
-        self.test_data = Variable(torch.Tensor([0, 1, 0]))
-        self.test_data_nhot = Variable(torch.Tensor([2]))
+        self.ps = torch.tensor([0.1, 0.6, 0.3])
+        self.batch_ps = torch.tensor([[0.1, 0.6, 0.3], [0.2, 0.4, 0.4]])
+        self.n = torch.tensor([n])
+        self.test_data = torch.tensor([0, 1, 0])
+        self.test_data_nhot = torch.tensor([2])
         self.analytic_mean = n * self.ps
-        one = Variable(torch.ones(3))
+        one = torch.ones(3)
         self.analytic_var = n * torch.mul(self.ps, one.sub(self.ps))
 
         # Discrete Distribution
-        self.d_ps = Variable(torch.Tensor([[0.2, 0.3, 0.5], [0.1, 0.1, 0.8]]))
-        self.d_test_data = Variable(torch.Tensor([[0], [5]]))
+        self.d_ps = torch.tensor([[0.2, 0.3, 0.5], [0.1, 0.1, 0.8]])
+        self.d_test_data = torch.tensor([[0], [5]])
         self.d_v_test_data = [['a'], ['f']]
 
         self.n_samples = 50000
 
-        self.support_one_hot_non_vec = torch.Tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-        self.support_one_hot = torch.Tensor([[[1, 0, 0], [1, 0, 0]],
+        self.support_one_hot_non_vec = torch.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        self.support_one_hot = torch.tensor([[[1, 0, 0], [1, 0, 0]],
                                              [[0, 1, 0], [0, 1, 0]],
                                              [[0, 0, 1], [0, 0, 1]]])
         self.support_non_vec = torch.LongTensor([[0], [1], [2]])
         self.support = torch.LongTensor([[[0], [0]], [[1], [1]], [[2], [2]]])
-        self.discrete_support_non_vec = torch.Tensor([[0], [1], [2]])
-        self.discrete_support = torch.Tensor([[[0], [3]], [[1], [4]], [[2], [5]]])
+        self.discrete_support_non_vec = torch.tensor([[0], [1], [2]])
+        self.discrete_support = torch.tensor([[[0], [3]], [[1], [4]], [[2], [5]]])
         self.discrete_arr_support_non_vec = [['a'], ['b'], ['c']]
         self.discrete_arr_support = [[['a'], ['d']], [['b'], ['e']], [['c'], ['f']]]
 
@@ -80,7 +79,7 @@ def ps(request):
 
 
 def modify_params_using_dims(ps, dim):
-    return Variable(torch.Tensor(wrap_nested(ps, dim-1)))
+    return torch.tensor(wrap_nested(ps, dim-1))
 
 
 def test_support_dims(dim, ps):

--- a/tests/distributions/test_one_hot_categorical.py
+++ b/tests/distributions/test_one_hot_categorical.py
@@ -61,10 +61,7 @@ def wrap_nested(x, dim):
 
 def assert_correct_dimensions(sample, ps):
     ps_shape = list(ps.data.size())
-    if isinstance(sample, torch.autograd.Variable):
-        sample_shape = list(sample.data.size())
-    else:
-        sample_shape = list(sample.shape)
+    sample_shape = list(sample.shape)
     assert_equal(sample_shape, ps_shape)
 
 

--- a/tests/distributions/test_rejector.py
+++ b/tests/distributions/test_rejector.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 import torch
-from torch.autograd import Variable, grad
+from torch.autograd import grad
 
 from pyro.distributions import Exponential, Gamma
 from pyro.distributions.testing.rejection_exponential import RejectionExponential
@@ -16,7 +16,7 @@ SIZES = list(map(torch.Size, [[], [1], [2], [3], [1, 1], [1, 2], [2, 3, 4]]))
 @pytest.mark.parametrize('sample_shape', SIZES)
 @pytest.mark.parametrize('batch_shape', filter(bool, SIZES))
 def test_rejection_standard_gamma_sample_shape(sample_shape, batch_shape):
-    alphas = Variable(torch.ones(batch_shape))
+    alphas = torch.ones(batch_shape)
     dist = RejectionStandardGamma(alphas)
     x = dist.rsample(sample_shape)
     assert x.shape == sample_shape + batch_shape
@@ -25,8 +25,8 @@ def test_rejection_standard_gamma_sample_shape(sample_shape, batch_shape):
 @pytest.mark.parametrize('sample_shape', SIZES)
 @pytest.mark.parametrize('batch_shape', filter(bool, SIZES))
 def test_rejection_exponential_sample_shape(sample_shape, batch_shape):
-    rates = Variable(torch.ones(batch_shape))
-    factors = Variable(torch.ones(batch_shape)) * 0.5
+    rates = torch.ones(batch_shape)
+    factors = torch.ones(batch_shape) * 0.5
     dist = RejectionExponential(rates, factors)
     x = dist.rsample(sample_shape)
     assert x.shape == sample_shape + batch_shape
@@ -45,8 +45,8 @@ def compute_elbo_grad(model, guide, variables):
 @pytest.mark.parametrize('factor', [0.25, 0.5, 1.0])
 def test_rejector(rate, factor):
     num_samples = 100000
-    rates = Variable(torch.Tensor([rate]).expand(num_samples, 1), requires_grad=True)
-    factors = Variable(torch.Tensor([factor]).expand(num_samples, 1), requires_grad=True)
+    rates = torch.tensor(torch.tensor(rate).expand(num_samples, 1), requires_grad=True)
+    factors = torch.tensor(torch.tensor(factor).expand(num_samples, 1), requires_grad=True)
 
     dist1 = Exponential(rates)
     dist2 = RejectionExponential(rates, factors)  # implemented using Rejector
@@ -61,10 +61,10 @@ def test_rejector(rate, factor):
 @pytest.mark.parametrize('factor', [0.25, 0.5, 1.0])
 def test_exponential_elbo(rate, factor):
     num_samples = 100000
-    rates = Variable(torch.Tensor([rate]).expand(num_samples, 1), requires_grad=True)
-    factors = Variable(torch.Tensor([factor]).expand(num_samples, 1), requires_grad=True)
+    rates = torch.tensor(torch.tensor(rate).expand(num_samples, 1), requires_grad=True)
+    factors = torch.tensor(torch.tensor(factor).expand(num_samples, 1), requires_grad=True)
 
-    model = Exponential(Variable(torch.ones(num_samples, 1)))
+    model = Exponential(torch.ones(num_samples, 1))
     guide1 = Exponential(rates)
     guide2 = RejectionExponential(rates, factors)  # implemented using Rejector
 
@@ -81,10 +81,10 @@ def test_exponential_elbo(rate, factor):
 @pytest.mark.parametrize('alpha', [1.0, 2.0, 5.0])
 def test_standard_gamma_elbo(alpha):
     num_samples = 100000
-    alphas = Variable(torch.Tensor([alpha]).expand(num_samples, 1), requires_grad=True)
-    betas = Variable(torch.ones(num_samples, 1))
+    alphas = torch.tensor(torch.tensor(alpha).expand(num_samples, 1), requires_grad=True)
+    betas = torch.ones(num_samples, 1)
 
-    model = Gamma(Variable(torch.ones(num_samples, 1)), betas)
+    model = Gamma(torch.ones(num_samples, 1), betas)
     guide1 = Gamma(alphas, betas)
     guide2 = RejectionStandardGamma(alphas)  # implemented using Rejector
 
@@ -99,10 +99,10 @@ def test_standard_gamma_elbo(alpha):
 @pytest.mark.parametrize('beta', [0.2, 0.5, 1.0, 2.0, 5.0])
 def test_gamma_elbo(alpha, beta):
     num_samples = 100000
-    alphas = Variable(torch.Tensor([alpha]).expand(num_samples, 1), requires_grad=True)
-    betas = Variable(torch.Tensor([beta]).expand(num_samples, 1), requires_grad=True)
+    alphas = torch.tensor(torch.tensor(alpha).expand(num_samples, 1), requires_grad=True)
+    betas = torch.tensor(torch.tensor(beta).expand(num_samples, 1), requires_grad=True)
 
-    model = Gamma(Variable(torch.ones(num_samples, 1)), Variable(torch.ones(num_samples, 1)))
+    model = Gamma(torch.ones(num_samples, 1), torch.ones(num_samples, 1))
     guide1 = Gamma(alphas, betas)
     guide2 = RejectionGamma(alphas, betas)  # implemented using Rejector
 
@@ -121,10 +121,10 @@ def test_gamma_elbo(alpha, beta):
 @pytest.mark.parametrize('beta', [0.2, 0.5, 1.0, 2.0, 5.0])
 def test_shape_augmented_gamma_elbo(alpha, beta):
     num_samples = 100000
-    alphas = Variable(torch.Tensor([alpha]).expand(num_samples, 1), requires_grad=True)
-    betas = Variable(torch.Tensor([beta]).expand(num_samples, 1), requires_grad=True)
+    alphas = torch.tensor(torch.tensor(alpha).expand(num_samples, 1), requires_grad=True)
+    betas = torch.tensor(torch.tensor(beta).expand(num_samples, 1), requires_grad=True)
 
-    model = Gamma(Variable(torch.ones(num_samples, 1)), Variable(torch.ones(num_samples, 1)))
+    model = Gamma(torch.ones(num_samples, 1), torch.ones(num_samples, 1))
     guide1 = Gamma(alphas, betas)
     guide2 = ShapeAugmentedGamma(alphas, betas)  # implemented using Rejector
 
@@ -143,8 +143,8 @@ def test_shape_augmented_gamma_elbo(alpha, beta):
 @pytest.mark.parametrize('beta', [0.5, 1.0, 4.0])
 def test_shape_augmented_beta(alpha, beta):
     num_samples = 10000
-    alphas = Variable(torch.Tensor([alpha]).expand(num_samples, 1), requires_grad=True)
-    betas = Variable(torch.Tensor([beta]).expand(num_samples, 1), requires_grad=True)
+    alphas = torch.tensor(torch.tensor(alpha).expand(num_samples, 1), requires_grad=True)
+    betas = torch.tensor(torch.tensor(beta).expand(num_samples, 1), requires_grad=True)
     dist = ShapeAugmentedBeta(alphas, betas)  # implemented using Rejector
     z = dist.rsample()
     cost = z.sum()

--- a/tests/distributions/test_reshape.py
+++ b/tests/distributions/test_reshape.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 import torch
-from torch.autograd import Variable
 
 from pyro.distributions.torch import Bernoulli
 
@@ -46,7 +45,7 @@ def test_reshape(sample_dim, extra_event_dims):
     shape = sample_shape + batch_shape + event_shape
 
     # Construct a base dist of desired starting shape.
-    dist0 = Bernoulli(Variable(0.5 * torch.ones(batch_shape)))
+    dist0 = Bernoulli(0.5 * torch.ones(batch_shape))
     assert dist0.event_shape == event_shape
     assert dist0.batch_shape == batch_shape
 
@@ -75,7 +74,7 @@ def test_reshape_reshape(sample_dim, extra_event_dims):
     shape = sample_shape + batch_shape + event_shape
 
     # Construct a base dist of desired starting shape.
-    dist0 = Bernoulli(Variable(0.5 * torch.ones(event_shape)))
+    dist0 = Bernoulli(0.5 * torch.ones(event_shape))
     dist1 = dist0.reshape(sample_shape=batch_shape, extra_event_dims=2)
     assert dist1.event_shape == event_shape
     assert dist1.batch_shape == batch_shape

--- a/tests/distributions/test_shapes.py
+++ b/tests/distributions/test_shapes.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
+import torch
+
 import pyro.distributions as dist
-from pyro.util import ng_ones, ng_zeros
 
 
 def test_categorical_shape():
-    ps = ng_ones(3, 2) / 2
+    ps = torch.ones(3, 2) / 2
     d = dist.Categorical(ps)
     assert d.batch_shape == (3,)
     assert d.event_shape == ()
@@ -14,7 +15,7 @@ def test_categorical_shape():
 
 
 def test_one_hot_categorical_shape():
-    ps = ng_ones(3, 2) / 2
+    ps = torch.ones(3, 2) / 2
     d = dist.OneHotCategorical(ps)
     assert d.batch_shape == (3,)
     assert d.event_shape == (2,)
@@ -23,8 +24,8 @@ def test_one_hot_categorical_shape():
 
 
 def test_normal_shape():
-    mu = ng_zeros(3, 2)
-    sigma = ng_ones(3, 2)
+    mu = torch.zeros(3, 2)
+    sigma = torch.ones(3, 2)
     d = dist.Normal(mu, sigma)
     assert d.batch_shape == (3, 2)
     assert d.event_shape == ()
@@ -33,7 +34,7 @@ def test_normal_shape():
 
 
 def test_dirichlet_shape():
-    alpha = ng_ones(3, 2) / 2
+    alpha = torch.ones(3, 2) / 2
     d = dist.Dirichlet(alpha)
     assert d.batch_shape == (3,)
     assert d.event_shape == (2,)
@@ -42,39 +43,39 @@ def test_dirichlet_shape():
 
 
 def test_bernoulli_batch_log_pdf_shape():
-    ps = ng_ones(3, 2)
-    x = ng_ones(3, 2)
+    ps = torch.ones(3, 2)
+    x = torch.ones(3, 2)
     d = dist.Bernoulli(ps)
     assert d.log_prob(x).size() == (3, 2)
 
 
 def test_categorical_batch_log_pdf_shape():
-    ps = ng_ones(3, 2, 4) / 4
-    x = ng_zeros(3, 2)
+    ps = torch.ones(3, 2, 4) / 4
+    x = torch.zeros(3, 2)
     d = dist.Categorical(ps)
     assert d.log_prob(x).size() == (3, 2)
 
 
 def test_one_hot_categorical_batch_log_pdf_shape():
-    ps = ng_ones(3, 2, 4) / 4
-    x = ng_zeros(3, 2, 4)
+    ps = torch.ones(3, 2, 4) / 4
+    x = torch.zeros(3, 2, 4)
     x[:, :, 0] = 1
     d = dist.OneHotCategorical(ps)
     assert d.log_prob(x).size() == (3, 2)
 
 
 def test_normal_batch_log_pdf_shape():
-    mu = ng_zeros(3, 2)
-    sigma = ng_ones(3, 2)
-    x = ng_zeros(3, 2)
+    mu = torch.zeros(3, 2)
+    sigma = torch.ones(3, 2)
+    x = torch.zeros(3, 2)
     d = dist.Normal(mu, sigma)
     assert d.log_prob(x).size() == (3, 2)
 
 
 def test_diag_normal_batch_log_pdf_shape():
-    mu1 = ng_zeros(2, 3)
-    mu2 = ng_zeros(2, 4)
-    sigma = ng_zeros(2, 1)
+    mu1 = torch.zeros(2, 3)
+    mu2 = torch.zeros(2, 4)
+    sigma = torch.zeros(2, 1)
     d1 = dist.Normal(mu1, sigma.expand_as(mu1)).reshape(extra_event_dims=1)
     d2 = dist.Normal(mu2, sigma.expand_as(mu2)).reshape(extra_event_dims=1)
     x1 = d1.sample()

--- a/tests/distributions/test_sparse_multivariate_normal.py
+++ b/tests/distributions/test_sparse_multivariate_normal.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import torch
-from torch.autograd import Variable
 
 from pyro.distributions import MultivariateNormal, SparseMultivariateNormal
 
@@ -9,9 +8,9 @@ from tests.common import assert_equal
 
 
 def test_scale_tril():
-    loc = Variable(torch.Tensor([1, 2, 1, 2, 0]))
-    D = Variable(torch.Tensor([1, 2, 3, 4, 5]))
-    W = Variable(torch.Tensor([[1, -1, 2, 3, 4], [2, 3, 1, 2, 4]]))
+    loc = torch.tensor([1, 2, 1, 2, 0])
+    D = torch.tensor([1, 2, 3, 4, 5])
+    W = torch.tensor([[1, -1, 2, 3, 4], [2, 3, 1, 2, 4]])
     cov = D.diag() + W.t().matmul(W)
 
     mvn = MultivariateNormal(loc, cov)
@@ -21,10 +20,10 @@ def test_scale_tril():
 
 
 def test_log_prob():
-    loc = Variable(torch.Tensor([2, 1, 1, 2, 2]))
-    D = Variable(torch.Tensor([1, 2, 3, 1, 3]))
-    W = Variable(torch.Tensor([[1, -1, 2, 2, 4], [2, 1, 1, 2, 6]]))
-    x = Variable(torch.Tensor([2, 3, 4, 1, 7]))
+    loc = torch.tensor([2, 1, 1, 2, 2])
+    D = torch.tensor([1, 2, 3, 1, 3])
+    W = torch.tensor([[1, -1, 2, 2, 4], [2, 1, 1, 2, 6]])
+    x = torch.tensor([2, 3, 4, 1, 7])
     cov = D.diag() + W.t().matmul(W)
 
     mvn = MultivariateNormal(loc, cov)
@@ -34,9 +33,9 @@ def test_log_prob():
 
 
 def test_variance():
-    loc = Variable(torch.Tensor([1, 1, 1, 2, 0]))
-    D = Variable(torch.Tensor([1, 2, 2, 4, 5]))
-    W = Variable(torch.Tensor([[3, -1, 3, 3, 4], [2, 3, 1, 3, 4]]))
+    loc = torch.tensor([1, 1, 1, 2, 0])
+    D = torch.tensor([1, 2, 2, 4, 5])
+    W = torch.tensor([[3, -1, 3, 3, 4], [2, 3, 1, 3, 4]])
     cov = D.diag() + W.t().matmul(W)
 
     mvn = MultivariateNormal(loc, cov)

--- a/tests/distributions/test_tensor_type.py
+++ b/tests/distributions/test_tensor_type.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import scipy.stats as sp
 import torch
-from torch.autograd import Variable
 
 import pyro.distributions as dist
 from tests.common import assert_equal
@@ -11,7 +10,7 @@ from tests.common import assert_equal
 
 @pytest.fixture()
 def test_data():
-    return Variable(torch.DoubleTensor([0.4]))
+    return torch.DoubleTensor([0.4])
 
 
 @pytest.fixture()
@@ -19,7 +18,7 @@ def alpha():
     """
     alpha parameter for the Beta distribution.
     """
-    return Variable(torch.DoubleTensor([2.4]))
+    return torch.DoubleTensor([2.4])
 
 
 @pytest.fixture()
@@ -27,22 +26,22 @@ def beta():
     """
     beta parameter for the Beta distribution.
     """
-    return Variable(torch.DoubleTensor([3.7]))
+    return torch.DoubleTensor([3.7])
 
 
 @pytest.fixture()
 def float_test_data(test_data):
-    return Variable(torch.FloatTensor(test_data.detach().cpu().numpy()))
+    return torch.FloatTensor(test_data.detach().cpu().numpy())
 
 
 @pytest.fixture()
 def float_alpha(alpha):
-    return Variable(torch.FloatTensor(alpha.detach().cpu().numpy()))
+    return torch.FloatTensor(alpha.detach().cpu().numpy())
 
 
 @pytest.fixture()
 def float_beta(beta):
-    return Variable(torch.FloatTensor(beta.detach().cpu().numpy()))
+    return torch.FloatTensor(beta.detach().cpu().numpy())
 
 
 def test_double_type(test_data, alpha, beta):

--- a/tests/distributions/test_transformed_distribution.py
+++ b/tests/distributions/test_transformed_distribution.py
@@ -44,10 +44,6 @@ EXAMPLES = list(map(make_lognormal, [
 ]))
 
 
-def unwrap_variable(x):
-    return x.detach().cpu().numpy()
-
-
 def AffineExp(affine_b, affine_a):
     affine_transform = AffineTransform(loc=affine_a, scale=affine_b)
     exp_transform = ExpTransform()

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import pytest
 import torch
-from torch.autograd import Variable
 
 from pyro.distributions.util import broadcast_shape, sum_leftmost, sum_rightmost
 
@@ -77,7 +76,7 @@ def test_broadcast_shape_strict_error(shapes):
 
 
 def test_sum_rightmost():
-    x = Variable(torch.ones(2, 3, 4))
+    x = torch.ones(2, 3, 4)
     assert sum_rightmost(x, 0).shape == (2, 3, 4)
     assert sum_rightmost(x, 1).shape == (2, 3)
     assert sum_rightmost(x, 2).shape == (2,)
@@ -87,7 +86,7 @@ def test_sum_rightmost():
 
 
 def test_sum_leftmost():
-    x = Variable(torch.ones(2, 3, 4))
+    x = torch.ones(2, 3, 4)
     assert sum_leftmost(x, 0).shape == (2, 3, 4)
     assert sum_leftmost(x, 1).shape == (3, 4)
     assert sum_leftmost(x, 2).shape == (4,)


### PR DESCRIPTION
This makes the `distributions` module compatible with PyTorch master. 
 - Removing `variable` usage as it throws a UserError.
 - Remove `ng_ones`, `ng_zeros`.

Note that this needs an intermediate PyTorch version (commit - `8327982`) which supports both the old tensor/variable constructors as well as the new; so that we can refactor the modules one by one and then update to PyTorch master.