### PR TITLE
Fix brittleness in profiling scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,14 +43,14 @@ jobs:
               - pip install -r docs/requirements.txt
               - make docs
         - stage: perf
-          #if: type = cron
+          if: type = cron
           python: 2.7
           env: STAGE=perf
           script:
               - pip install -e .[profile]
               - make perf-test
         - python: 3.5
-          #if: type = cron
+          if: type = cron
           env: STAGE=perf
           script:
               - pip install -e .[profile]

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ jobs:
               - pip install -e .[profile]
               - make perf-test
         - python: 3.5
+          if: type = cron
           env: STAGE=perf
           script:
               - pip install -e .[profile]

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,12 +50,12 @@ jobs:
               - pip install -e .[profile]
               - make perf-test
         - python: 3.5
-          if: type = cron
           env: STAGE=perf
           script:
               - pip install -e .[profile]
               - make perf-test
-        - python: 2.7
+        - stage: profiler
+          python: 2.7
           env: STAGE=profiler
           script:
               - pip install -e .[profile]

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,14 @@ jobs:
               - pip install -r docs/requirements.txt
               - make docs
         - stage: perf
+          if: type = cron
           python: 2.7
           env: STAGE=perf
           script:
               - pip install -e .[profile]
               - make perf-test
         - python: 3.5
+          if: type = cron
           env: STAGE=perf
           script:
               - pip install -e .[profile]

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,14 +43,14 @@ jobs:
               - pip install -r docs/requirements.txt
               - make docs
         - stage: perf
-          if: type = cron
+          #if: type = cron
           python: 2.7
           env: STAGE=perf
           script:
               - pip install -e .[profile]
               - make perf-test
         - python: 3.5
-          if: type = cron
+          #if: type = cron
           env: STAGE=perf
           script:
               - pip install -e .[profile]

--- a/scripts/perf_test.sh
+++ b/scripts/perf_test.sh
@@ -1,44 +1,39 @@
 #!/usr/bin/env bash
-set -x
+
+set -xe
+
+function _cleanup() {
+    [[ ${#DIRSTACK[@]} -gt 1 ]] && popd
+    [[ -d ${REF_TMP_DIR} ]] && rm -rf ${REF_TMP_DIR}
+}
+
+trap _cleanup EXIT
+
+# Reference is with respect to the `dev` branch, by default.
+REF_HEAD=${1:-dev}
+BENCHMARK_FILE=tests/perf/test_benchmark.py
+IS_BENCHMARK_FILE_IN_DEV=1
+REF_TMP_DIR=.tmp_test_dir
 
 CURRENT_HEAD=$(git rev-parse --abbrev-ref HEAD)
 # If the current state is detached head (e.g. travis), store current commit info instead.
 if [ ${CURRENT_HEAD} = 'HEAD' ]; then
-    git checkout -b tmp
     CURRENT_HEAD=$(git rev-parse HEAD)
 fi
-# Reference is with respect to the `dev` branch.
-REF_HEAD=${1:-dev}
-BENCHMARK_FILE=tests/perf/test_benchmark.py
-IS_BENCHMARK_FILE_IN_DEV=1
-REF_EXIT_CODE=0
-IS_DIRTY=0
 
-# If uncommitted changes exist, stash these and set a flag.
-git diff-index --quiet HEAD -- || IS_DIRTY=1
-git stash
-git checkout ${REF_HEAD}
+# clone the repo into the temporary directory and run benchmark tests
+git clone -b ${REF_HEAD} --single-branch https://github.com/uber/pyro.git ${REF_TMP_DIR}
+pushd ${REF_TMP_DIR}
 
 # Skip if benchmark utils are not on `dev` branch.
 if [ -e ${BENCHMARK_FILE} ]; then
     pytest -vs tests/perf/test_benchmark.py --benchmark-save=${REF_HEAD} --benchmark-name=short \
-        --benchmark-columns=min,median,max --benchmark-sort=name
-
-    REF_EXIT_CODE=$?
-else
-    IS_BENCHMARK_FILE_IN_DEV=0
+        --benchmark-columns=min,median,max --benchmark-sort=name \
+        --benchmark-storage=file://../.benchmarks || echo "ERR: Failed on branch upstream/${REF_HEAD}."
 fi
 
-# Check out the initial git state and pop stash to get uncommitted changes back
-git checkout ${CURRENT_HEAD}
-if [ ${IS_DIRTY} = 1 ]; then
-    git stash pop
-fi
-
-if [ ${REF_EXIT_CODE} != 0 ]; then
-    echo 'Failure on reference branch.'
-    exit 1
-fi
+# cd back into the current repo to run comparison benchmarks
+popd
 
 # Run benchmark comparison - fails if the min run time is 10% less than on the ref branch.
 if [ ${IS_BENCHMARK_FILE_IN_DEV} = 1 ]; then

--- a/scripts/perf_test.sh
+++ b/scripts/perf_test.sh
@@ -22,7 +22,7 @@ if [ ${CURRENT_HEAD} = 'HEAD' ]; then
 fi
 
 # clone the repo into the temporary directory and run benchmark tests
-git clone -b ${REF_HEAD} --single-branch https://github.com/uber/pyro.git ${REF_TMP_DIR}
+git clone -b ${REF_HEAD} --single-branch . ${REF_TMP_DIR}
 pushd ${REF_TMP_DIR}
 
 # Skip if benchmark utils are not on `dev` branch.

--- a/scripts/perf_test.sh
+++ b/scripts/perf_test.sh
@@ -29,7 +29,8 @@ pushd ${REF_TMP_DIR}
 if [ -e ${BENCHMARK_FILE} ]; then
     pytest -vs tests/perf/test_benchmark.py --benchmark-save=${REF_HEAD} --benchmark-name=short \
         --benchmark-columns=min,median,max --benchmark-sort=name \
-        --benchmark-storage=file://../.benchmarks || echo "ERR: Failed on branch upstream/${REF_HEAD}."
+        --benchmark-storage=file://../.benchmarks || echo "ERR: Failed on branch upstream/${REF_HEAD}." \
+        --benchmark-timer timeit.default_timer
 fi
 
 # cd back into the current repo to run comparison benchmarks
@@ -37,9 +38,10 @@ popd
 
 # Run benchmark comparison - fails if the min run time is 10% less than on the ref branch.
 if [ ${IS_BENCHMARK_FILE_IN_DEV} = 1 ]; then
-    pytest -vx tests/perf/test_benchmark.py --benchmark-compare --benchmark-compare-fail=min:20% \
-        --benchmark-name=short --benchmark-columns=min,median,max --benchmark-sort=name
+    pytest -vx tests/perf/test_benchmark.py --benchmark-compare --benchmark-compare-fail=min:15% \
+        --benchmark-name=short --benchmark-columns=min,median,max --benchmark-sort=name \
+        --benchmark-timer timeit.default_timer
 else
     pytest -vx tests/perf/test_benchmark.py --benchmark-name=short --benchmark-columns=min,median,max \
-        --benchmark-sort=name
+        --benchmark-sort=name --benchmark-timer timeit.default_timer
 fi

--- a/scripts/perf_test.sh
+++ b/scripts/perf_test.sh
@@ -37,7 +37,7 @@ popd
 
 # Run benchmark comparison - fails if the min run time is 10% less than on the ref branch.
 if [ ${IS_BENCHMARK_FILE_IN_DEV} = 1 ]; then
-    pytest -vx tests/perf/test_benchmark.py --benchmark-compare --benchmark-compare-fail=min:10% \
+    pytest -vx tests/perf/test_benchmark.py --benchmark-compare --benchmark-compare-fail=min:20% \
         --benchmark-name=short --benchmark-columns=min,median,max --benchmark-sort=name
 else
     pytest -vx tests/perf/test_benchmark.py --benchmark-name=short --benchmark-columns=min,median,max \

--- a/scripts/profile_model.sh
+++ b/scripts/profile_model.sh
@@ -24,7 +24,7 @@ if [ ${CURRENT_HEAD} = 'HEAD' ]; then
 fi
 
 # clone the repo into the temporary directory and run benchmark tests
-git clone -b ${REF_HEAD} --single-branch https://github.com/uber/pyro.git ${REF_TMP_DIR}
+git clone -b ${REF_HEAD} --single-branch . ${REF_TMP_DIR}
 pushd ${REF_TMP_DIR}
 
 # Skip if benchmark utils are not on `dev` branch.

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -81,7 +81,7 @@ def poisson_gamma_model(reparameterized):
 
     adam = optim.Adam({"lr": .0002, "betas": (0.97, 0.999)})
     svi = SVI(model, guide, adam, loss="ELBO", trace_graph=False)
-    for k in range(1000):
+    for k in range(2000):
         svi.step()
 
 
@@ -96,7 +96,7 @@ def bernoulli_beta_hmc(**kwargs):
         return p_latent
     kernel = kwargs.pop('kernel')
     mcmc_kernel = kernel(model, **kwargs)
-    mcmc_run = MCMC(mcmc_kernel, num_samples=300, warmup_steps=50)
+    mcmc_run = MCMC(mcmc_kernel, num_samples=500, warmup_steps=300)
     posterior = []
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -129,6 +129,8 @@ if __name__ == "__main__":
                         help="model name to match against model id, partial match (e.g. *NAME*) is acceptable.")
     parser.add_argument("-b", "--suffix", default="current_branch",
                         help="suffix to append to the cprofile output dump.")
+    parser.add_argument("-d", "--benchmark_dir", default=PROF_DIR,
+                        help="directory to save profiling benchmarks.")
     args = parser.parse_args()
     search_regexp = [re.compile(".*" + m + ".*") for m in args.models]
     profile_ids = []
@@ -144,6 +146,6 @@ if __name__ == "__main__":
         pr = cProfile.Profile()
         fn = profile_fn(test_model)
         pr.runctx("fn()", globals(), locals())
-        profile_file = os.path.join(PROF_DIR, test_model.model_id + "#" + args.suffix + ".prof")
+        profile_file = os.path.join(args.benchmark_dir, test_model.model_id + "#" + args.suffix + ".prof")
         pr.dump_stats(profile_file)
         print("Results in - {}".format(profile_file))


### PR DESCRIPTION
This makes the perf regression and profiling utils from #858 more robust as follows:
 - Instead of checking out some reference branch, we create a `tmp` directory pulling in the single branch from github, based on @fritzo's suggestion. This has the benefit that we do not need to worry about any interactions in the current working directory.
 - A `_cleanup` function is used as an exit trap to ensure that any temporary directory created is removed when the script exits.
 - Increased number of replications.

~NOTE: If the script runs, I will make changes to run it as a cron job instead.~