### PR TITLE
Add pytorch installation script for mac and linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,8 @@ env:
         - PYTHONPATH=$PWD:$PYTHONPATH
 
 install:
-    # download and install PyTorch wheel
-    - pip install --upgrade awscli
-    - mkdir -p tmp
-    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-        aws s3 --no-sign-request sync s3://pyro-ppl/ci tmp --exclude "*" --include "*-cp27-*";
-      else
-        aws s3 --no-sign-request sync s3://pyro-ppl/ci tmp --exclude "*" --include "*-cp35-*";
-      fi
-    - pip install tmp/*
-    - rm -r tmp
+    # Install PyTorch wheel using the install script
+    - bash scripts/install_pytorch.sh
     - pip install -e .[test]
     - pip freeze
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,15 @@ pip install pyro-ppl[extras]  # for running examples/tutorials
 
 For recent features you can install Pyro from source.
 
-First, build PyTorch following instructions in the PyTorch
+If you are would like to install a compatible CPU version
+ of Pytorch on OSX / Linux, you could use the PyTorch install helper
+ script.
+
+```
+bash scripts/install_pytorch.sh
+```
+
+Alternatively, build PyTorch following instructions in the PyTorch
 [README](https://github.com/pytorch/pytorch/blob/master/README.md).
 ```sh
 git clone --recursive https://github.com/pytorch/pytorch

--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ pip install pyro-ppl[extras]  # for running examples/tutorials
 
 For recent features you can install Pyro from source.
 
-If you are would like to install a compatible CPU version
- of Pytorch on OSX / Linux, you could use the PyTorch install helper
- script.
+To install a compatible CPU version of Pytorch on OSX / Linux, you
+could use the PyTorch install helper script.
 
 ```
 bash scripts/install_pytorch.sh

--- a/scripts/install_pytorch.sh
+++ b/scripts/install_pytorch.sh
@@ -17,7 +17,7 @@ PYTORCH_BUILD_COMMIT=e40425f
 
 
 # Detect OS and Python version numbers.
-OS=$(uname -s)
+OS=$(uname -s | cut -d " " -f1)
 PYTHON_VERSION=$(python -c 'import sys; version=sys.version_info[:3]; print("{0}{1}".format(*version))')
 
 # Lookup wheel names to download

--- a/scripts/install_pytorch.sh
+++ b/scripts/install_pytorch.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -xe
+
+
+TMP_DIR=tmp
+
+function _cleanup() {
+    [[ -d ${TMP_DIR} ]] && rm -rf ${TMP_DIR}
+}
+
+trap _cleanup EXIT
+
+# Adjust as per the version used in CI.
+PYTORCH_VERSION=0.4.0a0
+PYTORCH_BUILD_COMMIT=e40425f
+
+
+# Detect OS and Python version numbers.
+OS=$(uname -s)
+PYTHON_VERSION=$(python -c 'import sys; version=sys.version_info[:3]; print("{0}{1}".format(*version)')
+
+# Lookup wheel names to download
+WHL_VERSION=${PYTORCH_VERSION}%2B${PYTORCH_BUILD_COMMIT}
+PYTORCH_MAC_PY_27_WHL="torch-${WHL_VERSION}-cp27-cp27m-macosx_10_6_x86_64"
+PYTORCH_MAC_PY_35_WHL="torch-${WHL_VERSION}-cp35-cp35m-macosx_10_6_x86_64"
+PYTORCH_MAC_PY_36_WHL="torch-${WHL_VERSION}-cp36-cp36m-macosx_10_6_x86_64"
+PYTORCH_LINUX_PY_27_WHL="torch-{WHL_VERSION}-cp27-cp27mu-linux_x86_64"
+PYTORCH_LINUX_PY_35_WHL="torch-{WHL_VERSION}-cp35-cp36m-linux_x86_64"
+PYTORCH_LINUX_PY_36_WHL="torch-{WHL_VERSION}-cp36-cp36m-linux_x86_64"
+
+# Cloudfront path for the builds
+PYTORCH_OSX_PREFIX="https://d2fefpcigoriu7.cloudfront.net/pytorch-build/linux-cpu/"
+PYTORCH_LINUX_PREFIX="https://d2fefpcigoriu7.cloudfront.net/pytorch-build/mac-cpu/"
+
+
+mkdir -p ${TMP_DIR}
+
+if [[ ${OSTYPE} == Darwin* ]]; then
+    WHL_PREFIX=PYTORCH_OSX_PREFIX
+    WHL_LOOKUP=PYTORCH_MAC_PY_${PYTHON_VERSION}_WHL
+elif [[ ${OSTYPE} == Linux* ]]; then
+    WHL_PREFIX=PYTORCH_LINUX_PREFIX
+    WHL_LOOKUP=PYTORCH_LINUX_${PYTHON_VERSION}_WHL
+else
+    echo "OS - ${OS} current not supported."
+    exit 1
+fi
+
+# Download wheel and install
+wget -P tmp/ "${WHL_PREFIX}/{!WHL_LOOKUP}.whl"
+pip install tmp/*

--- a/scripts/install_pytorch.sh
+++ b/scripts/install_pytorch.sh
@@ -30,17 +30,17 @@ PYTORCH_LINUX_PY_35_WHL="torch-{WHL_VERSION}-cp35-cp36m-linux_x86_64"
 PYTORCH_LINUX_PY_36_WHL="torch-{WHL_VERSION}-cp36-cp36m-linux_x86_64"
 
 # Cloudfront path for the builds
-PYTORCH_OSX_PREFIX="https://d2fefpcigoriu7.cloudfront.net/pytorch-build/linux-cpu/"
-PYTORCH_LINUX_PREFIX="https://d2fefpcigoriu7.cloudfront.net/pytorch-build/mac-cpu/"
+PYTORCH_LINUX_PREFIX="https://d2fefpcigoriu7.cloudfront.net/pytorch-build/linux-cpu"
+PYTORCH_OSX_PREFIX="https://d2fefpcigoriu7.cloudfront.net/pytorch-build/mac-cpu"
 
 
 mkdir -p ${TMP_DIR}
 
 if [[ ${OS} == Darwin* ]]; then
-    WHL_PREFIX=PYTORCH_OSX_PREFIX
+    WHL_PREFIX=${PYTORCH_OSX_PREFIX}
     WHL_LOOKUP=PYTORCH_MAC_PY_${PYTHON_VERSION}_WHL
 elif [[ ${OS} == Linux* ]]; then
-    WHL_PREFIX=PYTORCH_LINUX_PREFIX
+    WHL_PREFIX=${PYTORCH_LINUX_PREFIX}
     WHL_LOOKUP=PYTORCH_LINUX_${PYTHON_VERSION}_WHL
 else
     echo "OS - ${OS} is not supported by the install script."
@@ -48,5 +48,5 @@ else
 fi
 
 # Download wheel and install
-wget -P tmp/ "${WHL_PREFIX}/{!WHL_LOOKUP}.whl"
+wget -P tmp/ "${WHL_PREFIX}/${!WHL_LOOKUP}.whl"
 pip install tmp/*

--- a/scripts/install_pytorch.sh
+++ b/scripts/install_pytorch.sh
@@ -26,7 +26,7 @@ PYTORCH_MAC_PY_27_WHL="torch-${WHL_VERSION}-cp27-cp27m-macosx_10_6_x86_64"
 PYTORCH_MAC_PY_35_WHL="torch-${WHL_VERSION}-cp35-cp35m-macosx_10_6_x86_64"
 PYTORCH_MAC_PY_36_WHL="torch-${WHL_VERSION}-cp36-cp36m-macosx_10_6_x86_64"
 PYTORCH_LINUX_PY_27_WHL="torch-${WHL_VERSION}-cp27-cp27mu-linux_x86_64"
-PYTORCH_LINUX_PY_35_WHL="torch-${WHL_VERSION}-cp35-cp36m-linux_x86_64"
+PYTORCH_LINUX_PY_35_WHL="torch-${WHL_VERSION}-cp35-cp35m-linux_x86_64"
 PYTORCH_LINUX_PY_36_WHL="torch-${WHL_VERSION}-cp36-cp36m-linux_x86_64"
 
 # Cloudfront path for the builds

--- a/scripts/install_pytorch.sh
+++ b/scripts/install_pytorch.sh
@@ -25,9 +25,9 @@ WHL_VERSION=${PYTORCH_VERSION}%2B${PYTORCH_BUILD_COMMIT}
 PYTORCH_MAC_PY_27_WHL="torch-${WHL_VERSION}-cp27-cp27m-macosx_10_6_x86_64"
 PYTORCH_MAC_PY_35_WHL="torch-${WHL_VERSION}-cp35-cp35m-macosx_10_6_x86_64"
 PYTORCH_MAC_PY_36_WHL="torch-${WHL_VERSION}-cp36-cp36m-macosx_10_6_x86_64"
-PYTORCH_LINUX_PY_27_WHL="torch-{WHL_VERSION}-cp27-cp27mu-linux_x86_64"
-PYTORCH_LINUX_PY_35_WHL="torch-{WHL_VERSION}-cp35-cp36m-linux_x86_64"
-PYTORCH_LINUX_PY_36_WHL="torch-{WHL_VERSION}-cp36-cp36m-linux_x86_64"
+PYTORCH_LINUX_PY_27_WHL="torch-${WHL_VERSION}-cp27-cp27mu-linux_x86_64"
+PYTORCH_LINUX_PY_35_WHL="torch-${WHL_VERSION}-cp35-cp36m-linux_x86_64"
+PYTORCH_LINUX_PY_36_WHL="torch-${WHL_VERSION}-cp36-cp36m-linux_x86_64"
 
 # Cloudfront path for the builds
 PYTORCH_LINUX_PREFIX="https://d2fefpcigoriu7.cloudfront.net/pytorch-build/linux-cpu"

--- a/scripts/install_pytorch.sh
+++ b/scripts/install_pytorch.sh
@@ -13,7 +13,7 @@ trap _cleanup EXIT
 
 # Adjust as per the version used in CI.
 PYTORCH_VERSION=0.4.0a0
-PYTORCH_BUILD_COMMIT=e40425f
+PYTORCH_BUILD_COMMIT=$(grep 'git checkout .* a well-tested commit' README.md | cut -f3 -d' ')
 
 
 # Detect OS and Python version numbers.

--- a/scripts/install_pytorch.sh
+++ b/scripts/install_pytorch.sh
@@ -17,7 +17,7 @@ PYTORCH_BUILD_COMMIT=e40425f
 
 
 # Detect OS and Python version numbers.
-OS=$(uname -s | cut -d " " -f1)
+OS=$(uname -s)
 PYTHON_VERSION=$(python -c 'import sys; version=sys.version_info[:3]; print("{0}{1}".format(*version))')
 
 # Lookup wheel names to download
@@ -36,14 +36,14 @@ PYTORCH_LINUX_PREFIX="https://d2fefpcigoriu7.cloudfront.net/pytorch-build/mac-cp
 
 mkdir -p ${TMP_DIR}
 
-if [[ ${OSTYPE} == Darwin* ]]; then
+if [[ ${OS} == Darwin* ]]; then
     WHL_PREFIX=PYTORCH_OSX_PREFIX
     WHL_LOOKUP=PYTORCH_MAC_PY_${PYTHON_VERSION}_WHL
-elif [[ ${OSTYPE} == Linux* ]]; then
+elif [[ ${OS} == Linux* ]]; then
     WHL_PREFIX=PYTORCH_LINUX_PREFIX
     WHL_LOOKUP=PYTORCH_LINUX_${PYTHON_VERSION}_WHL
 else
-    echo "OS - ${OS} current not supported."
+    echo "OS - ${OS} is not supported by the install script."
     exit 1
 fi
 

--- a/scripts/install_pytorch.sh
+++ b/scripts/install_pytorch.sh
@@ -18,7 +18,7 @@ PYTORCH_BUILD_COMMIT=e40425f
 
 # Detect OS and Python version numbers.
 OS=$(uname -s)
-PYTHON_VERSION=$(python -c 'import sys; version=sys.version_info[:3]; print("{0}{1}".format(*version)')
+PYTHON_VERSION=$(python -c 'import sys; version=sys.version_info[:3]; print("{0}{1}".format(*version))')
 
 # Lookup wheel names to download
 WHL_VERSION=${PYTORCH_VERSION}%2B${PYTORCH_BUILD_COMMIT}

--- a/scripts/install_pytorch.sh
+++ b/scripts/install_pytorch.sh
@@ -41,7 +41,7 @@ if [[ ${OS} == Darwin* ]]; then
     WHL_LOOKUP=PYTORCH_MAC_PY_${PYTHON_VERSION}_WHL
 elif [[ ${OS} == Linux* ]]; then
     WHL_PREFIX=${PYTORCH_LINUX_PREFIX}
-    WHL_LOOKUP=PYTORCH_LINUX_${PYTHON_VERSION}_WHL
+    WHL_LOOKUP=PYTORCH_LINUX_PY_${PYTHON_VERSION}_WHL
 else
     echo "OS - ${OS} is not supported by the install script."
     exit 1

--- a/scripts/install_pytorch.sh
+++ b/scripts/install_pytorch.sh
@@ -24,7 +24,7 @@ PYTHON_VERSION=$(python -c 'import sys; version=sys.version_info[:3]; print("{0}
 WHL_VERSION=${PYTORCH_VERSION}%2B${PYTORCH_BUILD_COMMIT}
 PYTORCH_MAC_PY_27_WHL="torch-${WHL_VERSION}-cp27-cp27m-macosx_10_6_x86_64"
 PYTORCH_MAC_PY_35_WHL="torch-${WHL_VERSION}-cp35-cp35m-macosx_10_6_x86_64"
-PYTORCH_MAC_PY_36_WHL="torch-${WHL_VERSION}-cp36-cp36m-macosx_10_6_x86_64"
+PYTORCH_MAC_PY_36_WHL="torch-${WHL_VERSION}-cp36-cp36m-macosx_10_7_x86_64"
 PYTORCH_LINUX_PY_27_WHL="torch-${WHL_VERSION}-cp27-cp27mu-linux_x86_64"
 PYTORCH_LINUX_PY_35_WHL="torch-${WHL_VERSION}-cp35-cp35m-linux_x86_64"
 PYTORCH_LINUX_PY_36_WHL="torch-${WHL_VERSION}-cp36-cp36m-linux_x86_64"


### PR DESCRIPTION
Fixes #896.
 - Includes a PyTorch installation script that can be used to download and install the CPU wheels for PyTorch version compatible with Pyro `dev`. This should make local Pyro development easy since users on `dev` will not have to build PyTorch from source.
 - Uses the same script in `.travis.yml` to install the linux wheels for CI testing.

**Testing:** Ran script locally for osx wheels. Travis will check the wheels for Linux.