### PR TITLE
Fix EnumerateMessenger dim allocation

### DIFF
--- a/pyro/poutine/enumerate_poutine.py
+++ b/pyro/poutine/enumerate_poutine.py
@@ -14,7 +14,12 @@ class EnumerateMessenger(Messenger):
     """
     def __init__(self, first_available_dim):
         super(EnumerateMessenger, self).__init__()
-        self.next_available_dim = first_available_dim
+        self.first_available_dim = first_available_dim
+        self.next_available_dim = None
+
+    def __enter__(self):
+        self.next_available_dim = self.first_available_dim
+        return super(EnumerateMessenger, self).__enter__()
 
     def _pyro_sample(self, msg):
         """


### PR DESCRIPTION
This fixes a performance bug in `EnumerateMessenger` whereby `self.next_available_dim` was not being reset to `first_available_dim` each time the wrapped function was called. This led to dimensions being allocated farther and farther to the left.

## Tested

- added a test for tensor shapes after multiple calls of a wrapped model
- added a test for combination of replay + `EnumeratePoutine`, following usage in `Trace*_ELBO`