### PR TITLE
Make irange iterators reusable

### DIFF
--- a/tests/infer/test_compute_downstream_costs.py
+++ b/tests/infer/test_compute_downstream_costs.py
@@ -298,7 +298,7 @@ def nested_model_guide(include_obs=True, dim1=11, dim2=7):
     pyro.sample("a1", dist.Bernoulli(p0 * p1))
     for i in pyro.irange("irange", dim1):
         pyro.sample("b{}".format(i), dist.Bernoulli(p0))
-        with pyro.iarange("iarange", dim2 + i) as ind:
+        with pyro.iarange("iarange_{}".format(i), dim2 + i) as ind:
             c_i = pyro.sample("c{}".format(i), dist.Bernoulli(p1).reshape(sample_shape=[len(ind)]))
             assert c_i.shape == (dim2 + i,)
             if include_obs:

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -528,9 +528,10 @@ def test_elbo_irange_iarange(outer_dim, inner_dim, enumerate1, enumerate2, enume
     def model():
         with pyro.iarange("particles", num_particles):
             pyro.sample("x", dist.Bernoulli(p).reshape([num_particles]))
+            inner_iarange = pyro.iarange("inner", inner_dim)
             for i in pyro.irange("outer", outer_dim):
                 pyro.sample("y_{}".format(i), dist.Bernoulli(p).reshape([num_particles]))
-                with pyro.iarange("inner", inner_dim):
+                with inner_iarange:
                     pyro.sample("z_{}".format(i), dist.Bernoulli(p).reshape([inner_dim, num_particles]))
 
     def guide():
@@ -538,10 +539,11 @@ def test_elbo_irange_iarange(outer_dim, inner_dim, enumerate1, enumerate2, enume
         with pyro.iarange("particles", num_particles):
             pyro.sample("x", dist.Bernoulli(q).reshape([num_particles]),
                         infer={"enumerate": enumerate1})
+            inner_iarange = pyro.iarange("inner", inner_dim)
             for i in pyro.irange("outer", outer_dim):
                 pyro.sample("y_{}".format(i), dist.Bernoulli(q).reshape([num_particles]),
                             infer={"enumerate": enumerate2})
-                with pyro.iarange("inner", inner_dim):
+                with inner_iarange:
                     pyro.sample("z_{}".format(i), dist.Bernoulli(q).reshape([inner_dim, num_particles]),
                                 infer={"enumerate": enumerate3})
 
@@ -577,9 +579,10 @@ def test_elbo_irange_irange(outer_dim, inner_dim, enumerate1, enumerate2, enumer
     def model():
         with pyro.iarange("particles", num_particles):
             pyro.sample("x", dist.Bernoulli(p).reshape([num_particles]))
+            inner_irange = pyro.irange("inner", outer_dim)
             for i in pyro.irange("outer", inner_dim):
                 pyro.sample("y_{}".format(i), dist.Bernoulli(p).reshape([num_particles]))
-                for j in pyro.irange("inner", outer_dim):
+                for j in inner_irange:
                     pyro.sample("z_{}_{}".format(i, j), dist.Bernoulli(p).reshape([num_particles]))
 
     def guide():
@@ -587,10 +590,11 @@ def test_elbo_irange_irange(outer_dim, inner_dim, enumerate1, enumerate2, enumer
         with pyro.iarange("particles", num_particles):
             pyro.sample("x", dist.Bernoulli(q).reshape([num_particles]),
                         infer={"enumerate": enumerate1})
+            inner_irange = pyro.irange("inner", inner_dim)
             for i in pyro.irange("outer", outer_dim):
                 pyro.sample("y_{}".format(i), dist.Bernoulli(q).reshape([num_particles]),
                             infer={"enumerate": enumerate2})
-                for j in pyro.irange("inner", inner_dim):
+                for j in inner_irange:
                     pyro.sample("z_{}_{}".format(i, j), dist.Bernoulli(q).reshape([num_particles]),
                                 infer={"enumerate": enumerate3})
 

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize("trace_graph,enum_discrete",
                          [(False, False), (True, False), (False, True)],
                          ids=["Trace", "TraceGraph", "TraceEnum"])
-def test_subsample_gradient_parallelized(trace_graph, enum_discrete, reparameterized, subsample):
+def test_subsample_gradient(trace_graph, enum_discrete, reparameterized, subsample):
     pyro.clear_param_store()
     data = variable([-0.5, 2.0])
     subsample_size = 1 if subsample else len(data)
@@ -67,11 +67,64 @@ def test_subsample_gradient_parallelized(trace_graph, enum_discrete, reparameter
 
 
 @pytest.mark.parametrize("reparameterized", [True, False], ids=["reparam", "nonreparam"])
+@pytest.mark.parametrize("trace_graph,enum_discrete", [
+    (False, False),
+    (True, False),
+    pytest.param(False, True, marks=pytest.mark.xfail(reason="https://github.com/uber/pyro/issues/846")),
+], ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_iarange(trace_graph, enum_discrete, reparameterized):
+    pyro.clear_param_store()
+    data = variable([-0.5, 2.0])
+    num_particles = 20000
+    precision = 0.05
+    Normal = dist.Normal if reparameterized else fakes.NonreparameterizedNormal
+
+    def model():
+        x = data.unsqueeze(-1).expand(-1, num_particles)
+        data_iarange = pyro.iarange("data", len(data), dim=-2)
+        particles_iarange = pyro.iarange("particles", num_particles, dim=-1)
+
+        pyro.sample("nuisance_a", Normal(0, 1))
+        with particles_iarange, data_iarange:
+            z = pyro.sample("z", Normal(0, 1).reshape(x.shape))
+        pyro.sample("nuisance_b", Normal(2, 3))
+        with data_iarange, particles_iarange:
+            pyro.sample("x", Normal(z, 1), obs=x)
+        pyro.sample("nuisance_c", Normal(4, 5))
+
+    def guide():
+        mu = pyro.param("mu", lambda: variable(torch.zeros(len(data)), requires_grad=True))
+        sigma = pyro.param("sigma", lambda: variable([1.0], requires_grad=True))
+        mus = mu.unsqueeze(-1).expand(-1, num_particles)
+
+        pyro.sample("nuisance_c", Normal(4, 5))
+        with pyro.iarange("particles", num_particles):
+            with pyro.iarange("data", len(data)):
+                pyro.sample("z", Normal(mus, sigma))
+        pyro.sample("nuisance_b", Normal(2, 3))
+        pyro.sample("nuisance_a", Normal(0, 1))
+
+    optim = Adam({"lr": 0.1})
+    inference = SVI(model, guide, optim, loss="ELBO",
+                    trace_graph=trace_graph, enum_discrete=enum_discrete)
+    inference.loss_and_grads(model, guide)
+    params = dict(pyro.get_param_store().named_parameters())
+    actual_grads = {name: param.grad.detach().cpu().numpy() / num_particles
+                    for name, param in params.items()}
+
+    expected_grads = {'mu': np.array([0.5, -2.0]), 'sigma': np.array([2.0])}
+    for name in sorted(params):
+        logger.info('expected {} = {}'.format(name, expected_grads[name]))
+        logger.info('actual   {} = {}'.format(name, actual_grads[name]))
+    assert_equal(actual_grads, expected_grads, prec=precision)
+
+
+@pytest.mark.parametrize("reparameterized", [True, False], ids=["reparam", "nonreparam"])
 @pytest.mark.parametrize("subsample", [False, True], ids=["full", "subsample"])
 @pytest.mark.parametrize("trace_graph,enum_discrete",
                          [(False, False), (True, False), (False, True)],
                          ids=["Trace", "TraceGraph", "TraceEnum"])
-def test_subsample_gradient(trace_graph, enum_discrete, reparameterized, subsample):
+def test_subsample_gradient_sequential(trace_graph, enum_discrete, reparameterized, subsample):
     pyro.clear_param_store()
     data = variable([-0.5, 2.0])
     subsample_size = 1 if subsample else len(data)

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -234,14 +234,18 @@ def test_irange_irange_ok(subsample_size, trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
-        for i in pyro.irange("irange_0", 10, subsample_size):
-            for j in pyro.irange("irange_1", 10, subsample_size):
+        outer_irange = pyro.irange("irange_0", 10, subsample_size)
+        inner_irange = pyro.irange("irange_1", 10, subsample_size)
+        for i in outer_irange:
+            for j in inner_irange:
                 pyro.sample("x_{}_{}".format(i, j), dist.Bernoulli(p))
 
     def guide():
         p = pyro.param("p", variable(0.5, requires_grad=True))
-        for i in pyro.irange("irange_0", 10, subsample_size):
-            for j in pyro.irange("irange_1", 10, subsample_size):
+        outer_irange = pyro.irange("irange_0", 10, subsample_size)
+        inner_irange = pyro.irange("irange_1", 10, subsample_size)
+        for i in outer_irange:
+            for j in inner_irange:
                 pyro.sample("x_{}_{}".format(i, j), dist.Bernoulli(p))
 
     assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
@@ -251,21 +255,25 @@ def test_irange_irange_ok(subsample_size, trace_graph, enum_discrete):
 @pytest.mark.parametrize("trace_graph,enum_discrete",
                          [(False, False), (True, False), (False, True)],
                          ids=["Trace", "TraceGraph", "TraceEnum"])
-def test_irange_irange_swap_error(subsample_size, trace_graph, enum_discrete):
+def test_irange_irange_swap_ok(subsample_size, trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
-        for i in pyro.irange("irange_0", 10, subsample_size):
-            for j in pyro.irange("irange_1", 10, subsample_size):
+        outer_irange = pyro.irange("irange_0", 10, subsample_size)
+        inner_irange = pyro.irange("irange_1", 10, subsample_size)
+        for i in outer_irange:
+            for j in inner_irange:
                 pyro.sample("x_{}_{}".format(i, j), dist.Bernoulli(p))
 
     def guide():
         p = pyro.param("p", variable(0.5, requires_grad=True))
-        for j in pyro.irange("irange_1", 10, subsample_size):
-            for i in pyro.irange("irange_0", 10, subsample_size):
+        outer_irange = pyro.irange("irange_0", 10, subsample_size)
+        inner_irange = pyro.irange("irange_1", 10, subsample_size)
+        for j in inner_irange:
+            for i in outer_irange:
                 pyro.sample("x_{}_{}".format(i, j), dist.Bernoulli(p))
 
-    assert_error(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
+    assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
@@ -319,8 +327,10 @@ def test_iarange_broadcast_error(trace_graph, enum_discrete):
     assert_error(model, model, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
-@pytest.mark.xfail(reason="RaoBlackwellization checks in trace_poutine need to be fixed to catch this")
-def test_iarange_irange_warning():
+@pytest.mark.parametrize("trace_graph,enum_discrete",
+                         [(False, False), (True, False), (False, True)],
+                         ids=["Trace", "TraceGraph", "TraceEnum"])
+def test_iarange_irange_ok(trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
@@ -334,7 +344,7 @@ def test_iarange_irange_warning():
             for i in pyro.irange("irange", 10, 5):
                 pyro.sample("x_{}".format(i), dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
-    assert_warning(model, guide, trace_graph=True)
+    assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
 
 
 @pytest.mark.parametrize("trace_graph,enum_discrete",
@@ -344,14 +354,16 @@ def test_irange_iarange_ok(trace_graph, enum_discrete):
 
     def model():
         p = variable(0.5)
+        inner_iarange = pyro.iarange("iarange", 10, 5)
         for i in pyro.irange("irange", 10, 5):
-            with pyro.iarange("iarange", 10, 5) as ind:
+            with inner_iarange as ind:
                 pyro.sample("x_{}".format(i), dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
     def guide():
         p = pyro.param("p", variable(0.5, requires_grad=True))
+        inner_iarange = pyro.iarange("iarange", 10, 5)
         for i in pyro.irange("irange", 10, 5):
-            with pyro.iarange("iarange", 10, 5) as ind:
+            with inner_iarange as ind:
                 pyro.sample("x_{}".format(i), dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
     assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
@@ -478,26 +490,28 @@ def test_three_indep_iarange_at_different_depths_ok():
     """
     def model():
         p = variable(0.5)
+        inner_iarange = pyro.iarange("iarange1", 10, 5)
         for i in pyro.irange("irange0", 2):
             pyro.sample("x_%d" % i, dist.Bernoulli(p))
             if i == 0:
                 for j in pyro.irange("irange1", 2):
-                    with pyro.iarange("iarange1", 10, 5) as ind:
+                    with inner_iarange as ind:
                         pyro.sample("y_%d" % j, dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
             elif i == 1:
-                with pyro.iarange("iarange1", 10, 5) as ind:
+                with inner_iarange as ind:
                     pyro.sample("z", dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
     def guide():
         p = pyro.param("p", variable(0.5, requires_grad=True))
+        inner_iarange = pyro.iarange("iarange1", 10, 5)
         for i in pyro.irange("irange0", 2):
             pyro.sample("x_%d" % i, dist.Bernoulli(p))
             if i == 0:
                 for j in pyro.irange("irange1", 2):
-                    with pyro.iarange("iarange1", 10, 5) as ind:
+                    with inner_iarange as ind:
                         pyro.sample("y_%d" % j, dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
             elif i == 1:
-                with pyro.iarange("iarange1", 10, 5) as ind:
+                with inner_iarange as ind:
                     pyro.sample("z", dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
     assert_ok(model, guide, trace_graph=True)

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -467,7 +467,7 @@ class RaoBlackwellizationTests(TestCase):
                                                                    torch.pow(self.lam0,
                                                                              -0.5)).reshape(extra_event_dims=1))
             for i in pyro.irange("outer", self.n_outer):
-                for j in pyro.irange("inner", self.n_inner):
+                for j in pyro.irange("inner_%d" % i, self.n_inner):
                     pyro.sample("obs_%d_%d" % (i, j),
                                 dist.Normal(mu_latent, torch.pow(self.lam, -0.5)).reshape(extra_event_dims=1),
                                 obs=self.data[i][j])
@@ -481,7 +481,7 @@ class RaoBlackwellizationTests(TestCase):
                         infer=dict(baseline=dict(use_decaying_avg_baseline=True)))
 
             for i in pyro.irange("outer", self.n_outer):
-                for j in pyro.irange("inner", self.n_inner):
+                for j in pyro.irange("inner_%d" % i, self.n_inner):
                     pass
 
         guide_trace = pyro.poutine.trace(guide, graph_type="dense").get_trace()

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -20,9 +20,10 @@ def test_nested_irange():
     std_batch_size = 3
 
     def model(means, stds):
+        a_iarange = pyro.irange("b", len(stds), std_batch_size)
+        b_iarange = pyro.irange("a", len(means), mean_batch_size)
         return [[pyro.sample("x_{}{}".format(i, j), dist.Normal(means[i], stds[j]))
-                 for j in pyro.irange("b", len(stds), std_batch_size)]
-                for i in pyro.irange("a", len(means), mean_batch_size)]
+                 for j in a_iarange] for i in b_iarange]
 
     xs = model(means, stds)
     assert len(xs) == mean_batch_size
@@ -57,9 +58,10 @@ def nested_irange_model(subsample_size):
     mu = torch.zeros(20)
     sigma = torch.ones(20)
     result = []
+    inner_irange = pyro.irange("inner", 20, 5)
     for i in pyro.irange("outer", 20, subsample_size):
         result.append([])
-        for j in pyro.irange("inner", 20, 5):
+        for j in inner_irange:
             pyro.sample("x_{}_{}".format(i, j), dist.Normal(mu[i] + mu[j], sigma[i] + sigma[j]))
             result[-1].append(j)
     return result

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -20,10 +20,10 @@ def test_nested_irange():
     std_batch_size = 3
 
     def model(means, stds):
-        a_iarange = pyro.irange("b", len(stds), std_batch_size)
-        b_iarange = pyro.irange("a", len(means), mean_batch_size)
+        a_irange = pyro.irange("a", len(means), mean_batch_size)
+        b_irange = pyro.irange("b", len(stds), std_batch_size)
         return [[pyro.sample("x_{}{}".format(i, j), dist.Normal(means[i], stds[j]))
-                 for j in a_iarange] for i in b_iarange]
+                 for j in b_irange] for i in a_irange]
 
     xs = model(means, stds)
     assert len(xs) == mean_batch_size


### PR DESCRIPTION
This is a follow-up to #863 that makes `irange` iterators reusable.

## Why?

The main purpose of this PR is to avoid name mangling in `_Subsample` sites, and thereby to simplify reasoning about `cond_indep_stack`s in `Trace*_ELBO` implementations. Additionally this PR allows finer control of synchronized-vs-independent subsampling in nested `irange`. Synchronized subsampling is often the desired behavior but is not supported before this PR.

Consider the nested `irange` sequence that subsamples 10x10 pixels from a 320x200 image
```py
for i in irange('outer', 200, 10):
    for j in irange('inner', 320, 10):
        ...
```
Before this PR, each `irange('inner')` would be name-mangled and subsample an independent 10 pixels. After this PR this code will error, and users need to be explicit about whether they want synchronized or independent inner subsamples:
```py
def synchronized_model():
    inner_irange = irange('inner', 320, 10)
    for i in irange('outer', 200, 10):
        for j in inner_irange:  # <---- irange is reused
            ...

def independent_model():
    for i in irange('outer', 200, 10):
        for j in irange('inner_%d' % i, 320, 10):  # <---- user must give distinct names
            ...
```

## Tested

- updated many existing tests with new idiom
- added a gradient tests that relies on lack of name mangling