### PR TITLE
Fix active_dims handling in pyro.contrib.gp

### DIFF
--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -161,7 +161,7 @@ class Combination(Kernel):
             if active_dims == active_dims1:  # on the same active_dims
                 pass
             elif len(active_dims & active_dims1) == 0:  # on disjoint active_dims
-                active_dims = active_dims + active_dims1
+                active_dims = active_dims | active_dims1
             else:
                 raise ValueError("Sub-kernels must act on the same active dimensions or disjoint active "
                                  "dimensions (to create direct sum or tensor product or kernels).")

--- a/tests/contrib/gp/test_kernels.py
+++ b/tests/contrib/gp/test_kernels.py
@@ -102,15 +102,18 @@ def test_combination():
     # test get_subkernel
     assert k.get_subkernel(k5.name) is k5
 
-    # test if error is catched if active_dims are not separated
-    k6 = Matern12(2, variance, lengthscale[0], active_dims=[0, 1])
-    k7 = Matern32(2, variance, lengthscale[0], active_dims=[1, 2])
-    try:
-        Sum(k6, k7)
-    except ValueError:
-        pass
-    else:
-        raise ValueError("Cannot catch ValueError for kernel combination.")
+
+def test_active_dims_overlap_error():
+    k1 = Matern12(2, variance, lengthscale[0], active_dims=[0, 1])
+    k2 = Matern32(2, variance, lengthscale[0], active_dims=[1, 2])
+    with pytest.raises(ValueError):
+        Sum(k1, k2)
+
+
+def test_active_dims_disjoint_ok():
+    k1 = Matern12(2, variance, lengthscale[0], active_dims=[0, 1])
+    k2 = Matern32(1, variance, lengthscale[0], active_dims=[2])
+    Sum(k1, k2)
 
 
 def test_deriving():


### PR DESCRIPTION
Simple fix to use `|` rather than `+` for set operations.

## Tested

- added a regression test
- fixed a nearby death test