### PR TITLE
use cat instead of stack in HMC

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -75,7 +75,7 @@ class HMC(TraceKernel):
         return trace_poutine.trace
 
     def _kinetic_energy(self, r):
-        return 0.5 * torch.sum(torch.stack([r[name]**2 for name in r]))
+        return 0.5 * torch.sum(torch.cat([r[name]**2 for name in r]))
 
     def _potential_energy(self, z):
         # Since the model is specified in the constrained space, transform the

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -75,7 +75,7 @@ class HMC(TraceKernel):
         return trace_poutine.trace
 
     def _kinetic_energy(self, r):
-        return 0.5 * torch.sum(torch.cat([r[name]**2 for name in r]))
+        return 0.5 * sum(x.pow(2).sum() for x in r.values())
 
     def _potential_energy(self, z):
         # Since the model is specified in the constrained space, transform the

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -6,7 +6,6 @@ import torch
 
 import pyro
 import pyro.distributions as dist
-from pyro.infer.util import torch_data_sum
 from pyro.ops.integrator import single_step_velocity_verlet
 
 from .hmc import HMC

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -81,10 +81,10 @@ class NUTS(HMC):
         self._max_sliced_energy = 1000
 
     def _is_turning(self, z_left, r_left, z_right, r_right):
-        z_left = torch.stack([z_left[name] for name in self._r_dist])
-        r_left = torch.stack([r_left[name] for name in self._r_dist])
-        z_right = torch.stack([z_right[name] for name in self._r_dist])
-        r_right = torch.stack([r_right[name] for name in self._r_dist])
+        z_left = torch.cat([z_left[name] for name in self._r_dist])
+        r_left = torch.cat([r_left[name] for name in self._r_dist])
+        z_right = torch.cat([z_right[name] for name in self._r_dist])
+        r_right = torch.cat([r_right[name] for name in self._r_dist])
         dz = z_right - z_left
         return (torch_data_sum(dz * r_left) < 0) or (torch_data_sum(dz * r_right) < 0)
 

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -81,12 +81,13 @@ class NUTS(HMC):
         self._max_sliced_energy = 1000
 
     def _is_turning(self, z_left, r_left, z_right, r_right):
-        z_left = torch.cat([z_left[name] for name in self._r_dist])
-        r_left = torch.cat([r_left[name] for name in self._r_dist])
-        z_right = torch.cat([z_right[name] for name in self._r_dist])
-        r_right = torch.cat([r_right[name] for name in self._r_dist])
-        dz = z_right - z_left
-        return (torch_data_sum(dz * r_left) < 0) or (torch_data_sum(dz * r_right) < 0)
+        diff_left = 0
+        diff_right = 0
+        for name in self._r_dist:
+            dz = z_right[name] - z_left[name]
+            diff_left += (dz * r_left[name]).sum()
+            diff_right += (dz * r_right[name]).sum()
+        return diff_left < 0 or diff_right < 0
 
     def _build_basetree(self, z, r, z_grads, log_slice, direction, energy_current):
         step_size = self.step_size if direction == 1 else -self.step_size


### PR DESCRIPTION
Using `torch.stack` for difference size latent variables throw errors because it requires latent variables have same shapes. This pull request changes it to `torch.cat` which covers more cases (still cannot cover arbitrary latent shapes).