### PR TITLE
Using torch.tensor API in other Pyro modules

### DIFF
--- a/pyro/nn/auto_reg_nn.py
+++ b/pyro/nn/auto_reg_nn.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
 from torch.nn import functional as F
 
 from pyro.distributions.util import torch_multinomial
@@ -17,7 +16,7 @@ class MaskedLinear(nn.Linear):
     :param out_features: the number of output features
     :type out_features: int
     :param mask: the mask to apply to the in_features x out_features weight matrix
-    :type mask: torch.autograd.Variable
+    :type mask: torch.Tensor
     :param bias: whether or not `MaskedLinear` should include a bias term. defaults to `True`
     :type bias: bool
     """
@@ -29,7 +28,7 @@ class MaskedLinear(nn.Linear):
         """
         the forward method that does the masked linear computation and returns the result
         """
-        masked_weight = self.weight * torch.autograd.Variable(self.mask)
+        masked_weight = self.weight * self.mask
         return F.linear(_input, masked_weight, self.bias)
 
 
@@ -82,8 +81,8 @@ class AutoRegressiveNN(nn.Module):
             self.permutation = permutation
 
         # these masks control the autoregressive structure
-        self.mask1 = Variable(torch.zeros(hidden_dim, input_dim))
-        self.mask2 = Variable(torch.zeros(input_dim * self.output_dim_multiplier, hidden_dim))
+        self.mask1 = torch.zeros(hidden_dim, input_dim)
+        self.mask2 = torch.zeros(input_dim * self.output_dim_multiplier, hidden_dim)
 
         for k in range(hidden_dim):
             # fill in mask1

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from torch.autograd import Variable, grad
+import torch
+from torch.autograd import grad
 
 
 def velocity_verlet(z, r, potential_fn, step_size, num_steps=1):
@@ -8,9 +9,9 @@ def velocity_verlet(z, r, potential_fn, step_size, num_steps=1):
     Second order symplectic integrator that uses the velocity verlet algorithm.
 
     :param dict z: dictionary of sample site names and their current values
-        (type :class:`~torch.autograd.Variable`).
+        (type :class:`~torch.Tensor`).
     :param dict r: dictionary of sample site names and corresponding momenta
-        (type :class:`~torch.autograd.Variable`).
+        (type :class:`~torch.Tensor`).
     :param callable potential_fn: function that returns potential energy given z
         for each sample site. The negative gradient of the function with respect
         to ``z`` determines the rate of change of the corresponding sites'
@@ -59,7 +60,7 @@ def single_step_velocity_verlet(z, r, potential_fn, step_size, z_grads=None):
 
 
 def _grad(potential_fn, z):
-    z = {k: Variable(v, requires_grad=True) for k, v in z.items()}
+    z = {k: torch.tensor(v, requires_grad=True) for k, v in z.items()}
     z_keys, z_nodes = zip(*z.items())
     potential_energy = potential_fn(z)
     grads = grad(potential_energy, z_nodes)

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import torch
 from torch.autograd import grad, Variable
 
 

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import torch
-from torch.autograd import grad
+from torch.autograd import grad, Variable
 
 
 def velocity_verlet(z, r, potential_fn, step_size, num_steps=1):
@@ -60,7 +60,7 @@ def single_step_velocity_verlet(z, r, potential_fn, step_size, z_grads=None):
 
 
 def _grad(potential_fn, z):
-    z = {k: torch.tensor(v, requires_grad=True) for k, v in z.items()}
+    z = {k: Variable(v, requires_grad=True) for k, v in z.items()}
     z_keys, z_nodes = zip(*z.items())
     potential_energy = potential_fn(z)
     grads = grad(potential_energy, z_nodes)

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -192,9 +192,9 @@ class ParamStoreDict(object):
         :param param_name: parameter name
         :type param_name: str
         :param new_param: the paramater to be put into the ParamStore
-        :type new_param: torch.autograd.Variable
+        :type new_param: torch.Tensor
         :param old_param: the paramater to be removed from the ParamStore
-        :type new_param: torch.autograd.Variable
+        :type new_param: torch.Tensor
         """
         assert id(self._params[param_name]) == id(old_param)
         self._params[param_name] = new_param
@@ -210,11 +210,11 @@ class ParamStoreDict(object):
         :param name: parameter name
         :type name: str
         :param init_tensor: initial tensor
-        :type init_tensor: torch.autograd.Variable
+        :type init_tensor: torch.Tensor
         :param tags: the tag(s) to assign to the parameter
         :type tags: a string or iterable of strings
         :returns: parameter
-        :rtype: torch.autograd.Variable
+        :rtype: torch.Tensor
         """
         if name not in self._params:
             # if not create the init tensor through

--- a/tests/ops/test_integrator.py
+++ b/tests/ops/test_integrator.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 
 import pytest
 import torch
-from torch.autograd import Variable
 
 from pyro.ops.integrator import velocity_verlet
 from tests.common import assert_equal
@@ -18,10 +17,6 @@ EXAMPLE_IDS = []
 
 ModelArgs = namedtuple('model_args', ['step_size', 'num_steps', 'q_i', 'p_i', 'q_f', 'p_f', 'prec'])
 Example = namedtuple('test_case', ['model', 'args'])
-
-
-def tensor(arr):
-    return Variable(torch.Tensor(arr))
 
 
 def register_model(init_args):
@@ -41,10 +36,10 @@ def register_model(init_args):
     ModelArgs(
         step_size=0.01,
         num_steps=100,
-        q_i={'x': tensor([0.0])},
-        p_i={'x': tensor([1.0])},
-        q_f={'x': torch.sin(tensor([1.0]))},
-        p_f={'x': torch.cos(tensor([1.0]))},
+        q_i={'x': torch.tensor([0.0])},
+        p_i={'x': torch.tensor([1.0])},
+        q_f={'x': torch.sin(torch.tensor([1.0]))},
+        p_f={'x': torch.cos(torch.tensor([1.0]))},
         prec=1e-4
     )
 ])
@@ -62,10 +57,10 @@ class HarmonicOscillator(object):
     ModelArgs(
         step_size=0.01,
         num_steps=628,
-        q_i={'x': tensor([1.0]), 'y': tensor([0.0])},
-        p_i={'x': tensor([0.0]), 'y': tensor([1.0])},
-        q_f={'x': tensor([1.0]), 'y': tensor([0.0])},
-        p_f={'x': tensor([0.0]), 'y': tensor([1.0])},
+        q_i={'x': torch.tensor([1.0]), 'y': torch.tensor([0.0])},
+        p_i={'x': torch.tensor([0.0]), 'y': torch.tensor([1.0])},
+        q_f={'x': torch.tensor([1.0]), 'y': torch.tensor([0.0])},
+        p_f={'x': torch.tensor([0.0]), 'y': torch.tensor([1.0])},
         prec=5.0e-3
     )
 ])
@@ -84,10 +79,10 @@ class CircularPlanetaryMotion(object):
     ModelArgs(
         step_size=0.1,
         num_steps=1810,
-        q_i={'x': tensor([0.02])},
-        p_i={'x': tensor([0.0])},
-        q_f={'x': tensor([-0.02])},
-        p_f={'x': tensor([0.0])},
+        q_i={'x': torch.tensor([0.02])},
+        p_i={'x': torch.tensor([0.0])},
+        q_f={'x': torch.tensor([-0.02])},
+        p_f={'x': torch.tensor([0.0])},
         prec=1.0e-4
     )
 ])

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from unittest import TestCase
 
 import torch
-from torch.autograd import Variable
 
 import pyro
 import pyro.optim as optim
@@ -15,11 +14,11 @@ class OptimTests(TestCase):
 
     def setUp(self):
         # normal-normal; known covariance
-        self.lam0 = Variable(torch.Tensor([0.1]))  # precision of prior
-        self.mu0 = Variable(torch.Tensor([0.5]))  # prior mean
+        self.lam0 = torch.tensor([0.1])  # precision of prior
+        self.mu0 = torch.tensor([0.5])  # prior mean
         # known precision of observation noise
-        self.lam = Variable(torch.Tensor([6.0]))
-        self.data = Variable(torch.Tensor([1.0]))  # a single observation
+        self.lam = torch.tensor([6.0])
+        self.data = torch.tensor([1.0])  # a single observation
 
     def test_per_param_optim(self):
         self.do_test_per_param_optim("mu_q", "log_sig_q")
@@ -39,12 +38,10 @@ class OptimTests(TestCase):
         def guide():
             mu_q = pyro.param(
                 "mu_q",
-                Variable(
-                    torch.zeros(1),
-                    requires_grad=True))
+                torch.zeros(1, requires_grad=True))
             log_sig_q = pyro.param(
-                "log_sig_q", Variable(
-                    torch.zeros(1), requires_grad=True))
+                "log_sig_q",
+                torch.zeros(1, requires_grad=True))
             sig_q = torch.exp(log_sig_q)
             pyro.sample("mu_latent", Normal(mu_q, sig_q))
 

--- a/tests/params/test_module.py
+++ b/tests/params/test_module.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
 
 import pyro
 import pyro.distributions as dist
@@ -74,7 +73,7 @@ def test_module_sequential(nn_module):
 def test_random_module(nn_module):
     pyro.clear_param_store()
     nn_module = nn_module()
-    p = Variable(torch.ones(2, 2))
+    p = torch.ones(2, 2)
     prior = dist.Bernoulli(p)
     lifted_mod = pyro.random_module("module", nn_module, prior)
     nn_module = lifted_mod()

--- a/tests/params/test_param.py
+++ b/tests/params/test_param.py
@@ -7,7 +7,6 @@ import numpy as np
 import torch
 import torch.optim
 from torch import nn as nn
-from torch.autograd import Variable
 
 import pyro
 
@@ -23,8 +22,8 @@ class ParamStoreDictTests(TestCase):
     def test_save_and_load(self):
         lin = pyro.module("mymodule", self.linear_module)
         pyro.module("mymodule2", self.linear_module2)
-        x = Variable(torch.randn(1, 3))
-        myparam = pyro.param("myparam", Variable(1.234 * torch.ones(1), requires_grad=True))
+        x = torch.randn(1, 3)
+        myparam = pyro.param("myparam", torch.tensor(1.234 * torch.ones(1), requires_grad=True))
 
         cost = torch.sum(torch.pow(lin(x), 2.0)) * torch.pow(myparam, 4.0)
         cost.backward()


### PR DESCRIPTION
Same as #868 for `nn`, `params`, `optim` and `ops`. After this and #868, we will only need to make changes to the `infer` module.