### PR TITLE
Make iarange contexts reusable

### DIFF
--- a/examples/vae_comparison.py
+++ b/examples/vae_comparison.py
@@ -190,7 +190,7 @@ class PyroVAEImpl(VAE):
             z = pyro.sample('latent', Normal(z_mean, z_std).reshape(extra_event_dims=1))
             img = decoder.forward(z)
             pyro.sample('obs',
-                        Bernoulli(img).reshape(extra_event_dims=2),
+                        Bernoulli(img).reshape(extra_event_dims=1),
                         obs=data.view(-1, 784))
 
     def guide(self, data):

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import contextlib
 import copy
 import logging
 import warnings
@@ -165,23 +164,22 @@ def _subsample(name, size=None, subsample_size=None, subsample=None, use_cuda=No
     return size, subsample_size, subsample
 
 
-@contextlib.contextmanager
-def iarange(name, size=None, subsample_size=None, subsample=None, use_cuda=None):
+class iarange(object):
     """
     Context manager for conditionally independent ranges of variables.
 
-    :func:`iarange` is similar to :func:`torch.arange` in that it yields an
-    array of indices by which other tensors can be indexed. :func:`iarange`
+    :class:`iarange` is similar to :func:`torch.arange` in that it yields an
+    array of indices by which other tensors can be indexed. :class:`iarange`
     differs from :func:`torch.arange` in that it also informs inference
     algorithms that the variables being indexed are conditionally independent.
-    To do this, :func:`iarange` is a provided as context manager rather than a
+    To do this, :class:`iarange` is a provided as context manager rather than a
     function, and users must guarantee that all computation within an
-    :func:`iarange` context is conditionally independent::
+    :class:`iarange` context is conditionally independent::
 
         with iarange("name", size) as ind:
             # ...do conditionally independent stuff with ind...
 
-    Additionally, :func:`iarange` can take advantage of the conditional
+    Additionally, :class:`iarange` can take advantage of the conditional
     independence assumptions by subsampling the indices and informing inference
     algorithms to scale various computed values. This is typically used to
     subsample minibatches of data::
@@ -199,7 +197,7 @@ def iarange(name, size=None, subsample_size=None, subsample=None, use_cuda=None)
         independent within the context.
 
     :param str name: A unique name to help inference algorithms match
-        ``iarange`` sites between models and guides.
+        :class:`iarange` sites between models and guides.
     :param int size: Optional size of the collection being subsampled
         (like `stop` in builtin `range`).
     :param int subsample_size: Size of minibatches used in subsampling.
@@ -208,36 +206,63 @@ def iarange(name, size=None, subsample_size=None, subsample=None, use_cuda=None)
         schemes. If specified, then `subsample_size` will be set to
         `len(subsample)`.
     :type subsample: Anything supporting `len()`.
+    :param int dim: An optional dimension to use for this independence index.
+        If specified, ``dim`` should be negative, i.e. should index from the
+        right. If not specified, ``dim = -(1 + num_enclosing_iaranges)``.
     :param bool use_cuda: Optional bool specifying whether to use cuda tensors
         for `subsample` and `log_pdf`. Defaults to `torch.Tensor.is_cuda`.
-    :return: A context manager yielding a single 1-dimensional `torch.Tensor`
-        of indices.
+    :return: A reusabe context manager yielding a single 1-dimensional
+        :class:`torch.Tensor` of indices.
 
     Examples::
 
         # This version simply declares independence:
         >>> with iarange('data'):
-                observe('obs', normal, data, mu, sigma)
+                sample('obs', Normal(mu, sigma), obs=data)
 
         # This version subsamples data in vectorized way:
         >>> with iarange('data', 100, subsample_size=10) as ind:
-                observe('obs', normal, data.index_select(0, ind), mu, sigma)
+                sample('obs', Normal(mu, sigma), obs=data[ind])
 
         # This wraps a user-defined subsampling method for use in pyro:
         >>> ind = my_custom_subsample
         >>> with iarange('data', 100, subsample=ind):
-                observe('obs', normal, data.index_select(0, ind), mu, sigma)
+                sample('obs', Normal(mu, sigma), obs=data[ind])
+
+        # This reuses two different independence contexts.
+        >>> x_axis = iarange('outer', 320, dim=-1)
+        >>> y_axis = iarange('outer', 200, dim=-2)
+        >>> with x_axis:
+                x_noise = sample("x_noise", Normal(mu, sigma).reshape([320]))
+        >>> with y_axis:
+                y_noise = sample("y_noise", Normal(mu, sigma).reshape([200, 1]))
+        >>> with x_axis, y_axis:
+                xy_noise = sample("xy_noise", Normal(mu, sigma).reshape([200, 320]))
 
     See `SVI Part II <http://pyro.ai/examples/svi_part_ii.html>`_ for an
     extended discussion.
     """
-    size, subsample_size, subsample = _subsample(name, size, subsample_size, subsample, use_cuda)
-    if not am_i_wrapped():
-        yield subsample
-    else:
-        with poutine.scale(None, size / subsample_size):
-            with poutine.indep(name, vectorized=True, size=subsample_size):
-                yield subsample
+    def __init__(self, name, size=None, subsample_size=None, subsample=None, dim=None, use_cuda=None):
+        if dim is not None and dim >= 0:
+            raise ValueError('Expected dim < 0 to index from the right, actual {}'.format(dim))
+        self.name = name
+        self.dim = dim
+        self.size, self.subsample_size, self.subsample = _subsample(name, size, subsample_size, subsample, use_cuda)
+
+    def __enter__(self):
+        self._wrapped = am_i_wrapped()
+        if self._wrapped:
+            dim = 'auto' if self.dim is None else self.dim
+            self._scale_poutine = poutine.scale(None, self.size / self.subsample_size)
+            self._indep_poutine = poutine.IndepMessenger(self.name, size=self.subsample_size, dim=dim)
+            self._scale_poutine.__enter__()
+            self._indep_poutine.__enter__()
+        return self.subsample
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._wrapped:
+            self._indep_poutine.__exit__(exc_type, exc_value, traceback)
+            self._scale_poutine.__exit__(exc_type, exc_value, traceback)
 
 
 def irange(name, size, subsample_size=None, subsample=None, use_cuda=None):
@@ -271,7 +296,7 @@ def irange(name, size, subsample_size=None, subsample=None, use_cuda=None):
         for i in subsample:
             yield i.item() if isinstance(i, Variable) else i
     else:
-        indep_context = poutine.indep(name, vectorized=False, size=subsample_size)
+        indep_context = poutine.IndepMessenger(name, size=subsample_size)
         with poutine.scale(None, size / subsample_size):
             for i in subsample:
                 indep_context.next_context()

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -254,7 +254,7 @@ class iarange(object):
         self._wrapped = am_i_wrapped()
         if self._wrapped:
             dim = 'auto' if self.dim is None else self.dim
-            self._scale_poutine = poutine.scale(None, self.size / self.subsample_size)
+            self._scale_poutine = poutine.ScaleMessenger(self.size / self.subsample_size)
             self._indep_poutine = poutine.IndepMessenger(self.name, size=self.subsample_size, dim=dim)
             self._scale_poutine.__enter__()
             self._indep_poutine.__enter__()
@@ -298,7 +298,7 @@ def irange(name, size, subsample_size=None, subsample=None, use_cuda=None):
             yield i.item() if isinstance(i, Variable) else i
     else:
         indep_context = poutine.IndepMessenger(name, size=subsample_size)
-        with poutine.scale(None, size / subsample_size):
+        with poutine.ScaleMessenger(size / subsample_size):
             for i in subsample:
                 indep_context.next_context()
                 with indep_context:

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -208,7 +208,8 @@ class iarange(object):
     :type subsample: Anything supporting `len()`.
     :param int dim: An optional dimension to use for this independence index.
         If specified, ``dim`` should be negative, i.e. should index from the
-        right. If not specified, ``dim = -(1 + num_enclosing_iaranges)``.
+        right. If not specified, ``dim`` is set to the rightmost dim that is
+        left of all enclosing ``iarange`` contexts.
     :param bool use_cuda: Optional bool specifying whether to use cuda tensors
         for `subsample` and `log_pdf`. Defaults to `torch.Tensor.is_cuda`.
     :return: A reusabe context manager yielding a single 1-dimensional

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -140,20 +140,6 @@ def infer_config(fn, config_fn):
     return InferConfigPoutine(fn, config_fn)
 
 
-def indep(name, vectorized, size):
-    """
-    :param str name: a name for subsample sites
-    :param bool vectorized: True for ``iarange``, False for ``irange``
-    :param int size: Size of the subsampled batch, or -1 if unknown
-    :rtype: pyro.poutine.IndepMessenger
-
-    Alias for IndepMessenger constructor.
-
-    Used internally by ``iarange`` and ``irange``.
-    """
-    return IndepMessenger(name=name, vectorized=vectorized, size=size)
-
-
 def scale(null, scale):
     """
     :param scale: a positive scaling factor

--- a/pyro/poutine/indep_poutine.py
+++ b/pyro/poutine/indep_poutine.py
@@ -4,7 +4,11 @@ from collections import namedtuple
 
 from .poutine import Messenger
 
-CondIndepStackFrame = namedtuple("CondIndepStackFrame", ["name", "counter", "vectorized", "size"])
+
+class CondIndepStackFrame(namedtuple("CondIndepStackFrame", ["name", "dim", "size", "counter"])):
+    @property
+    def vectorized(self):
+        return self.dim is not None
 
 
 class IndepMessenger(Messenger):
@@ -14,16 +18,16 @@ class IndepMessenger(Messenger):
     a ``cond_indep_stack`` at each sample/observe site for consumption by
     ``TracePoutine``.
     """
-    def __init__(self, name, vectorized, size):
+    def __init__(self, name, size, dim=None):
         """
         Constructor: basically default, but store a counter to keep track of
         which ``irange`` branch we're in.
         """
         super(IndepMessenger, self).__init__()
         self.name = name
-        self.counter = 0
-        self.vectorized = vectorized
+        self.dim = dim
         self.size = size
+        self.counter = 0
 
     def next_context(self):
         """
@@ -32,6 +36,6 @@ class IndepMessenger(Messenger):
         self.counter += 1
 
     def _process_message(self, msg):
-        frame = CondIndepStackFrame(self.name, self.counter, self.vectorized, self.size)
+        frame = CondIndepStackFrame(self.name, self.dim, self.size, self.counter)
         msg["cond_indep_stack"] = (frame,) + msg["cond_indep_stack"]
         return None

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -350,7 +350,7 @@ def check_model_guide_match(model_trace, guide_trace):
 
 
 def check_site_shape(site, max_iarange_nesting):
-    actual_shape = site["batch_log_pdf"].shape
+    actual_shape = list(site["batch_log_pdf"].shape)
 
     # Compute expected shape.
     expected_shape = []
@@ -358,7 +358,7 @@ def check_site_shape(site, max_iarange_nesting):
         if f.dim is None:
             continue  # irange
         elif f.dim == 'auto':
-            # Automatically use the rightmost available dimension.
+            # Automatically use the rightmost dim left of all enclosing iarange dims.
             expected_shape.insert(0, f.size)
         else:
             # Use the specified dimension, which counts from the right.
@@ -366,9 +366,11 @@ def check_site_shape(site, max_iarange_nesting):
             if len(expected_shape) < -f.dim:
                 expected_shape = [None] * (-f.dim - len(expected_shape)) + expected_shape
             if expected_shape[f.dim] is not None:
-                raise ValueError('at site "{}", iarange("") dim collision, '.format(site["name"], f.name),
-                                 'try setting dim arg in other iaranges.')
+                raise ValueError('\n  '.join([
+                    'at site "{}" within iarange("", dim={}), dim collision'.format(site["name"], f.name, f.dim),
+                    'Try setting dim arg in other iaranges.']))
             expected_shape[f.dim] = f.size
+    expected_shape = [1 if e is None else e for e in expected_shape]
 
     # Check for iarange stack overflow.
     if len(expected_shape) > max_iarange_nesting:
@@ -382,10 +384,10 @@ def check_site_shape(site, max_iarange_nesting):
 
     # Check for incorrect iarange placement on the right of max_iarange_nesting.
     for actual_size, expected_size in zip_longest(reversed(actual_shape), reversed(expected_shape), fillvalue=1):
-        if expected_size != -1 and actual_size not in (1, expected_size):
+        if expected_size != -1 and expected_size != actual_size:
             raise ValueError('\n  '.join([
                 'at site "{}", invalid log_prob shape'.format(site["name"]),
-                'Expected shape compatible with {}, actual {}'.format(expected_shape, actual_shape),
+                'Expected {}, actual {}'.format(expected_shape, actual_shape),
                 'Try one of the following fixes:',
                 '- enclose the batched tensor in a with iarange(...): context',
                 '- .reshape(extra_event_dims=...) the distribution being sampled',

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -427,7 +427,7 @@ def test_elbo_iarange_iarange(outer_dim, inner_dim, enumerate1, enumerate2, enum
             context2 = pyro.iarange("inner", inner_dim, dim=-3)
             pyro.sample("w", d.reshape([num_particles]))
             with context1:
-                pyro.sample("x", d.reshape([1, outer_dim, num_particles]))
+                pyro.sample("x", d.reshape([outer_dim, num_particles]))
             with context2:
                 pyro.sample("y", d.reshape([inner_dim, 1, num_particles]))
             with context1, context2:
@@ -440,7 +440,7 @@ def test_elbo_iarange_iarange(outer_dim, inner_dim, enumerate1, enumerate2, enum
             context2 = pyro.iarange("inner", inner_dim, dim=-3)
             pyro.sample("w", d.reshape([num_particles]), infer={"enumerate": enumerate1})
             with context1:
-                pyro.sample("x", d.reshape([1, outer_dim, num_particles]), infer={"enumerate": enumerate2})
+                pyro.sample("x", d.reshape([outer_dim, num_particles]), infer={"enumerate": enumerate2})
             with context2:
                 pyro.sample("y", d.reshape([inner_dim, 1, num_particles]), infer={"enumerate": enumerate3})
             with context1, context2:
@@ -465,14 +465,11 @@ def test_elbo_iarange_iarange(outer_dim, inner_dim, enumerate1, enumerate2, enum
     ]))
 
 
-@pytest.mark.parametrize("enumerate3", [None, "sequential", xfail_parallel])
-@pytest.mark.parametrize("enumerate2", [None, "sequential", xfail_parallel])
-@pytest.mark.parametrize("enumerate1", [None, "sequential", xfail_parallel])
+@pytest.mark.parametrize("enumerate3", [None, "sequential", "parallel"])
+@pytest.mark.parametrize("enumerate2", [None, "sequential", "parallel"])
+@pytest.mark.parametrize("enumerate1", [None, "sequential", "parallel"])
 @pytest.mark.parametrize("inner_dim", [2])
-@pytest.mark.parametrize("outer_dim", [
-    1,
-    xfail_param(3, reason='not using MultiViewTensor in broadcasted var inside iarange'),
-])
+@pytest.mark.parametrize("outer_dim", [3])
 def test_elbo_iarange_irange(outer_dim, inner_dim, enumerate1, enumerate2, enumerate3):
     pyro.clear_param_store()
     num_particles = 10000
@@ -485,7 +482,7 @@ def test_elbo_iarange_irange(outer_dim, inner_dim, enumerate1, enumerate2, enume
             with pyro.iarange("outer", outer_dim):
                 pyro.sample("y", dist.Bernoulli(p).reshape([outer_dim, num_particles]))
                 for i in pyro.irange("inner", inner_dim):
-                    pyro.sample("z_{}".format(i), dist.Bernoulli(p).reshape([num_particles]))
+                    pyro.sample("z_{}".format(i), dist.Bernoulli(p).reshape([outer_dim, num_particles]))
 
     def guide():
         q = pyro.param("q")


### PR DESCRIPTION
This enhances `iarange` to be a reusable context manager.

## Why?

Reusable `iarange` contexts are needed to support overlapping but non-nested independence. For example, consider an image noise model with independent noise components for each row, column, and pixel:
```py
x_axis = iarange('outer', 320, dim=-1)
y_axis = iarange('outer', 200, dim=-2)
with x_axis:
    x_noise = sample("x_noise", Normal(mu, sigma).reshape([320]))
with y_axis:
    y_noise = sample("y_noise", Normal(mu, sigma).reshape([200, 1]))
with x_axis, y_axis:
    xy_noise = sample("xy_noise", Normal(mu, sigma).reshape([200, 320]))
```
This corresponds to non-nested the plate diagram
```
+----------------+
| x_noise    320 |
|                |
| +--------------------------------+
| | xy_noise     |  y_noise    200 |                
| +--------------------------------+
+----------------+
```

This PR also fixes a subsampling bug whereby variables such as `y_noise` used to be scaled by both `x_axis` and `y_axis` subsampling, but henceforth will be scaled by only `y_axis` subsampling.

## How?

This changes `iarange` to implement the full context manager interface. We now need a new `dim` arg to keep track of which tensor dim will be used later on (since this is not know at time of construction).

This functionality allows us to disallow broadcasting of log_prob within `iarange` contexts. Henceforth you can specify for each sampled tensor exactly the independence dims of that tensor.

## Tested

- added new shape checks to `check_site_shape`
- added reuse examples to `tests/infer/test_enum.py`
- added reuse examples to `tests/infer/test_valid_models.py`
- added tests for broadcasting errors to `tests/infer/test_valid_models.py`

Closes #370 (although @martinjankowiak's #780 did most of the work)