### PR TITLE
Remove ng_ones(), ng_zeros() in favor of .new_zeros(), .new_ones()

### DIFF
--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -19,7 +19,6 @@ import numpy as np
 from observations import jsb_chorales
 from os.path import join, exists
 import six.moves.cPickle as pickle
-from pyro.util import ng_zeros
 
 
 # this function processes the raw data; in particular it unsparsifies it
@@ -68,7 +67,7 @@ def reverse_sequences_numpy(mini_batch, seq_lengths):
 # in contrast to `reverse_sequences_numpy`, this function plays
 # nice with torch autograd
 def reverse_sequences_torch(mini_batch, seq_lengths):
-    reversed_mini_batch = ng_zeros(mini_batch.size(), type_as=mini_batch.data)
+    reversed_mini_batch = mini_batch.new_zeros(mini_batch.size())
     for b in range(mini_batch.size(0)):
         T = seq_lengths[b]
         time_slice = np.arange(T - 1, -1, -1)

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -157,28 +157,6 @@ def zeros(*args, **kwargs):
     return Parameter(p_tensor if retype is None else p_tensor.type_as(retype))
 
 
-def ng_ones(*args, **kwargs):
-    """
-    :param torch.Tensor type_as: optional argument for tensor type
-
-    A convenience function for torch.ones(..., requires_grad=False)
-    """
-    retype = kwargs.pop('type_as', None)
-    p_tensor = torch.ones(*args, **kwargs)
-    return torch.tensor(p_tensor if retype is None else p_tensor.type_as(retype), requires_grad=False)
-
-
-def ng_zeros(*args, **kwargs):
-    """
-    :param torch.Tensor type_as: optional argument for tensor type
-
-    A convenience function for torch.ones(..., requires_grad=False)
-    """
-    retype = kwargs.pop('type_as', None)
-    p_tensor = torch.zeros(*args, **kwargs)
-    return torch.tensor(p_tensor if retype is None else p_tensor.type_as(retype), requires_grad=False)
-
-
 def is_nan(x):
     """
     A convenient function to check if a Tensor contains all nan; also works with numbers


### PR DESCRIPTION
PyTorch 0.4 now has more convenient helper functions:
- `torch.zeros()` and `torch.ones()` now return variables (since variables and tensors were merged)
- `x.new_zeros()` and `x.new_ones()` now returns a tensor with same type and *gpu placement* as `x`. This is now preferred because it supports multi-gpu systems. (note that type_as ignored gpu device placement and often created tensors on the wrong gpu in multi gpu systems)