### PR TITLE
Run make test-tutorials in the current environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-examples: lint FORCE
 
 test-tutorials: lint FORCE
 	CI=1 grep -l smoke_test tutorial/source/*.ipynb \
-	  | xargs pytest -vx --nbval-lax
+	  | xargs pytest -vx --nbval-lax --current-env
 
 integration-test: lint FORCE
 	pytest -vx -n auto --stage integration


### PR DESCRIPTION
This is to make sure that `make test` runs in the same environment locally. By default, it uses the global ipython install.