### PR TITLE
Add semver compliant build metadata to Pyro version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ examples/processed
 examples/results
 examples/raw
 examples/dmm/*.pkl
+pyro/_version.py
 processed
 raw
 

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -19,7 +19,14 @@ from pyro.poutine import _PYRO_STACK, condition, do  # noqa: F401
 from pyro.poutine.indep_poutine import _DIM_ALLOCATOR
 from pyro.util import am_i_wrapped, apply_stack, deep_getattr, ones, set_rng_seed, zeros  # noqa: F401
 
-__version__ = '0.1.2'
+version_prefix = '0.2.0-a0'
+
+# Get the __version__ string from the auto-generated _version.py file, if exists.
+try:
+    from pyro._version import __version__
+except ImportError:
+    __version__ = version_prefix
+
 
 # Default logger to prevent 'No handler found' warning.
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,16 @@ for line in open(os.path.join(PROJECT_PATH, 'pyro', '__init__.py')):
         version = line.strip().split()[2][1:-1]
 
 # Append current commit sha to version
-commit_sha = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
-                                     cwd=PROJECT_PATH).strip()
+commit_sha = ''
+try:
+    commit_sha = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
+                                         cwd=PROJECT_PATH).decode('ascii').strip()
+except OSError:
+    pass
 
 # Write version to _version.py
-version += '+{}'.format(commit_sha)
+if commit_sha:
+    version += '+{}'.format(commit_sha)
 with open(os.path.join(PROJECT_PATH, 'pyro', '_version.py'), 'w') as f:
     f.write(VERSION.format(version))
 

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,31 @@
 from __future__ import absolute_import, division, print_function
 
+import subprocess
 import sys
 
+import os
 from setuptools import find_packages, setup
 
+PROJECT_PATH = os.path.dirname(os.path.abspath(__file__))
+VERSION = """
+# This file is auto-generated with the version information during setup.py installation.
+
+__version__ = '{}'
+"""
+
 # Find pyro version.
-for line in open('pyro/__init__.py'):
-    if line.startswith('__version__ = '):
+for line in open(os.path.join(PROJECT_PATH, 'pyro', '__init__.py')):
+    if line.startswith('version_prefix = '):
         version = line.strip().split()[2][1:-1]
+
+# Append current commit sha to version
+commit_sha = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
+                                     cwd=PROJECT_PATH).strip()
+
+# Write version to _version.py
+version += '+{}'.format(commit_sha)
+with open(os.path.join(PROJECT_PATH, 'pyro', '_version.py'), 'w') as f:
+    f.write(VERSION.format(version))
 
 # Convert README.md to rst for display at https://pypi.python.org/pypi/pyro-ppl
 # When releasing on pypi, make sure pandoc is on your system:


### PR DESCRIPTION
Addresses #921 (with a caveat. See below). 

After looking at how a few projects have implemented including the commit sha in their version info, I decided on the following approach (same as that of PyTorch):
 - Only the `version_prefix` needs to be changed anytime we are doing a public release.
 - When `setup.py` is called we read the `version_prefix`, append the current commit information and write to `_version.py`.
 - `__init__.py` reads `__version__` from the `_version.py`.

The caveat is that this will not be sufficient when Pyro is an editable install (i.e. installed via `-e / --editable`). In that case the source may have been modified beyond what is indicated by the commit sha in `_version.py`. For the case of an editable install, we will need a dynamic `__version__`, which first detects (via pip helper utilities) that `pyro-ppl` is an editable installation, and then runs the git incantations to get the current commit information. We will need to be a bit careful with this, but it can be included, if we need.