### PR TITLE
Clean up inference module by using torch.tensor API

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -15,7 +15,7 @@ from pyro.distributions.distribution import Distribution
 from pyro.params import _MODULE_NAMESPACE_DIVIDER, _PYRO_PARAM_STORE, param_with_module_name
 from pyro.poutine import _PYRO_STACK, condition, do  # noqa: F401
 from pyro.poutine.indep_poutine import _DIM_ALLOCATOR
-from pyro.util import am_i_wrapped, apply_stack, deep_getattr, get_tensor_data, ones, set_rng_seed, zeros  # noqa: F401
+from pyro.util import am_i_wrapped, apply_stack, deep_getattr, ones, set_rng_seed, zeros  # noqa: F401
 
 __version__ = '0.1.2'
 
@@ -375,7 +375,7 @@ def module(name, nn_module, tags="default", update_module_params=False):
         full_param_name = param_with_module_name(name, param_name)
         returned_param = param(full_param_name, param_value, tags=tags)
 
-        if get_tensor_data(param_value)._cdata != get_tensor_data(returned_param)._cdata:
+        if param_value._cdata != returned_param._cdata:
             target_state_dict[param_name] = returned_param
 
     if target_state_dict and update_module_params:

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -8,7 +8,6 @@ from collections import OrderedDict
 from inspect import isclass
 
 import torch
-from torch.autograd import Variable
 
 import pyro.poutine as poutine
 from pyro.distributions.distribution import Distribution
@@ -122,7 +121,7 @@ class _Subsample(Distribution):
     def sample(self, sample_shape=torch.Size()):
         """
         :returns: a random subsample of `range(size)`
-        :rtype: torch.autograd.Variable of torch.LongTensor
+        :rtype: torch.LongTensor
         """
         if sample_shape:
             raise NotImplementedError
@@ -130,15 +129,15 @@ class _Subsample(Distribution):
         if subsample_size is None or subsample_size > self.size:
             subsample_size = self.size
         if subsample_size == self.size:
-            result = Variable(torch.LongTensor(list(range(self.size))))
+            result = torch.LongTensor(list(range(self.size)))
         else:
-            result = Variable(torch.randperm(self.size)[:self.subsample_size])
+            result = torch.randperm(self.size)[:self.subsample_size]
         return result.cuda() if self.use_cuda else result
 
     def log_prob(self, x):
         # This is zero so that iarange can provide an unbiased estimate of
         # the non-subsampled log_prob.
-        result = Variable(torch.zeros(1))
+        result = torch.zeros(1)
         return result.cuda() if self.use_cuda else result
 
 

--- a/pyro/contrib/gp/likelihoods/likelihood.py
+++ b/pyro/contrib/gp/likelihoods/likelihood.py
@@ -18,9 +18,9 @@ class Likelihood(Parameterized):
         """
         Samples :math:`y` (``obs``) given :math:`f`.
 
-        :param torch.autograd.Variable f: A 1D tensor of size :math:`N`.
-        :param torch.autograd.Variable obs: A 1D tensor of size :math:`N`.
+        :param torch.Tensor f: A 1D tensor of size :math:`N`.
+        :param torch.Tensor obs: A 1D tensor of size :math:`N`.
         :return: A 1D tensor of size :math:`N`.
-        :rtype: torch.autograd.Variable
+        :rtype: torch.Tensor
         """
         raise NotImplementedError

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import torch
-from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.nn import Parameter
 
@@ -29,8 +28,8 @@ class SparseGPRegression(Model):
     [2] `Variational learning of inducing variables in sparse Gaussian processes`,
     Michalis Titsias
 
-    :param torch.autograd.Variable X: A 1D or 2D tensor of inputs.
-    :param torch.autograd.Variable y: A 1D tensor of outputs for training.
+    :param torch.Tensor X: A 1D or 2D tensor of inputs.
+    :param torch.Tensor y: A 1D tensor of outputs for training.
     :param pyro.contrib.gp.kernels.Kernel kernel: A Pyro kernel object.
     :param torch.Tensor Xu: Initial values for inducing points, which are parameters
         of our model.
@@ -61,7 +60,7 @@ class SparseGPRegression(Model):
             raise ValueError("The sparse approximation method should be one of 'DTC', "
                              "'FITC', 'VFE'.")
 
-        self.jitter = Variable(self.X.data.new([jitter]))
+        self.jitter = self.X.data.new([jitter])
 
     def model(self):
         self.set_mode("model")
@@ -88,7 +87,7 @@ class SparseGPRegression(Model):
             else:  # approx = "VFE"
                 trace_term += (Kffdiag - Qffdiag).sum() / noise
 
-        zero_loc = Variable(D.data.new([0])).expand(self.num_data)
+        zero_loc = D.data.new([0]).expand(self.num_data)
         # DTC: cov = Qff + noise, trace_term = 0
         # FITC: cov = Qff + diag(Kff - Qff) + noise, trace_term = 0
         # VFE: cov = Qff + noise, trace_term = tr(Kff - Qff) / noise
@@ -108,11 +107,11 @@ class SparseGPRegression(Model):
         Computes the parameters of :math:`p(y^*|Xnew) \sim N(\\text{loc}, \\text{cov})`
         w.r.t. the new input :math:`Xnew`.
 
-        :param torch.autograd.Variable Xnew: A 1D or 2D tensor.
+        :param torch.Tensor Xnew: A 1D or 2D tensor.
         :param bool full_cov: Predicts full covariance matrix or just its diagonal.
         :param bool noiseless: Includes noise in the prediction or not.
         :return: loc and covariance matrix of :math:`p(y^*|Xnew)`.
-        :rtype: torch.autograd.Variable and torch.autograd.Variable
+        :rtype: torch.Tensor and torch.Tensor
         """
         self._check_Xnew_shape(Xnew, self.X)
 
@@ -139,7 +138,7 @@ class SparseGPRegression(Model):
 
         W_Dinv = W / D
         M = W.size(0)
-        Id = torch.eye(M, M, out=Variable(W.data.new(M, M)))
+        Id = torch.eye(M, M, out=W.data.new(M, M))
         K = Id + W_Dinv.matmul(W.t())
         L = K.potrf(upper=False)
 

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -12,7 +12,7 @@ import pyro.poutine as poutine
 from pyro.infer.mcmc.trace_kernel import TraceKernel
 from pyro.ops.dual_averaging import DualAveraging
 from pyro.ops.integrator import velocity_verlet, single_step_velocity_verlet
-from pyro.util import ng_ones, ng_zeros, is_nan, is_inf
+from pyro.util import is_nan, is_inf
 
 
 class HMC(TraceKernel):
@@ -204,7 +204,7 @@ class HMC(TraceKernel):
         energy_proposal = self._energy(z_new, r_new)
         energy_current = self._energy(z, r)
         delta_energy = energy_proposal - energy_current
-        rand = pyro.sample("rand_t={}".format(self._t), dist.Uniform(ng_zeros(1), ng_ones(1)))
+        rand = pyro.sample("rand_t={}".format(self._t), dist.Uniform(torch.zeros(1), torch.ones(1)))
         if rand < (-delta_energy).exp():
             self._accept_cnt += 1
             z = z_new

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -4,7 +4,6 @@ import logging
 import math
 
 import torch
-from torch.autograd import Variable
 
 from pyro.infer import TracePosterior
 
@@ -47,5 +46,5 @@ class MCMC(TracePosterior):
                 if t == self.warmup_steps:
                     self.kernel.end_warmup()
                 continue
-            yield (trace, Variable(torch.Tensor([1.0])))
+            yield (trace, torch.tensor([1.0]))
         self.kernel.cleanup()

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -5,7 +5,6 @@ from operator import itemgetter
 
 import networkx
 import torch
-from torch.autograd import variable
 
 import pyro
 import pyro.poutine as poutine
@@ -136,7 +135,7 @@ def _compute_elbo_non_reparam(guide_trace, non_reparam_nodes, downstream_costs):
         if use_decaying_avg_baseline:
             dc_shape = downstream_cost.shape
             avg_downstream_cost_old = pyro.param("__baseline_avg_downstream_cost_" + node,
-                                                 variable(0.0).expand(dc_shape).clone(),
+                                                 torch.tensor(0.0).expand(dc_shape).clone(),
                                                  tags="__tracegraph_elbo_internal_tag")
             avg_downstream_cost_new = (1 - baseline_beta) * downstream_cost.detach() + \
                 baseline_beta * avg_downstream_cost_old

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -33,7 +33,7 @@ def torch_backward(x):
     Like ``x.backward()`` for a :class:`~torch.Tensor`, but also accepts
     numbers (a no-op if given a number).
     """
-    if isinstance(x, torch.autograd.Variable):
+    if torch.is_tensor(x):
         x.backward()
 
 

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -8,7 +8,6 @@ import warnings
 import graphviz
 from six.moves import zip_longest
 import torch
-from torch.autograd import Variable
 from torch.nn import Parameter
 
 from pyro.params import _PYRO_PARAM_STORE
@@ -85,7 +84,7 @@ def am_i_wrapped():
 
 
 def detach_iterable(iterable):
-    if isinstance(iterable, Variable):
+    if isinstance(torch.is_tensor(iterable)):
         return iterable.detach()
     else:
         return [var.detach() for var in iterable]
@@ -101,12 +100,6 @@ def _dict_to_tuple(d):
         return tuple([(k, _dict_to_tuple(d[k])) for k in sorted(d.keys())])
     else:
         return d
-
-
-def get_tensor_data(t):
-    if isinstance(t, Variable):
-        return t.data
-    return t
 
 
 def memoize(fn):
@@ -167,22 +160,22 @@ def ng_ones(*args, **kwargs):
     """
     :param torch.Tensor type_as: optional argument for tensor type
 
-    A convenience function for Variable(torch.ones(...), requires_grad=False)
+    A convenience function for torch.ones(..., requires_grad=False)
     """
     retype = kwargs.pop('type_as', None)
     p_tensor = torch.ones(*args, **kwargs)
-    return Variable(p_tensor if retype is None else p_tensor.type_as(retype), requires_grad=False)
+    return torch.tensor(p_tensor if retype is None else p_tensor.type_as(retype), requires_grad=False)
 
 
 def ng_zeros(*args, **kwargs):
     """
     :param torch.Tensor type_as: optional argument for tensor type
 
-    A convenience function for Variable(torch.ones(...), requires_grad=False)
+    A convenience function for torch.ones(..., requires_grad=False)
     """
     retype = kwargs.pop('type_as', None)
     p_tensor = torch.zeros(*args, **kwargs)
-    return Variable(p_tensor if retype is None else p_tensor.type_as(retype), requires_grad=False)
+    return torch.tensor(p_tensor if retype is None else p_tensor.type_as(retype), requires_grad=False)
 
 
 def is_nan(x):

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -84,7 +84,7 @@ def am_i_wrapped():
 
 
 def detach_iterable(iterable):
-    if isinstance(torch.is_tensor(iterable)):
+    if torch.is_tensor(iterable):
         return iterable.detach()
     else:
         return [var.detach() for var in iterable]

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,7 +4,6 @@ import contextlib
 import numbers
 import os
 import warnings
-from copy import deepcopy
 from itertools import product
 
 import numpy as np
@@ -13,7 +12,6 @@ import torch
 import torch.cuda
 from numpy.testing import assert_allclose
 from pytest import approx
-from torch.autograd import Variable
 
 torch.set_default_tensor_type(os.environ.get('PYRO_TENSOR_TYPE', 'torch.DoubleTensor'))
 
@@ -54,25 +52,6 @@ def get_cpu_type(t):
 def get_gpu_type(t):
     assert t.__module__ == 'torch'
     return getattr(torch.cuda, t.__name__)
-
-
-def to_gpu(obj, type_map={}):
-    if torch.is_tensor(obj):
-        t = type_map.get(type(obj), get_gpu_type(type(obj)))
-        return obj.clone().type(t)
-    elif torch.is_storage(obj):
-        return obj.new().resize_(obj.size()).copy_(obj)
-    elif isinstance(obj, Variable):
-        assert obj.is_leaf
-        t = type_map.get(type(obj.data), get_gpu_type(type(obj.data)))
-        return Variable(obj.data.clone().type(
-            t), requires_grad=obj.requires_grad)
-    elif isinstance(obj, list):
-        return [to_gpu(o, type_map) for o in obj]
-    elif isinstance(obj, tuple):
-        return tuple(to_gpu(o, type_map) for o in obj)
-    else:
-        return deepcopy(obj)
 
 
 @contextlib.contextmanager

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -1,7 +1,6 @@
 import logging
 
 import torch
-from torch.autograd import Variable
 
 import pyro
 import pyro.distributions as dist
@@ -39,14 +38,14 @@ class PriorKernel(TraceKernel):
 
 
 def normal_normal_model(data):
-    x = pyro.param('mu', Variable(torch.Tensor([0.0])))
-    y = pyro.sample('x', dist.Normal(x, Variable(torch.Tensor([1]))))
-    pyro.sample('obs', dist.Normal(y, Variable(torch.Tensor([1]))), obs=data)
+    x = pyro.param('mu', torch.tensor([0.0]))
+    y = pyro.sample('x', dist.Normal(x, torch.tensor([1])))
+    pyro.sample('obs', dist.Normal(y, torch.tensor([1])), obs=data)
     return y
 
 
 def test_mcmc_interface():
-    data = Variable(torch.Tensor([1.0]))
+    data = torch.tensor([1.0])
     kernel = PriorKernel(normal_normal_model)
     mcmc = MCMC(kernel=kernel, num_samples=800, warmup_steps=100)
     marginal = Marginal(mcmc)
@@ -57,5 +56,5 @@ def test_mcmc_interface():
         samples.append(values[dist.sample().item()])
     sample_mean = torch.mean(torch.stack(samples), 0)
     sample_std = torch.std(torch.stack(samples), 0)
-    assert_equal(sample_mean.data, torch.Tensor([0.0]), prec=0.08)
-    assert_equal(sample_std.data, torch.Tensor([1.0]), prec=0.08)
+    assert_equal(sample_mean.data, torch.tensor([0.0]), prec=0.08)
+    assert_equal(sample_std.data, torch.tensor([1.0]), prec=0.08)

--- a/tests/infer/test_compute_downstream_costs.py
+++ b/tests/infer/test_compute_downstream_costs.py
@@ -5,7 +5,6 @@ import math
 import networkx
 import pytest
 import torch
-from torch.autograd import Variable, variable
 
 import pyro
 import pyro.distributions as dist
@@ -58,9 +57,9 @@ def _brute_force_compute_downstream_costs(model_trace, guide_trace,  #
 
 def big_model_guide(include_obs=True, include_single=False, include_inner_1=False, flip_c23=False,
                     include_triple=False, include_z1=False):
-    p0 = variable(math.exp(-0.20), requires_grad=True)
-    p1 = variable(math.exp(-0.33), requires_grad=True)
-    p2 = variable(math.exp(-0.70), requires_grad=True)
+    p0 = torch.tensor(math.exp(-0.20), requires_grad=True)
+    p1 = torch.tensor(math.exp(-0.33), requires_grad=True)
+    p2 = torch.tensor(math.exp(-0.70), requires_grad=True)
     if include_triple:
         with pyro.iarange("iarange_triple1", 6) as ind_triple1:
             with pyro.iarange("iarange_triple2", 7) as ind_triple2:
@@ -92,7 +91,7 @@ def big_model_guide(include_obs=True, include_single=False, include_inner_1=Fals
             assert d2.shape == (4, 2)
             if include_obs:
                 pyro.sample("obs", dist.Bernoulli(p0).reshape(sample_shape=[len(ind_inner), len(ind_outer)]),
-                            obs=Variable(torch.ones(d2.size())))
+                            obs=torch.ones(d2.size()))
 
 
 @pytest.mark.parametrize("include_inner_1", [True, False])
@@ -204,19 +203,19 @@ def test_compute_downstream_costs_big_model_guide_pair(include_inner_1, include_
 
 
 def diamond_model(dim):
-    p0 = variable(math.exp(-0.20), requires_grad=True)
-    p1 = variable(math.exp(-0.33), requires_grad=True)
+    p0 = torch.tensor(math.exp(-0.20), requires_grad=True)
+    p1 = torch.tensor(math.exp(-0.33), requires_grad=True)
     pyro.sample("a1", dist.Bernoulli(p0))
     pyro.sample("c1", dist.Bernoulli(p1))
     for i in pyro.irange("irange", 2):
         b_i = pyro.sample("b{}".format(i), dist.Bernoulli(p0 * p1))
         assert b_i.shape == ()
-    pyro.sample("obs", dist.Bernoulli(p0), obs=variable(1.0))
+    pyro.sample("obs", dist.Bernoulli(p0), obs=torch.tensor(1.0))
 
 
 def diamond_guide(dim):
-    p0 = variable(math.exp(-0.70), requires_grad=True)
-    p1 = variable(math.exp(-0.43), requires_grad=True)
+    p0 = torch.tensor(math.exp(-0.70), requires_grad=True)
+    p1 = torch.tensor(math.exp(-0.43), requires_grad=True)
     pyro.sample("a1", dist.Bernoulli(p0))
     for i in pyro.irange("irange", dim):
         pyro.sample("b{}".format(i), dist.Bernoulli(p1))
@@ -272,8 +271,8 @@ def test_compute_downstream_costs_duplicates(dim):
 
 
 def nested_model_guide(include_obs=True, dim1=11, dim2=7):
-    p0 = variable(math.exp(-0.40 - include_obs * 0.2), requires_grad=True)
-    p1 = variable(math.exp(-0.33 - include_obs * 0.1), requires_grad=True)
+    p0 = torch.tensor(math.exp(-0.40 - include_obs * 0.2), requires_grad=True)
+    p1 = torch.tensor(math.exp(-0.33 - include_obs * 0.1), requires_grad=True)
     pyro.sample("a1", dist.Bernoulli(p0 * p1))
     for i in pyro.irange("irange", dim1):
         pyro.sample("b{}".format(i), dist.Bernoulli(p0))
@@ -281,7 +280,7 @@ def nested_model_guide(include_obs=True, dim1=11, dim2=7):
             c_i = pyro.sample("c{}".format(i), dist.Bernoulli(p1).reshape(sample_shape=[len(ind)]))
             assert c_i.shape == (dim2 + i,)
             if include_obs:
-                obs_i = pyro.sample("obs{}".format(i), dist.Bernoulli(c_i), obs=Variable(torch.ones(c_i.size())))
+                obs_i = pyro.sample("obs{}".format(i), dist.Bernoulli(c_i), obs=torch.ones(c_i.size()))
                 assert obs_i.shape == (dim2 + i,)
 
 
@@ -331,8 +330,8 @@ def test_compute_downstream_costs_iarange_in_irange(dim1):
 
 
 def nested_model_guide2(include_obs=True, dim1=3, dim2=2):
-    p0 = variable(math.exp(-0.40 - include_obs * 0.2), requires_grad=True)
-    p1 = variable(math.exp(-0.33 - include_obs * 0.1), requires_grad=True)
+    p0 = torch.tensor(math.exp(-0.40 - include_obs * 0.2), requires_grad=True)
+    p1 = torch.tensor(math.exp(-0.33 - include_obs * 0.1), requires_grad=True)
     pyro.sample("a1", dist.Bernoulli(p0 * p1))
     with pyro.iarange("iarange", dim1) as ind:
         c = pyro.sample("c", dist.Bernoulli(p1).reshape(sample_shape=[len(ind)]))
@@ -341,7 +340,7 @@ def nested_model_guide2(include_obs=True, dim1=3, dim2=2):
             b_i = pyro.sample("b{}".format(i), dist.Bernoulli(p0).reshape(sample_shape=[len(ind)]))
             assert b_i.shape == (dim1,)
             if include_obs:
-                obs_i = pyro.sample("obs{}".format(i), dist.Bernoulli(b_i), obs=Variable(torch.ones(b_i.size())))
+                obs_i = pyro.sample("obs{}".format(i), dist.Bernoulli(b_i), obs=torch.ones(b_i.size()))
                 assert obs_i.shape == (dim1,)
 
 
@@ -385,8 +384,8 @@ def test_compute_downstream_costs_irange_in_iarange(dim1, dim2):
 
 
 def iarange_reuse_model_guide(include_obs=True, dim1=3, dim2=2):
-    p0 = variable(math.exp(-0.40 - include_obs * 0.2), requires_grad=True)
-    p1 = variable(math.exp(-0.33 - include_obs * 0.1), requires_grad=True)
+    p0 = torch.tensor(math.exp(-0.40 - include_obs * 0.2), requires_grad=True)
+    p1 = torch.tensor(math.exp(-0.33 - include_obs * 0.1), requires_grad=True)
     pyro.sample("a1", dist.Bernoulli(p0 * p1))
     my_iarange1 = pyro.iarange("iarange1", dim1)
     my_iarange2 = pyro.iarange("iarange2", dim2)
@@ -398,7 +397,7 @@ def iarange_reuse_model_guide(include_obs=True, dim1=3, dim2=2):
         with my_iarange1 as ind1:
             c2 = pyro.sample("c2", dist.Bernoulli(p1).reshape(sample_shape=[len(ind2), len(ind1)]))
             if include_obs:
-                pyro.sample("obs", dist.Bernoulli(c2), obs=Variable(torch.ones(c2.size())))
+                pyro.sample("obs", dist.Bernoulli(c2), obs=torch.ones(c2.size()))
 
 
 @pytest.mark.parametrize("dim1", [2, 5])

--- a/tests/infer/test_elbo_mapdata.py
+++ b/tests/infer/test_elbo_mapdata.py
@@ -28,7 +28,7 @@ def test_elbo_mapdata(batch_size, map_type):
     sum_data = torch.zeros(2)
 
     def add_data_point(x, y):
-        data.append(torch.Tensor([x, y]))
+        data.append(torch.tensor([x, y]))
         sum_data.data.add_(data[-1].data)
 
     add_data_point(0.1, 0.21)
@@ -71,11 +71,10 @@ def test_elbo_mapdata(batch_size, map_type):
         return mu_latent
 
     def guide():
-        mu_q = pyro.param("mu_q", analytic_mu_n.data +
-                          torch.tensor([-0.18, 0.23]), requires_grad=True)
+        mu_q = pyro.param("mu_q", torch.tensor(
+            analytic_mu_n.data + torch.tensor([-0.18, 0.23]), requires_grad=True))
         log_sig_q = pyro.param("log_sig_q", torch.tensor(
-            analytic_log_sig_n.data - torch.tensor([-0.18, 0.23]),
-            requires_grad=True))
+            analytic_log_sig_n.data - torch.tensor([-0.18, 0.23]), requires_grad=True))
         sig_q = torch.exp(log_sig_q)
         pyro.sample("mu_latent", dist.Normal(mu_q, sig_q).reshape(extra_event_dims=1))
         if map_type == "irange" or map_type is None:

--- a/tests/infer/test_elbo_mapdata.py
+++ b/tests/infer/test_elbo_mapdata.py
@@ -4,7 +4,6 @@ import logging
 
 import pytest
 import torch
-from torch.autograd import Variable
 
 import pyro
 import pyro.distributions as dist
@@ -21,15 +20,15 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize("map_type", ["iarange", "irange", "range"])
 def test_elbo_mapdata(batch_size, map_type):
     # normal-normal: known covariance
-    lam0 = Variable(torch.Tensor([0.1, 0.1]))   # precision of prior
-    mu0 = Variable(torch.Tensor([0.0, 0.5]))   # prior mean
+    lam0 = torch.tensor([0.1, 0.1])   # precision of prior
+    mu0 = torch.tensor([0.0, 0.5])   # prior mean
     # known precision of observation noise
-    lam = Variable(torch.Tensor([6.0, 4.0]))
+    lam = torch.tensor([6.0, 4.0])
     data = []
-    sum_data = Variable(torch.zeros(2))
+    sum_data = torch.zeros(2)
 
     def add_data_point(x, y):
-        data.append(Variable(torch.Tensor([x, y])))
+        data.append(torch.Tensor([x, y]))
         sum_data.data.add_(data[-1].data)
 
     add_data_point(0.1, 0.21)
@@ -42,7 +41,7 @@ def test_elbo_mapdata(batch_size, map_type):
     add_data_point(-0.04, 0.17)
 
     data = torch.stack(data)
-    n_data = Variable(torch.Tensor([len(data)]))
+    n_data = torch.tensor([len(data)])
     analytic_lam_n = lam0 + n_data.expand_as(lam) * lam
     analytic_log_sig_n = -0.5 * torch.log(analytic_lam_n)
     analytic_mu_n = sum_data * (lam / analytic_lam_n) +\
@@ -72,10 +71,10 @@ def test_elbo_mapdata(batch_size, map_type):
         return mu_latent
 
     def guide():
-        mu_q = pyro.param("mu_q", Variable(analytic_mu_n.data + torch.Tensor([-0.18, 0.23]),
-                                           requires_grad=True))
-        log_sig_q = pyro.param("log_sig_q", Variable(
-            analytic_log_sig_n.data - torch.Tensor([-0.18, 0.23]),
+        mu_q = pyro.param("mu_q", analytic_mu_n.data +
+                          torch.tensor([-0.18, 0.23]), requires_grad=True)
+        log_sig_q = pyro.param("log_sig_q", torch.tensor(
+            analytic_log_sig_n.data - torch.tensor([-0.18, 0.23]),
             requires_grad=True))
         sig_q = torch.exp(log_sig_q)
         pyro.sample("mu_latent", dist.Normal(mu_q, sig_q).reshape(extra_event_dims=1))

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 import torch
 import torch.optim
-from torch.autograd import variable
 
 import pyro
 import pyro.distributions as dist
@@ -25,7 +24,7 @@ logger = logging.getLogger(__name__)
                          ids=["Trace", "TraceGraph", "TraceEnum"])
 def test_subsample_gradient(trace_graph, enum_discrete, reparameterized, subsample):
     pyro.clear_param_store()
-    data = variable([-0.5, 2.0])
+    data = torch.tensor([-0.5, 2.0])
     subsample_size = 1 if subsample else len(data)
     num_particles = 20000
     precision = 0.05
@@ -39,8 +38,8 @@ def test_subsample_gradient(trace_graph, enum_discrete, reparameterized, subsamp
                 pyro.sample("x", Normal(z, 1), obs=x)
 
     def guide(subsample):
-        mu = pyro.param("mu", lambda: variable(torch.zeros(len(data)), requires_grad=True))
-        sigma = pyro.param("sigma", lambda: variable([1.0], requires_grad=True))
+        mu = pyro.param("mu", lambda: torch.tensor(torch.zeros(len(data)), requires_grad=True))
+        sigma = pyro.param("sigma", lambda: torch.tensor([1.0], requires_grad=True))
         with pyro.iarange("particles", num_particles):
             with pyro.iarange("data", len(data), subsample_size, subsample) as ind:
                 mu_ind = mu[ind].unsqueeze(-1).expand(-1, num_particles)
@@ -74,7 +73,7 @@ def test_subsample_gradient(trace_graph, enum_discrete, reparameterized, subsamp
 ], ids=["Trace", "TraceGraph", "TraceEnum"])
 def test_iarange(trace_graph, enum_discrete, reparameterized):
     pyro.clear_param_store()
-    data = variable([-0.5, 2.0])
+    data = torch.tensor([-0.5, 2.0])
     num_particles = 20000
     precision = 0.05
     Normal = dist.Normal if reparameterized else fakes.NonreparameterizedNormal
@@ -93,8 +92,8 @@ def test_iarange(trace_graph, enum_discrete, reparameterized):
         pyro.sample("nuisance_c", Normal(4, 5))
 
     def guide():
-        mu = pyro.param("mu", lambda: variable(torch.zeros(len(data)), requires_grad=True))
-        sigma = pyro.param("sigma", lambda: variable([1.0], requires_grad=True))
+        mu = pyro.param("mu", lambda: torch.tensor(torch.zeros(len(data)), requires_grad=True))
+        sigma = pyro.param("sigma", lambda: torch.tensor([1.0], requires_grad=True))
         mus = mu.unsqueeze(-1).expand(-1, num_particles)
 
         pyro.sample("nuisance_c", Normal(4, 5))
@@ -126,7 +125,7 @@ def test_iarange(trace_graph, enum_discrete, reparameterized):
                          ids=["Trace", "TraceGraph", "TraceEnum"])
 def test_subsample_gradient_sequential(trace_graph, enum_discrete, reparameterized, subsample):
     pyro.clear_param_store()
-    data = variable([-0.5, 2.0])
+    data = torch.tensor([-0.5, 2.0])
     subsample_size = 1 if subsample else len(data)
     num_particles = 5000
     precision = 0.333
@@ -139,8 +138,8 @@ def test_subsample_gradient_sequential(trace_graph, enum_discrete, reparameteriz
             pyro.sample("x", Normal(z, 1), obs=x)
 
     def guide():
-        mu = pyro.param("mu", lambda: variable(torch.zeros(len(data)), requires_grad=True))
-        sigma = pyro.param("sigma", lambda: variable([1.0], requires_grad=True))
+        mu = pyro.param("mu", lambda: torch.tensor(torch.zeros(len(data)), requires_grad=True))
+        sigma = pyro.param("sigma", lambda: torch.tensor([1.0], requires_grad=True))
         with pyro.iarange("data", len(data), subsample_size) as ind:
             pyro.sample("z", Normal(mu[ind], sigma))
 

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -38,7 +38,7 @@ def test_subsample_gradient(trace_graph, enum_discrete, reparameterized, subsamp
                 pyro.sample("x", Normal(z, 1), obs=x)
 
     def guide(subsample):
-        mu = pyro.param("mu", lambda: torch.tensor(torch.zeros(len(data)), requires_grad=True))
+        mu = pyro.param("mu", lambda: torch.zeros(len(data), requires_grad=True))
         sigma = pyro.param("sigma", lambda: torch.tensor([1.0], requires_grad=True))
         with pyro.iarange("particles", num_particles):
             with pyro.iarange("data", len(data), subsample_size, subsample) as ind:
@@ -92,7 +92,7 @@ def test_iarange(trace_graph, enum_discrete, reparameterized):
         pyro.sample("nuisance_c", Normal(4, 5))
 
     def guide():
-        mu = pyro.param("mu", lambda: torch.tensor(torch.zeros(len(data)), requires_grad=True))
+        mu = pyro.param("mu", lambda: torch.zeros(len(data), requires_grad=True))
         sigma = pyro.param("sigma", lambda: torch.tensor([1.0], requires_grad=True))
         mus = mu.unsqueeze(-1).expand(-1, num_particles)
 
@@ -138,7 +138,7 @@ def test_subsample_gradient_sequential(trace_graph, enum_discrete, reparameteriz
             pyro.sample("x", Normal(z, 1), obs=x)
 
     def guide():
-        mu = pyro.param("mu", lambda: torch.tensor(torch.zeros(len(data)), requires_grad=True))
+        mu = pyro.param("mu", lambda: torch.zeros(len(data), requires_grad=True))
         sigma = pyro.param("sigma", lambda: torch.tensor([1.0], requires_grad=True))
         with pyro.iarange("data", len(data), subsample_size) as ind:
             pyro.sample("z", Normal(mu[ind], sigma))

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -226,7 +226,7 @@ class ExponentialGammaTests(TestCase):
         # gamma prior hyperparameter
         self.beta0 = torch.tensor(1.0)
         self.n_data = 2
-        self.data = torch.tensor(torch.Tensor([3.0, 2.0]))  # two observations
+        self.data = torch.tensor([3.0, 2.0])  # two observations
         self.alpha_n = self.alpha0 + torch.tensor(self.n_data)  # posterior alpha
         self.beta_n = self.beta0 + torch.sum(self.data)  # posterior beta
         self.log_alpha_n = torch.log(self.alpha_n)

--- a/tests/infer/test_sampling.py
+++ b/tests/infer/test_sampling.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 
 import pytest
 import torch
-from torch.autograd import Variable
 
 import pyro
 import pyro.infer
@@ -18,10 +17,10 @@ class HMMSamplingTestCase(TestCase):
 
         # simple Gaussian-emission HMM
         def model():
-            p_latent = pyro.param("p1", Variable(torch.Tensor([[0.7], [0.3]])))
-            p_obs = pyro.param("p2", Variable(torch.Tensor([[0.9], [0.1]])))
+            p_latent = pyro.param("p1", torch.tensor([[0.7], [0.3]]))
+            p_obs = pyro.param("p2", torch.tensor([[0.9], [0.1]]))
 
-            latents = [Variable(torch.ones(1, 1))]
+            latents = [torch.ones(1, 1)]
             observes = []
             for t in range(self.model_steps):
 
@@ -47,20 +46,20 @@ class NormalNormalSamplingTestCase(TestCase):
         pyro.clear_param_store()
 
         def model():
-            mu = pyro.sample("mu", Normal(Variable(torch.zeros(1)),
-                                          Variable(torch.ones(1))))
-            xd = Normal(mu, Variable(torch.ones(1)))
+            mu = pyro.sample("mu", Normal(torch.zeros(1),
+                                          torch.ones(1)))
+            xd = Normal(mu, torch.ones(1))
             pyro.observe("xs", xd, self.data)
             return mu
 
         def guide():
-            return pyro.sample("mu", Normal(Variable(torch.zeros(1)),
-                                            Variable(torch.ones(1))))
+            return pyro.sample("mu", Normal(torch.zeros(1),
+                                            torch.ones(1)))
 
         # data
-        self.data = Variable(torch.zeros(50, 1))
-        self.mu_mean = Variable(torch.zeros(1))
-        self.mu_stddev = torch.sqrt(Variable(torch.ones(1)) / 51.0)
+        self.data = torch.zeros(50, 1)
+        self.mu_mean = torch.zeros(1)
+        self.mu_stddev = torch.sqrt(torch.ones(1)) / 51.0
 
         # model and guide
         self.model = model

--- a/tests/infer/test_sampling.py
+++ b/tests/infer/test_sampling.py
@@ -59,7 +59,7 @@ class NormalNormalSamplingTestCase(TestCase):
         # data
         self.data = torch.zeros(50, 1)
         self.mu_mean = torch.zeros(1)
-        self.mu_stddev = torch.sqrt(torch.ones(1)) / 51.0
+        self.mu_stddev = torch.sqrt(torch.ones(1) / 51.0)
 
         # model and guide
         self.model = model
@@ -104,7 +104,7 @@ class ImportanceTest(NormalNormalSamplingTestCase):
 
     @pytest.mark.init(rng_seed=0)
     def test_importance_guide(self):
-        posterior = pyro.infer.Importance(self.model, guide=self.guide, num_samples=10000)
+        posterior = pyro.infer.Importance(self.model, guide=self.guide, num_samples=5000)
         marginal = pyro.infer.Marginal(posterior)
         posterior_samples = [marginal() for i in range(1000)]
         posterior_mean = torch.mean(torch.cat(posterior_samples))

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -5,7 +5,6 @@ import warnings
 
 import pytest
 import torch
-from torch.autograd import Variable, variable
 
 import pyro
 import pyro.distributions as dist
@@ -56,8 +55,8 @@ def assert_warning(model, guide, **kwargs):
 def test_nonempty_model_empty_guide_ok(trace_graph, enum_discrete):
 
     def model():
-        mu = Variable(torch.Tensor([0, 0]))
-        sigma = Variable(torch.Tensor([1, 1]))
+        mu = torch.tensor([0, 0])
+        sigma = torch.tensor([1, 1])
         pyro.sample("x", dist.Normal(mu, sigma).reshape(extra_event_dims=1), obs=mu)
 
     def guide():
@@ -86,12 +85,12 @@ def test_empty_model_empty_guide_ok(trace_graph, enum_discrete):
 def test_variable_clash_in_model_error(trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         pyro.sample("x", dist.Bernoulli(p))
         pyro.sample("x", dist.Bernoulli(p))  # Should error here.
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         pyro.sample("x", dist.Bernoulli(p))
 
     assert_error(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
@@ -103,13 +102,13 @@ def test_variable_clash_in_model_error(trace_graph, enum_discrete):
 def test_model_guide_dim_mismatch_error(trace_graph, enum_discrete):
 
     def model():
-        mu = Variable(torch.zeros(2))
-        sigma = Variable(torch.zeros(2))
+        mu = torch.zeros(2)
+        sigma = torch.zeros(2)
         pyro.sample("x", dist.Normal(mu, sigma))
 
     def guide():
-        mu = pyro.param("mu", Variable(torch.zeros(2, 1), requires_grad=True))
-        sigma = pyro.param("sigma", Variable(torch.zeros(2, 1), requires_grad=True))
+        mu = pyro.param("mu", torch.zeros(2, 1, requires_grad=True))
+        sigma = pyro.param("sigma", torch.zeros(2, 1, requires_grad=True))
         pyro.sample("x", dist.Normal(mu, sigma))
 
     assert_error(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
@@ -121,13 +120,13 @@ def test_model_guide_dim_mismatch_error(trace_graph, enum_discrete):
 def test_model_guide_shape_mismatch_error(trace_graph, enum_discrete):
 
     def model():
-        mu = Variable(torch.zeros(1, 2))
-        sigma = Variable(torch.zeros(1, 2))
+        mu = torch.zeros(1, 2)
+        sigma = torch.zeros(1, 2)
         pyro.sample("x", dist.Normal(mu, sigma))
 
     def guide():
-        mu = pyro.param("mu", Variable(torch.zeros(2, 1), requires_grad=True))
-        sigma = pyro.param("sigma", Variable(torch.zeros(2, 1), requires_grad=True))
+        mu = pyro.param("mu", torch.zeros(2, 1, requires_grad=True))
+        sigma = pyro.param("sigma", torch.zeros(2, 1, requires_grad=True))
         pyro.sample("x", dist.Normal(mu, sigma))
 
     assert_error(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
@@ -139,11 +138,11 @@ def test_model_guide_shape_mismatch_error(trace_graph, enum_discrete):
 def test_variable_clash_in_guide_error(trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         pyro.sample("x", dist.Bernoulli(p))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         pyro.sample("x", dist.Bernoulli(p))
         pyro.sample("x", dist.Bernoulli(p))  # Should error here.
 
@@ -157,12 +156,12 @@ def test_variable_clash_in_guide_error(trace_graph, enum_discrete):
 def test_irange_ok(subsample_size, trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         for i in pyro.irange("irange", 10, subsample_size):
             pyro.sample("x_{}".format(i), dist.Bernoulli(p))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         for i in pyro.irange("irange", 10, subsample_size):
             pyro.sample("x_{}".format(i), dist.Bernoulli(p))
 
@@ -175,13 +174,13 @@ def test_irange_ok(subsample_size, trace_graph, enum_discrete):
 def test_irange_variable_clash_error(trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         for i in pyro.irange("irange", 2):
             # Each loop iteration should give the sample site a different name.
             pyro.sample("x", dist.Bernoulli(p))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         for i in pyro.irange("irange", 2):
             # Each loop iteration should give the sample site a different name.
             pyro.sample("x", dist.Bernoulli(p))
@@ -196,12 +195,12 @@ def test_irange_variable_clash_error(trace_graph, enum_discrete):
 def test_iarange_ok(subsample_size, trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         with pyro.iarange("iarange", 10, subsample_size) as ind:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         with pyro.iarange("iarange", 10, subsample_size) as ind:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
@@ -214,12 +213,12 @@ def test_iarange_ok(subsample_size, trace_graph, enum_discrete):
 def test_iarange_no_size_ok(trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         with pyro.iarange("iarange"):
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[10]))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         with pyro.iarange("iarange"):
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[10]))
 
@@ -233,7 +232,7 @@ def test_iarange_no_size_ok(trace_graph, enum_discrete):
 def test_irange_irange_ok(subsample_size, trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         outer_irange = pyro.irange("irange_0", 10, subsample_size)
         inner_irange = pyro.irange("irange_1", 10, subsample_size)
         for i in outer_irange:
@@ -241,7 +240,7 @@ def test_irange_irange_ok(subsample_size, trace_graph, enum_discrete):
                 pyro.sample("x_{}_{}".format(i, j), dist.Bernoulli(p))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         outer_irange = pyro.irange("irange_0", 10, subsample_size)
         inner_irange = pyro.irange("irange_1", 10, subsample_size)
         for i in outer_irange:
@@ -258,7 +257,7 @@ def test_irange_irange_ok(subsample_size, trace_graph, enum_discrete):
 def test_irange_irange_swap_ok(subsample_size, trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         outer_irange = pyro.irange("irange_0", 10, subsample_size)
         inner_irange = pyro.irange("irange_1", 10, subsample_size)
         for i in outer_irange:
@@ -266,7 +265,7 @@ def test_irange_irange_swap_ok(subsample_size, trace_graph, enum_discrete):
                 pyro.sample("x_{}_{}".format(i, j), dist.Bernoulli(p))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         outer_irange = pyro.irange("irange_0", 10, subsample_size)
         inner_irange = pyro.irange("irange_1", 10, subsample_size)
         for j in inner_irange:
@@ -283,13 +282,13 @@ def test_irange_irange_swap_ok(subsample_size, trace_graph, enum_discrete):
 def test_irange_in_model_not_guide_ok(subsample_size, trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         for i in pyro.irange("irange", 10, subsample_size):
             pass
         pyro.sample("x", dist.Bernoulli(p))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         pyro.sample("x", dist.Bernoulli(p))
 
     assert_ok(model, guide, trace_graph=trace_graph, enum_discrete=enum_discrete)
@@ -302,11 +301,11 @@ def test_irange_in_model_not_guide_ok(subsample_size, trace_graph, enum_discrete
 def test_irange_in_guide_not_model_error(subsample_size, trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         pyro.sample("x", dist.Bernoulli(p))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         for i in pyro.irange("irange", 10, subsample_size):
             pass
         pyro.sample("x", dist.Bernoulli(p))
@@ -320,7 +319,7 @@ def test_irange_in_guide_not_model_error(subsample_size, trace_graph, enum_discr
 def test_iarange_broadcast_error(trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5, requires_grad=True)
+        p = torch.tensor(0.5, requires_grad=True)
         with pyro.iarange("iarange", 10, 5):
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[1]))
 
@@ -333,13 +332,13 @@ def test_iarange_broadcast_error(trace_graph, enum_discrete):
 def test_iarange_irange_ok(trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         with pyro.iarange("iarange", 10, 5) as ind:
             for i in pyro.irange("irange", 10, 5):
                 pyro.sample("x_{}".format(i), dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         with pyro.iarange("iarange", 10, 5) as ind:
             for i in pyro.irange("irange", 10, 5):
                 pyro.sample("x_{}".format(i), dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
@@ -353,14 +352,14 @@ def test_iarange_irange_ok(trace_graph, enum_discrete):
 def test_irange_iarange_ok(trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         inner_iarange = pyro.iarange("iarange", 10, 5)
         for i in pyro.irange("irange", 10, 5):
             with inner_iarange as ind:
                 pyro.sample("x_{}".format(i), dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         inner_iarange = pyro.iarange("iarange", 10, 5)
         for i in pyro.irange("irange", 10, 5):
             with inner_iarange as ind:
@@ -375,7 +374,7 @@ def test_irange_iarange_ok(trace_graph, enum_discrete):
 def test_nested_iarange_iarange_ok(trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5, requires_grad=True)
+        p = torch.tensor(0.5, requires_grad=True)
         with pyro.iarange("iarange_outer", 10, 5) as ind_outer:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[len(ind_outer)]))
             with pyro.iarange("iarange_inner", 11, 6) as ind_inner:
@@ -390,7 +389,7 @@ def test_nested_iarange_iarange_ok(trace_graph, enum_discrete):
 def test_iarange_reuse_ok(trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5, requires_grad=True)
+        p = torch.tensor(0.5, requires_grad=True)
         iarange_outer = pyro.iarange("iarange_outer", 10, 5, dim=-1)
         iarange_inner = pyro.iarange("iarange_inner", 11, 6, dim=-2)
         with iarange_outer as ind_outer:
@@ -409,7 +408,7 @@ def test_iarange_reuse_ok(trace_graph, enum_discrete):
 def test_nested_iarange_iarange_dim_error_1(trace_graph, enum_discrete):
 
     def model():
-        p = Variable(torch.Tensor([0.5]), requires_grad=True)
+        p = torch.tensor([0.5], requires_grad=True)
         with pyro.iarange("iarange_outer", 10, 5) as ind_outer:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[len(ind_outer)]))  # error here
             with pyro.iarange("iarange_inner", 11, 6) as ind_inner:
@@ -425,7 +424,7 @@ def test_nested_iarange_iarange_dim_error_1(trace_graph, enum_discrete):
 def test_nested_iarange_iarange_dim_error_2(trace_graph, enum_discrete):
 
     def model():
-        p = Variable(torch.Tensor([0.5]), requires_grad=True)
+        p = torch.tensor([0.5], requires_grad=True)
         with pyro.iarange("iarange_outer", 10, 5) as ind_outer:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[len(ind_outer), 1]))
             with pyro.iarange("iarange_inner", 11, 6) as ind_inner:
@@ -441,7 +440,7 @@ def test_nested_iarange_iarange_dim_error_2(trace_graph, enum_discrete):
 def test_nested_iarange_iarange_dim_error_3(trace_graph, enum_discrete):
 
     def model():
-        p = Variable(torch.Tensor([0.5]), requires_grad=True)
+        p = torch.tensor([0.5], requires_grad=True)
         with pyro.iarange("iarange_outer", 10, 5) as ind_outer:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[len(ind_outer), 1]))
             with pyro.iarange("iarange_inner", 11, 6) as ind_inner:
@@ -457,7 +456,7 @@ def test_nested_iarange_iarange_dim_error_3(trace_graph, enum_discrete):
 def test_nested_iarange_iarange_dim_error_4(trace_graph, enum_discrete):
 
     def model():
-        p = Variable(torch.Tensor([0.5]), requires_grad=True)
+        p = torch.tensor([0.5], requires_grad=True)
         with pyro.iarange("iarange_outer", 10, 5) as ind_outer:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[len(ind_outer), 1]))
             with pyro.iarange("iarange_inner", 11, 6) as ind_inner:
@@ -473,7 +472,7 @@ def test_nested_iarange_iarange_dim_error_4(trace_graph, enum_discrete):
 def test_nonnested_iarange_iarange_ok(trace_graph, enum_discrete):
 
     def model():
-        p = variable(0.5, requires_grad=True)
+        p = torch.tensor(0.5, requires_grad=True)
         with pyro.iarange("iarange_0", 10, 5) as ind1:
             pyro.sample("x0", dist.Bernoulli(p).reshape(sample_shape=[len(ind1)]))
         with pyro.iarange("iarange_1", 11, 6) as ind2:
@@ -489,7 +488,7 @@ def test_three_indep_iarange_at_different_depths_ok():
     ia ia
     """
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         inner_iarange = pyro.iarange("iarange1", 10, 5)
         for i in pyro.irange("irange0", 2):
             pyro.sample("x_%d" % i, dist.Bernoulli(p))
@@ -502,7 +501,7 @@ def test_three_indep_iarange_at_different_depths_ok():
                     pyro.sample("z", dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         inner_iarange = pyro.iarange("iarange1", 10, 5)
         for i in pyro.irange("irange0", 2):
             pyro.sample("x_%d" % i, dist.Bernoulli(p))
@@ -520,12 +519,12 @@ def test_three_indep_iarange_at_different_depths_ok():
 def test_iarange_wrong_size_error():
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         with pyro.iarange("iarange", 10, 5) as ind:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[1 + len(ind)]))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         with pyro.iarange("iarange", 10, 5) as ind:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[1 + len(ind)]))
 
@@ -535,11 +534,11 @@ def test_iarange_wrong_size_error():
 def test_enum_discrete_single_ok():
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         pyro.sample("x", dist.Bernoulli(p))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         pyro.sample("x", dist.Bernoulli(p))
 
     assert_ok(model, config_enumerate(guide), enum_discrete=True)
@@ -548,12 +547,12 @@ def test_enum_discrete_single_ok():
 def test_enum_discrete_single_single_ok():
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         pyro.sample("x", dist.Bernoulli(p))
         pyro.sample("y", dist.Bernoulli(p))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         pyro.sample("x", dist.Bernoulli(p))
         pyro.sample("y", dist.Bernoulli(p))
 
@@ -563,12 +562,12 @@ def test_enum_discrete_single_single_ok():
 def test_enum_discrete_irange_single_ok():
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         for i in pyro.irange("irange", 10, 5):
             pyro.sample("x_{}".format(i), dist.Bernoulli(p))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         for i in pyro.irange("irange", 10, 5):
             pyro.sample("x_{}".format(i), dist.Bernoulli(p))
 
@@ -578,12 +577,12 @@ def test_enum_discrete_irange_single_ok():
 def test_iarange_enum_discrete_batch_ok():
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         with pyro.iarange("iarange", 10, 5) as ind:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         with pyro.iarange("iarange", 10, 5) as ind:
             pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[len(ind)]))
 
@@ -593,14 +592,14 @@ def test_iarange_enum_discrete_batch_ok():
 def test_iarange_enum_discrete_no_discrete_vars_ok():
 
     def model():
-        mu = variable(0.0)
-        sigma = variable(1.0)
+        mu = torch.tensor(0.0)
+        sigma = torch.tensor(1.0)
         with pyro.iarange("iarange", 10, 5) as ind:
             pyro.sample("x", dist.Normal(mu, sigma).reshape(sample_shape=[len(ind)]))
 
     def guide():
-        mu = pyro.param("mu", variable(1.0, requires_grad=True))
-        sigma = pyro.param("sigma", variable(2.0, requires_grad=True))
+        mu = pyro.param("mu", torch.tensor(1.0, requires_grad=True))
+        sigma = pyro.param("sigma", torch.tensor(2.0, requires_grad=True))
         with pyro.iarange("iarange", 10, 5) as ind:
             pyro.sample("x", dist.Normal(mu, sigma).reshape(sample_shape=[len(ind)]))
 
@@ -610,11 +609,11 @@ def test_iarange_enum_discrete_no_discrete_vars_ok():
 def test_no_iarange_enum_discrete_batch_error():
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[5]))
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         pyro.sample("x", dist.Bernoulli(p).reshape(sample_shape=[5]))
 
     assert_error(model, config_enumerate(guide), enum_discrete=True)
@@ -625,12 +624,12 @@ def test_enum_discrete_parallel_ok(max_iarange_nesting):
     iarange_shape = torch.Size([1] * max_iarange_nesting)
 
     def model():
-        p = variable(0.5)
+        p = torch.tensor(0.5)
         x = pyro.sample("x", dist.Bernoulli(p))
         assert x.shape == torch.Size([2]) + iarange_shape
 
     def guide():
-        p = pyro.param("p", variable(0.5, requires_grad=True))
+        p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         x = pyro.sample("x", dist.Bernoulli(p))
         assert x.shape == torch.Size([2]) + iarange_shape
 
@@ -643,8 +642,8 @@ def test_enum_discrete_parallel_nested_ok(max_iarange_nesting):
     iarange_shape = torch.Size([1] * max_iarange_nesting)
 
     def model():
-        p2 = Variable(torch.ones(2) / 2)
-        p3 = Variable(torch.ones(3) / 3)
+        p2 = torch.tensor(torch.ones(2) / 2)
+        p3 = torch.tensor(torch.ones(3) / 3)
         x2 = pyro.sample("x2", dist.OneHotCategorical(p2))
         x3 = pyro.sample("x3", dist.OneHotCategorical(p3))
         assert x2.shape == torch.Size([2]) + iarange_shape + p2.shape
@@ -658,9 +657,9 @@ def test_enum_discrete_parallel_iarange_ok():
     enum_discrete = "defined below"
 
     def model():
-        p2 = Variable(torch.ones(2) / 2)
-        p34 = Variable(torch.ones(3, 4) / 4)
-        p536 = Variable(torch.ones(5, 3, 6) / 6)
+        p2 = torch.ones(2) / 2
+        p34 = torch.ones(3, 4) / 4
+        p536 = torch.ones(5, 3, 6) / 6
 
         x2 = pyro.sample("x2", dist.Categorical(p2))
         with pyro.iarange("outer", 3):

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -420,7 +420,7 @@ class GaussianPyramidTests(TestCase):
                                                          requires_grad=True))
             for dep in deps:
                 kappa_dep = pyro.param("kappa_" + node_suffix + '_' + dep[10:],
-                                       torch.tensor(torch.Tensor([0.5 + difficulty * i / n_nodes]),
+                                       torch.tensor([0.5 + difficulty * i / n_nodes],
                                                     requires_grad=True))
                 mean_function_node = mean_function_node + kappa_dep * latents_dict[dep]
             node_flagged = True if self.which_nodes_reparam[i] == 1.0 else False

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -5,7 +5,6 @@ import gc
 import networkx as nx
 import pytest
 import torch
-from torch.autograd import Variable
 
 import pyro
 import pyro.distributions as dist
@@ -24,11 +23,11 @@ def count_objects_of_type(type_):
 
 def test_trace():
     n = 11
-    data = Variable(torch.zeros(n))
+    data = torch.zeros(n)
 
     def model(data):
-        loc = pyro.param('loc', Variable(torch.zeros(n), requires_grad=True))
-        scale = pyro.param('log_scale', Variable(torch.zeros(n), requires_grad=True)).exp()
+        loc = pyro.param('loc', torch.zeros(n, requires_grad=True))
+        scale = pyro.param('log_scale', torch.zeros(n, requires_grad=True)).exp()
         pyro.sample('obs', dist.Normal(loc, scale).reshape(extra_event_dims=1), obs=data)
 
     counts = []
@@ -88,11 +87,11 @@ def test_copy():
 
 def test_trace_copy():
     n = 11
-    data = Variable(torch.zeros(n))
+    data = torch.zeros(n)
 
     def model(data):
-        loc = pyro.param('loc', Variable(torch.zeros(n), requires_grad=True))
-        scale = pyro.param('log_scale', Variable(torch.zeros(n), requires_grad=True)).exp()
+        loc = pyro.param('loc', torch.zeros(n, requires_grad=True))
+        scale = pyro.param('log_scale', torch.zeros(n, requires_grad=True)).exp()
         pyro.sample('obs', dist.Normal(loc, scale).reshape(extra_event_dims=1), obs=data)
 
     counts = []
@@ -113,11 +112,11 @@ def trace_replay(model, guide, *args):
 
 def test_trace_replay():
     n = 11
-    data = Variable(torch.zeros(n))
+    data = torch.zeros(n)
 
     def model(data):
-        loc = pyro.param('loc', Variable(torch.zeros(n), requires_grad=True))
-        scale = pyro.param('log_scale', Variable(torch.zeros(n), requires_grad=True)).exp()
+        loc = pyro.param('loc', torch.zeros(n, requires_grad=True))
+        scale = pyro.param('log_scale', torch.zeros(n, requires_grad=True)).exp()
         pyro.sample('obs', dist.Normal(loc, scale).reshape(extra_event_dims=1), obs=data)
 
     def guide(data):
@@ -136,11 +135,11 @@ def test_trace_replay():
 
 def test_svi():
     n = 11
-    data = Variable(torch.zeros(n))
+    data = torch.zeros(n)
 
     def model(data):
-        loc = pyro.param('loc', Variable(torch.zeros(n), requires_grad=True))
-        scale = pyro.param('log_scale', Variable(torch.zeros(n), requires_grad=True)).exp()
+        loc = pyro.param('loc', torch.zeros(n, requires_grad=True))
+        scale = pyro.param('log_scale', torch.zeros(n, requires_grad=True)).exp()
         pyro.sample('obs', dist.Normal(loc, scale).reshape(extra_event_dims=1), obs=data)
 
     def guide(data):


### PR DESCRIPTION
Fixes the `pyro.infer` module to use the `torch.tensor` API, along the same lines as some of the previous PRs like #857. 
 - I have removed a few methods that are no longer needed.
 - Reduced the number of samples in `test_importance_guide` test which sporadically times out.
 - Also, modified `contrib.gp.spgr` which was somehow still using the old syntax.
 - Ran perf tests locally.

The tutorials and examples will be modified in a separate PR before we move to PyTorch master.