### PR TITLE
Add check for TraceEnum_ELBO requirements

### DIFF
--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -10,7 +10,7 @@ from pyro.infer.enum import iter_discrete_traces
 from pyro.infer.util import MultiFrameDice
 from pyro.poutine.enumerate_poutine import EnumeratePoutine
 from pyro.poutine.util import prune_subsample_sites
-from pyro.util import check_model_guide_match, check_site_shape, is_nan
+from pyro.util import check_model_guide_match, check_site_shape, check_traceenum_requirements, is_nan
 
 
 def _compute_dice_elbo(model_trace, guide_trace):
@@ -58,6 +58,7 @@ class TraceEnum_ELBO(ELBO):
                 check_model_guide_match(model_trace, guide_trace)
                 guide_trace = prune_subsample_sites(guide_trace)
                 model_trace = prune_subsample_sites(model_trace)
+                check_traceenum_requirements(model_trace, guide_trace)
 
                 model_trace.compute_batch_log_pdf()
                 for site in model_trace.nodes.values():

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -396,7 +396,7 @@ def check_traceenum_requirements(model_trace, guide_trace):
         for name, site in trace.nodes.items():
             if site["type"] != "sample":
                 continue
-            iranges[name] = tuple(f for f in  site["cond_indep_stack"] if not f.vectorized)
+            iranges[name] = tuple(f for f in site["cond_indep_stack"] if not f.vectorized)
             context = frozenset(f for f in site["cond_indep_stack"] if f.vectorized)
             for restricted_context, names in restricted_contexts.items():
 

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -387,32 +387,54 @@ def check_site_shape(site, max_iarange_nesting):
     # TODO Check parallel dimensions on the left of max_iarange_nesting.
 
 
+def _are_independent(counters1, counters2):
+    for name, counter1 in counters1.items():
+        if name in counters2:
+            if counters2[name] != counter1:
+                return True
+    return False
+
+
 def check_traceenum_requirements(model_trace, guide_trace):
+    """
+    Warn if user could easily rewrite the model or guide in a way that would
+    clearly avoid invalid dependencies on enumerated variables.
+
+    :class:`~pyro.infer.traceenum_elbo.TraceEnum_ELBO` enumerates over
+    synchronized products rather than full cartesian products. Therefore models
+    must ensure that no variable outside of an iarange depends on an enumerated
+    variable inside that iarange. Since full dependency checking is impossible,
+    this function aims to warn only in cases where models can be easily
+    rewitten to be obviously correct.
+    """
     enumerated_sites = set(name for name, site in guide_trace.nodes.items()
                            if site["type"] == "sample" and site["infer"].get("enumerate"))
-    iranges = {}
     for role, trace in [('model', model_trace), ('guide', guide_trace)]:
-        restricted_contexts = defaultdict(set)
+        irange_counters = {}
+        enumerated_contexts = defaultdict(set)
         for name, site in trace.nodes.items():
             if site["type"] != "sample":
                 continue
-            iranges[name] = tuple(f for f in site["cond_indep_stack"] if not f.vectorized)
+            irange_counter = {f.name: f.counter for f in site["cond_indep_stack"] if not f.vectorized}
             context = frozenset(f for f in site["cond_indep_stack"] if f.vectorized)
-            for restricted_context, names in restricted_contexts.items():
 
-                # Check that sites outside each iarange context precede sites inside that context.
-                if context < restricted_context:
-                    names = sorted(n for n in names
-                                   if all(f1.count == f2.count for f1, f2 in zip(iranges[n], iranges[name])))
-                    if names:
-                        diff = sorted(f.name for f in restricted_context - context)
-                        warnings.warn('\n  '.join([
-                            'at {} site "{}", possibly invalid dependency.'.format(role, name),
-                            'Expected site "{}" to precede sites "{}"'.format(name, '", "'.join(sorted(names))),
-                            'to avoid breaking independence of iaranges "{}"'.format('", "'.join(diff)),
-                            ]), RuntimeWarning)
+            # Check that sites outside each independence context precede enumerated sites inside that context.
+            for enumerated_context, names in enumerated_contexts.items():
+                if not (context < enumerated_context):
+                    continue
+                names = sorted(n for n in names if not _are_independent(irange_counter, irange_counters[n]))
+                if not names:
+                    continue
+                diff = sorted(f.name for f in enumerated_context - context)
+                warnings.warn('\n  '.join([
+                    'at {} site "{}", possibly invalid dependency.'.format(role, name),
+                    'Expected site "{}" to precede sites "{}"'.format(name, '", "'.join(sorted(names))),
+                    'to avoid breaking independence of iaranges "{}"'.format('", "'.join(diff)),
+                ]), RuntimeWarning)
+
+            irange_counters[name] = irange_counter
             if name in enumerated_sites:
-                restricted_contexts[context].add(name)
+                enumerated_contexts[context].add(name)
 
 
 def deep_getattr(obj, name):

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -684,3 +684,50 @@ def test_enum_discrete_parallel_iarange_ok():
     enum_discrete = True
     assert_ok(model, config_enumerate(model, "parallel"), enum_discrete=True,
               max_iarange_nesting=2)
+
+
+@pytest.mark.parametrize('enumerate_', [None, "sequential", "parallel"])
+def test_enum_discrete_iarange_dependency_warning(enumerate_):
+
+    def model():
+        with pyro.iarange("iarange", 10, 5):
+            x = pyro.sample("x", dist.Bernoulli(0.5).reshape([5]),
+                            infer={'enumerate': enumerate_})
+        pyro.sample("y", dist.Bernoulli(x.mean()))
+
+    if enumerate_:
+        assert_warning(model, model, enum_discrete=True, max_iarange_nesting=1)
+    else:
+        assert_ok(model, model, enum_discrete=True, max_iarange_nesting=1)
+
+
+@pytest.mark.parametrize('enumerate_', [None, "sequential", "parallel"])
+def test_enum_discrete_irange_iarange_dependency_ok(enumerate_):
+
+    def model():
+        inner_iarange = pyro.iarange("iarange", 10, 5)
+        for i in pyro.irange("irange", 3):
+            pyro.sample("y_{}".format(i), dist.Bernoulli(0.5))
+            with inner_iarange:
+                pyro.sample("x_{}".format(i), dist.Bernoulli(0.5).reshape([5]),
+                            infer={'enumerate': enumerate_})
+
+    assert_ok(model, model, enum_discrete=True, max_iarange_nesting=1)
+
+
+@pytest.mark.parametrize('enumerate_', [None, "sequential", "parallel"])
+def test_enum_discrete_iarange_iarange_dependency_ok(enumerate_):
+
+    def model():
+        x_iarange = pyro.iarange("x_iarange", 10, 5, dim=-1)
+        y_iarange = pyro.iarange("y_iarange", 11, 6, dim=-2)
+        pyro.sample("a", dist.Bernoulli(0.5))
+        with x_iarange:
+            pyro.sample("b", dist.Bernoulli(0.5).reshape([5]))
+        with y_iarange:
+            # Note that it is difficult to check that c does not depend on b.
+            pyro.sample("c", dist.Bernoulli(0.5).reshape([6, 1]))
+        with x_iarange, y_iarange:
+            pyro.sample("d", dist.Bernoulli(0.5).reshape([6, 5]))
+
+    assert_ok(model, model, enum_discrete=True, max_iarange_nesting=2)


### PR DESCRIPTION
This adds a conservative warning to `TraceEnum_ELBO` in cases where the model or guide might contain dependencies on enumerated variables. The warning is only triggered in cases where the model or guide could easily be rewritten to be obviously correct.