### PR TITLE
Implement MultiFrameTensor data structure for Trace*_ELBO

### DIFF
--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -133,6 +133,50 @@ class MultiViewTensor(dict):
         return '%s(%s)' % (type(self).__name__, ", ".join([str(k) for k in self.keys()]))
 
 
+class CondIndepTensor(dict):
+    """
+    A container for sums of Tensors in different :class:`iarange` contexts.
+
+    Used in :class:`~pyro.infer.tracegraph_elbo.TraceGraph_ELBO` to simplify
+    downstream cost computation logic.
+
+    Example::
+
+        downstream_cost = CondIndepTensor()
+        for site in downstream_nodes:
+            downstream_cost.add(site["cond_indep_stack"], site["batch_log_pdf"])
+        summed = downstream_cost.sum_to(target_site["cond_indep_stack"])
+    """
+    def __init__(self, *items):
+        super(CondIndepTensor, self).__init__()
+        self.add(*items)
+
+    def add(self, *items):
+        """
+        Add a collection of (key, tensor) pairs. Keys are
+        ``cond_indep_stack``s, i.e. tuples of :class:`CondIndepStackFrame`s.
+        Values are :class:`torch.Tensor`s.
+        """
+        for key, value in items:
+            assert all(f.dim < 0 and -len(value.shape) <= f.dim for f in key)
+            if key in self:
+                self[key] = self[key] + value
+            else:
+                self[key] = value
+
+    def sum_to(self, target_key):
+        total = None
+        for key, value in self:
+            for f in key:
+                if f not in target_key and value.shape[f.dim] != 1:
+                    value = value.sum(f.dim, True)
+            total = value if total is None else total + value
+        return total
+
+    def __repr__(self):
+        return '%s(%s)' % (type(self).__name__, ",\n\t".join(['({}, ...)'.format(key) for key in self]))
+
+
 class TreeSum(object):
     """
     Data structure to compute cumulative costs along paths in a tree.

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -133,48 +133,53 @@ class MultiViewTensor(dict):
         return '%s(%s)' % (type(self).__name__, ", ".join([str(k) for k in self.keys()]))
 
 
-class CondIndepTensor(dict):
+class MultiFrameTensor(dict):
     """
-    A container for sums of Tensors in different :class:`iarange` contexts.
+    A container for sums of Tensors among different :class:`iarange` contexts.
 
     Used in :class:`~pyro.infer.tracegraph_elbo.TraceGraph_ELBO` to simplify
     downstream cost computation logic.
 
     Example::
 
-        downstream_cost = CondIndepTensor()
+        downstream_cost = MultiFrameTensor()
         for site in downstream_nodes:
-            downstream_cost.add(site["cond_indep_stack"], site["batch_log_pdf"])
+            downstream_cost.add((site["cond_indep_stack"], site["batch_log_pdf"]))
+        downstream_cost.add(*other_costs.items())  # add in bulk
         summed = downstream_cost.sum_to(target_site["cond_indep_stack"])
     """
     def __init__(self, *items):
-        super(CondIndepTensor, self).__init__()
+        super(MultiFrameTensor, self).__init__()
         self.add(*items)
 
     def add(self, *items):
         """
-        Add a collection of (key, tensor) pairs. Keys are
+        Add a collection of (cond_indep_stack, tensor) pairs. Keys are
         ``cond_indep_stack``s, i.e. tuples of :class:`CondIndepStackFrame`s.
         Values are :class:`torch.Tensor`s.
         """
-        for key, value in items:
-            assert all(f.dim < 0 and -len(value.shape) <= f.dim for f in key)
-            if key in self:
-                self[key] = self[key] + value
+        for cond_indep_stack, value in items:
+            frames = frozenset(f for f in cond_indep_stack if f.vectorized)
+            assert all(f.dim < 0 and -len(value.shape) <= f.dim for f in frames)
+            if frames in self:
+                self[frames] = self[frames] + value
             else:
-                self[key] = value
+                self[frames] = value
 
-    def sum_to(self, target_key):
+    def sum_to(self, target_frames):
         total = None
-        for key, value in self:
-            for f in key:
-                if f not in target_key and value.shape[f.dim] != 1:
+        for frames, value in self.items():
+            for f in frames:
+                if f not in target_frames and value.shape[f.dim] != 1:
                     value = value.sum(f.dim, True)
+            while value.shape and value.shape[0] == 1:
+                value.squeeze_(0)
             total = value if total is None else total + value
         return total
 
     def __repr__(self):
-        return '%s(%s)' % (type(self).__name__, ",\n\t".join(['({}, ...)'.format(key) for key in self]))
+        return '%s(%s)' % (type(self).__name__, ",\n\t".join([
+            '({}, ...)'.format(frames) for frames in self]))
 
 
 class TreeSum(object):

--- a/pyro/poutine/indep_poutine.py
+++ b/pyro/poutine/indep_poutine.py
@@ -11,6 +11,54 @@ class CondIndepStackFrame(namedtuple("CondIndepStackFrame", ["name", "dim", "siz
         return self.dim is not None
 
 
+class _DimAllocator(object):
+    """
+    Dimension allocator for internal use by :class:`iarange`.
+    There is a single global instance.
+
+    Note that dimensions are indexed from the right, e.g. -1, -2.
+    """
+    def __init__(self):
+        self._stack = []  # in reverse orientation of log_prob.shape
+
+    def allocate(self, name, dim):
+        """
+        Allocate a dimension to an :class:`iarange` with given name.
+        Dim should be either None for automatic allocation or a negative
+        integer for manual allocation.
+        """
+        if name in self._stack:
+            raise ValueError('duplicate iarange "{}"'.format(name))
+        if dim is None:
+            # Automatically allocate the rightmost dimension to the left of all existing dims.
+            self._stack.append(name)
+            dim = -len(self._stack)
+        elif dim >= 0:
+            raise ValueError('Expected dim < 0 to index from the right, actual {}'.format(dim))
+        else:
+            # Allocate the requested dimension.
+            while dim < -len(self._stack):
+                self._stack.append(None)
+            if self._stack[-1 - dim] is not None:
+                raise ValueError('\n'.join([
+                    'at iaranges "{}" and "{}", collide at dim={}'.format(name, self._stack[-1 - dim], dim),
+                    '\nTry moving the dim of one iarange to the left, e.g. dim={}'.format(dim - 1)]))
+            self._stack[-1 - dim] = name
+        return dim
+
+    def free(self, name, dim):
+        """
+        Free a dimension.
+        """
+        assert self._stack[-1 - dim] == name
+        self._stack[-1 - dim] = None
+        while self._stack and self._stack[-1] is None:
+            self._stack.pop()
+
+
+_DIM_ALLOCATOR = _DimAllocator()
+
+
 class IndepMessenger(Messenger):
     """
     This messenger keeps track of stack of independence information declared by

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -357,13 +357,8 @@ def check_site_shape(site, max_iarange_nesting):
     # Compute expected shape.
     expected_shape = []
     for f in site["cond_indep_stack"]:
-        if f.dim is None:
-            continue  # irange
-        elif f.dim == 'auto':
-            # Automatically use the rightmost dim left of all enclosing iarange dims.
-            expected_shape.insert(0, f.size)
-        else:
-            # Use the specified dimension, which counts from the right.
+        if f.dim is not None:
+            # Use the specified iarange dimension, which counts from the right.
             assert f.dim < 0
             if len(expected_shape) < -f.dim:
                 expected_shape = [None] * (-f.dim - len(expected_shape)) + expected_shape

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -649,9 +649,9 @@ def test_enum_discrete_parallel_iarange_ok():
         p536 = Variable(torch.ones(5, 3, 6) / 6)
 
         x2 = pyro.sample("x2", dist.Categorical(p2))
-        with pyro.iarange("iarange", 3):
+        with pyro.iarange("outer", 3):
             x34 = pyro.sample("x34", dist.Categorical(p34))
-            with pyro.iarange("iarange", 5):
+            with pyro.iarange("inner", 5):
                 x536 = pyro.sample("x536", dist.Categorical(p536))
 
         if not enum_discrete:


### PR DESCRIPTION
This implements a `MultiFrameTensor` data structure for internal use by `Trace*_ELBO` implementations. This will replace `MultiViewTensor` in the more flexible `iarange` setting since #863.

## Tasks

- [x] Allocate `iarange` dims at the first `__enter__()` rather than later at each `pyro.sample()` statement. This is needed so that iarange `CondIndepStackFrame`s always have their `.dim` field set (no more 'auto').
- [x] Implement `MulitFrameTensor` keyed on `cond_indep_stack` tuples.
- [x] Add unit tests.
- [x] Integrate into `TraceGraph_ELBO`. 
- #865 Integrate into `Trace_ELBO`.

Pair coded by @fritzo and @martinjankowiak.