### PR TITLE
 Adding EmpiricalDistribution and testing on MCMC

### DIFF
--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import torch
+
+from pyro.distributions.distribution import Distribution
+
+
+class Empirical(Distribution):
+    r"""
+    Empirical distribution associated with the sampled data. This is
+    used for assessing the statistical properties of the sample.
+    In particular, scoring of additional data points from the sample
+    via ``log_prob`` is not currently supported.
+    """
+
+    def __init__(self):
+        self.samples = []
+        self.tensorized_samples = None
+        super(Distribution, self).__init__()
+
+    @property
+    def finalized_tensor(self):
+        """
+        Collect samples along the left-most dimension and return the
+        tensor.
+
+        :return: torch.Tensor
+        """
+        if not self.samples or self.tensorized_samples is None:
+            return self.tensorized_samples
+        new_samples = torch.stack(self.samples, dim=0)
+        self.tensorized_samples = torch.cat([self.tensorized_samples, new_samples], dim=0)
+        self.samples = []
+        return self.tensorized_samples
+
+    def add(self, value):
+        """
+        Adds the data point to the sample. The values in successive
+        calls to ``add`` must have the same tensor shape and size.
+
+        :param torch.Tensor value: tensor to add to the sample.
+        """
+        if self.tensorized_samples is None:
+            self.tensorized_samples = value.new(0)
+        self.samples.append(value)
+
+    def sample(self, sample_shape=torch.Size()):
+        if not sample_shape:
+            rand_idx = np.random.randint(0, high=self.finalized_tensor.size(0), dtype=np.int64)
+        else:
+            rand_idx = np.random.randint(0, high=self.finalized_tensor.size(0), dtype=np.int64,
+                                         size=np.prod(sample_shape).astype(np.int64))
+        return self.finalized_tensor[rand_idx].view(sample_shape + self.batch_shape)
+
+    def log_prob(self, value):
+        raise NotImplemented("Empirical distribution does not implement `log_prob`")
+
+    @property
+    def batch_shape(self):
+        if self.finalized_tensor is None:
+            return None
+        return self.finalized_tensor.size()[1:]
+
+    @property
+    def mean(self):
+        samples = self.finalized_tensor.type(torch.float32) \
+            if self.finalized_tensor.dtype in (torch.int, torch.long) else self.finalized_tensor
+        return samples.mean(dim=0)
+
+    @property
+    def variance(self):
+        samples = self.finalized_tensor.type(torch.float32) \
+            if self.finalized_tensor.dtype in (torch.int, torch.long) else self.finalized_tensor
+        return samples.var(dim=0)

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -34,6 +34,10 @@ class Empirical(Distribution):
         self.samples = []
         return self.tensorized_samples
 
+    @property
+    def sample_size(self):
+        return self.finalized_tensor.size(0)
+
     def add(self, value):
         """
         Adds the data point to the sample. The values in successive

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -50,11 +50,9 @@ class Empirical(Distribution):
         self.samples.append(value)
 
     def sample(self, sample_shape=torch.Size()):
-        if not sample_shape:
-            rand_idx = np.random.randint(0, high=self.finalized_tensor.size(0), dtype=np.int64)
-        else:
-            rand_idx = np.random.randint(0, high=self.finalized_tensor.size(0), dtype=np.int64,
-                                         size=np.prod(sample_shape).astype(np.int64))
+        sample_size = np.prod(sample_shape)
+        rand_idx = torch.empty(size=torch.Size((sample_size,)),
+                               dtype=torch.long).random_(to=self.sample_size)
         return self.finalized_tensor[rand_idx].view(sample_shape + self.batch_shape)
 
     def log_prob(self, value):

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -5,10 +5,10 @@ import math
 
 import torch
 
-from pyro.infer import TracePosterior
+from pyro.infer.mcmc.trace_joint import TraceJoint
 
 
-class MCMC(TracePosterior):
+class MCMC(TraceJoint):
     """
     Wrapper class for Markov Chain Monte Carlo algorithms. Specific MCMC algorithms
     are TraceKernel instances and need to be supplied as a ``kernel`` argument
@@ -46,5 +46,5 @@ class MCMC(TracePosterior):
                 if t == self.warmup_steps:
                     self.kernel.end_warmup()
                 continue
-            yield (trace, torch.tensor([1.0]))
+            yield trace
         self.kernel.cleanup()

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import, division, print_function
 import logging
 import math
 
-import torch
-
 from pyro.infer.mcmc.trace_joint import TraceJoint
 
 

--- a/pyro/infer/mcmc/trace_joint.py
+++ b/pyro/infer/mcmc/trace_joint.py
@@ -1,0 +1,44 @@
+from abc import ABCMeta, abstractmethod
+
+from six import add_metaclass
+
+from pyro.distributions.empirical import Empirical
+
+
+@add_metaclass(ABCMeta)
+class TraceJoint(object):
+    """
+    TODO: merge with TracePosterior
+    """
+    def __init__(self):
+        self._reset()
+
+    def _reset(self):
+        self.traces = []
+        self.marginal_dist = {}
+
+    @abstractmethod
+    def _traces(self, *args, **kwargs):
+        return NotImplementedError
+
+    def run(self, *args, **kwargs):
+        self._reset()
+        for tr in self._traces(*args, **kwargs):
+            self.traces.append(tr)
+        return self
+
+    def marginal(self, site="_RETURN"):
+        """
+        Return the marginal for a sample site from the collection of execution traces.
+        This is cached for any future calls.
+
+        :param site: sample site whose marginal to return.
+        :return: ``dist.Empirical``
+        """
+        if site in self.marginal_dist:
+            return self.marginal_dist[site]
+        marginal_site = Empirical()
+        for tr in self.traces:
+            marginal_site.add(tr.nodes[site]["value"])
+        self.marginal_dist[site] = marginal_site
+        return marginal_site

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -1,0 +1,29 @@
+import pytest
+import torch
+
+from pyro.distributions.empirical import Empirical
+from tests.common import assert_equal
+
+
+@pytest.mark.parametrize("size", [torch.Size(), torch.Size((1,)), torch.Size((2, 3))])
+@pytest.mark.parametrize("dtype", [torch.long, torch.float32, torch.float64])
+def test_mean_and_var(size, dtype):
+    empirical_dist = Empirical()
+    for i in range(5):
+        empirical_dist.add(torch.ones(size, dtype=dtype) * i)
+    true_mean = torch.ones(size) * 2
+    true_var = torch.ones(size) * 2.5
+    assert_equal(empirical_dist.mean, true_mean)
+    assert_equal(empirical_dist.variance, true_var)
+
+
+@pytest.mark.parametrize("batch_shape", [torch.Size(), torch.Size((1,)), torch.Size((2, 3))])
+@pytest.mark.parametrize("sample_shape", [torch.Size((20,)), torch.Size((20, 3, 4))])
+@pytest.mark.parametrize("dtype", [torch.long, torch.float32, torch.float64])
+def test_sample(batch_shape, sample_shape, dtype):
+    empirical_dist = Empirical()
+    for i in range(5):
+        empirical_dist.add(torch.ones(batch_shape, dtype=dtype) * i)
+    samples = empirical_dist.sample(sample_shape=sample_shape)
+    assert_equal(samples.size(), sample_shape + batch_shape)
+    assert_equal(set(samples.view(-1).tolist()), set(range(5)))

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 import logging
 import os
 
@@ -128,18 +128,14 @@ def test_hmc_conjugate_gaussian(fixture,
                                 expected_precs,
                                 mean_tol,
                                 std_tol):
-    hmc_kernel = HMC(fixture.model, **hmc_params)
-    mcmc_run = MCMC(hmc_kernel, num_samples, warmup_steps)
     pyro.get_param_store().clear()
-    post_trace = defaultdict(list)
-    for t, _ in mcmc_run._traces(fixture.data):
-        for i in range(1, fixture.chain_len + 1):
-            param_name = 'mu_' + str(i)
-            post_trace[param_name].append(t.nodes[param_name]['value'])
+    hmc_kernel = HMC(fixture.model, **hmc_params)
+    mcmc_run = MCMC(hmc_kernel, num_samples, warmup_steps).run(fixture.data)
     for i in range(1, fixture.chain_len + 1):
         param_name = 'mu_' + str(i)
-        latent_mu = torch.mean(torch.stack(post_trace[param_name]), 0)
-        latent_std = torch.std(torch.stack(post_trace[param_name]), 0)
+        marginal = mcmc_run.marginal(param_name)
+        latent_mu = marginal.mean
+        latent_std = marginal.variance.sqrt()
         expected_mean = torch.ones(fixture.dim) * expected_means[i - 1]
         expected_std = 1 / torch.sqrt(torch.ones(fixture.dim) * expected_precs[i - 1])
 
@@ -171,12 +167,9 @@ def test_logistic_regression():
         return y
 
     hmc_kernel = HMC(model, step_size=0.0855, num_steps=4)
-    mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100)
-    posterior = []
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['beta']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.05)
+    mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
+    beta_posterior = mcmc_run.marginal('beta')
+    assert_equal(rmse(true_coefs, beta_posterior.mean).item(), 0.0, prec=0.05)
 
 
 def test_bernoulli_beta():
@@ -187,15 +180,12 @@ def test_bernoulli_beta():
         pyro.observe('obs', dist.Bernoulli(p_latent), data)
         return p_latent
 
-    hmc_kernel = HMC(model, step_size=0.02, num_steps=3)
-    mcmc_run = MCMC(hmc_kernel, num_samples=800, warmup_steps=500)
-    posterior = []
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['p_latent']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean, true_probs, prec=0.01)
+    hmc_kernel = HMC(model, step_size=0.02, num_steps=3)
+    mcmc_run = MCMC(hmc_kernel, num_samples=800, warmup_steps=500).run(data)
+    posterior = mcmc_run.marginal("p_latent")
+    assert_equal(posterior.mean, true_probs, prec=0.01)
 
 
 def test_normal_gamma():
@@ -206,15 +196,12 @@ def test_normal_gamma():
         pyro.observe("obs", dist.Normal(3, p_latent), data)
         return p_latent
 
-    hmc_kernel = HMC(model, step_size=0.01, num_steps=3)
-    mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=100)
-    posterior = []
     true_std = torch.tensor([0.5, 2])
     data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['p_latent']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean, true_std, prec=0.02)
+    hmc_kernel = HMC(model, step_size=0.01, num_steps=3)
+    mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=100).run(data)
+    posterior = mcmc_run.marginal('p_latent')
+    assert_equal(posterior.mean, true_std, prec=0.02)
 
 
 @pytest.mark.xfail(reason='log_abs_det_jacobian not implemented for StickBreakingTransform')
@@ -225,15 +212,12 @@ def test_categorical_dirichlet():
         pyro.observe("obs", dist.Categorical(p_latent), data)
         return p_latent
 
-    hmc_kernel = HMC(model, step_size=0.01, num_steps=3)
-    mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=100)
-    posterior = []
     true_probs = torch.tensor([0.1, 0.6, 0.3])
     data = dist.Categorical(true_probs).sample(sample_shape=(torch.Size((2000,))))
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['p_latent']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean, true_probs, prec=0.02)
+    hmc_kernel = HMC(model, step_size=0.01, num_steps=3)
+    mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=100).run(data)
+    posterior = mcmc_run.marginal('p_latent')
+    assert_equal(posterior.mean, true_probs, prec=0.02)
 
 
 def test_logistic_regression_with_dual_averaging():
@@ -249,12 +233,9 @@ def test_logistic_regression_with_dual_averaging():
         return y
 
     hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True)
-    mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100)
-    posterior = []
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['beta']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.05)
+    mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
+    posterior = mcmc_run.marginal('beta')
+    assert_equal(rmse(true_coefs, posterior.mean).item(), 0.0, prec=0.05)
 
 
 def test_bernoulli_beta_with_dual_averaging():
@@ -265,15 +246,12 @@ def test_bernoulli_beta_with_dual_averaging():
         pyro.observe('obs', dist.Bernoulli(p_latent), data)
         return p_latent
 
-    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True)
-    mcmc_run = MCMC(hmc_kernel, num_samples=800, warmup_steps=500)
-    posterior = []
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['p_latent']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean, true_probs, prec=0.01)
+    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True)
+    mcmc_run = MCMC(hmc_kernel, num_samples=800, warmup_steps=500).run(data)
+    posterior = mcmc_run.marginal('p_latent')
+    assert_equal(posterior.mean, true_probs, prec=0.01)
 
 
 @pytest.mark.xfail(reason='the model is sensitive to NaN log_pdf')
@@ -285,12 +263,9 @@ def test_normal_gamma_with_dual_averaging():
         pyro.observe("obs", dist.Normal(3, p_latent), data)
         return p_latent
 
-    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True)
-    mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=100)
-    posterior = []
     true_std = torch.tensor([0.5, 2])
     data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['p_latent']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean, true_std, prec=0.02)
+    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True)
+    mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=100).run(data)
+    posterior = mcmc_run.marginal('p_latent')
+    assert_equal(posterior.mean, true_std, prec=0.02)

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -5,7 +5,6 @@ import torch
 import pyro
 import pyro.distributions as dist
 from pyro import poutine
-from pyro.infer import Marginal
 from pyro.infer.mcmc.mcmc import MCMC
 from pyro.infer.mcmc.trace_kernel import TraceKernel
 from tests.common import assert_equal

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -47,14 +47,10 @@ def normal_normal_model(data):
 def test_mcmc_interface():
     data = torch.tensor([1.0])
     kernel = PriorKernel(normal_normal_model)
-    mcmc = MCMC(kernel=kernel, num_samples=800, warmup_steps=100)
-    marginal = Marginal(mcmc)
-    dist, values = marginal._dist_and_values(data)
-    assert_equal(len(values), 800)
-    samples = []
-    for _ in range(600):
-        samples.append(values[dist.sample().item()])
-    sample_mean = torch.mean(torch.stack(samples), 0)
-    sample_std = torch.std(torch.stack(samples), 0)
-    assert_equal(sample_mean.data, torch.tensor([0.0]), prec=0.08)
-    assert_equal(sample_std.data, torch.tensor([1.0]), prec=0.08)
+    mcmc = MCMC(kernel=kernel, num_samples=800, warmup_steps=100).run(data)
+    marginal = mcmc.marginal()
+    assert_equal(marginal.sample_size, 800)
+    sample_mean = marginal.mean
+    sample_std = marginal.variance.sqrt()
+    assert_equal(sample_mean, torch.tensor([0.0]), prec=0.08)
+    assert_equal(sample_std, torch.tensor([1.0]), prec=0.08)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import defaultdict
 import logging
 import os
 
@@ -42,18 +41,14 @@ def test_nuts_conjugate_gaussian(fixture,
                                  expected_precs,
                                  mean_tol,
                                  std_tol):
-    nuts_kernel = NUTS(fixture.model, hmc_params['step_size'])
-    mcmc_run = MCMC(nuts_kernel, num_samples, warmup_steps)
     pyro.get_param_store().clear()
-    post_trace = defaultdict(list)
-    for t, _ in mcmc_run._traces(fixture.data):
-        for i in range(1, fixture.chain_len + 1):
-            param_name = 'mu_' + str(i)
-            post_trace[param_name].append(t.nodes[param_name]['value'])
+    nuts_kernel = NUTS(fixture.model, hmc_params['step_size'])
+    mcmc_run = MCMC(nuts_kernel, num_samples, warmup_steps).run(fixture.data)
     for i in range(1, fixture.chain_len + 1):
         param_name = 'mu_' + str(i)
-        latent_mu = torch.mean(torch.stack(post_trace[param_name]), 0)
-        latent_std = torch.std(torch.stack(post_trace[param_name]), 0)
+        marginal = mcmc_run.marginal(param_name)
+        latent_mu = marginal.mean
+        latent_std = marginal.variance.sqrt()
         expected_mean = torch.ones(fixture.dim) * expected_means[i - 1]
         expected_std = 1 / torch.sqrt(torch.ones(fixture.dim) * expected_precs[i - 1])
 
@@ -85,12 +80,9 @@ def test_logistic_regression():
         return y
 
     nuts_kernel = NUTS(model, step_size=0.0855)
-    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100)
-    posterior = []
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['beta']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.05)
+    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100).run(data)
+    posterior = mcmc_run.marginal('beta')
+    assert_equal(rmse(true_coefs, posterior.mean).item(), 0.0, prec=0.05)
 
 
 def test_bernoulli_beta():
@@ -101,15 +93,12 @@ def test_bernoulli_beta():
         pyro.observe("obs", dist.Bernoulli(p_latent), data)
         return p_latent
 
-    nuts_kernel = NUTS(model, step_size=0.02)
-    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100)
-    posterior = []
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['p_latent']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean.data, true_probs.data, prec=0.01)
+    nuts_kernel = NUTS(model, step_size=0.02)
+    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100).run(data)
+    posterior = mcmc_run.marginal('p_latent')
+    assert_equal(posterior.mean, true_probs, prec=0.01)
 
 
 def test_normal_gamma():
@@ -120,15 +109,12 @@ def test_normal_gamma():
         pyro.observe("obs", dist.Normal(3, p_latent), data)
         return p_latent
 
-    nuts_kernel = NUTS(model, step_size=0.01)
-    mcmc_run = MCMC(nuts_kernel, num_samples=200, warmup_steps=100)
-    posterior = []
     true_std = torch.tensor([0.5, 2])
     data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['p_latent']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean, true_std, prec=0.02)
+    nuts_kernel = NUTS(model, step_size=0.01)
+    mcmc_run = MCMC(nuts_kernel, num_samples=200, warmup_steps=100).run(data)
+    posterior = mcmc_run.marginal('p_latent')
+    assert_equal(posterior.mean, true_std, prec=0.02)
 
 
 def test_logistic_regression_with_dual_averaging():
@@ -144,12 +130,9 @@ def test_logistic_regression_with_dual_averaging():
         return y
 
     nuts_kernel = NUTS(model, adapt_step_size=True)
-    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100)
-    posterior = []
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['beta']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.05)
+    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100).run(data)
+    posterior = mcmc_run.marginal('beta')
+    assert_equal(rmse(true_coefs, posterior.mean).item(), 0.0, prec=0.05)
 
 
 @pytest.mark.xfail(reason='the model is sensitive to NaN log_pdf')
@@ -161,12 +144,9 @@ def test_bernoulli_beta_with_dual_averaging():
         pyro.observe("obs", dist.Bernoulli(p_latent), data)
         return p_latent
 
-    nuts_kernel = NUTS(model, adapt_step_size=True)
-    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100)
-    posterior = []
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
-    for trace, _ in mcmc_run._traces(data):
-        posterior.append(trace.nodes['p_latent']['value'])
-    posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean.data, true_probs.data, prec=0.01)
+    nuts_kernel = NUTS(model, adapt_step_size=True)
+    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100)
+    posterior = mcmc_run.marginal('p_latent')
+    assert_equal(posterior.mean, true_probs, prec=0.01)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -147,6 +147,6 @@ def test_bernoulli_beta_with_dual_averaging():
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
     nuts_kernel = NUTS(model, adapt_step_size=True)
-    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100)
+    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100).run(data)
     posterior = mcmc_run.marginal('p_latent')
     assert_equal(posterior.mean, true_probs, prec=0.01)


### PR DESCRIPTION
This adds the draft for the `EmpiricalDistribution` as discussed in #942, for discussion. Broadly the design is as follows:
 - `EmpiricalDistribution` holds a collection of data points with the same type and shape. These data-points are collected along the leftmost dimension. It provides a method called `add` to add a single datum to the existing collection. These are lazily collected into a tensor, so as to avoid repeated tensor copies per iteration. We can compute `mean`, `variance` and generate samples from `EmpiricalDistribution` for any arbitrary shape. 
 - `MCMC` inherits off of `TraceJoint` that stores a bag of traces corresponding to the joint distribution of latents and observed. We can call `.marginal(site=x)` on this, to return the marginal for a given sample site (we can add other methods that condition, etc.). The return type is the `EmpiricalDistribution`.

What needs to be fixed:
 - There is redundancy between `TracePosterior` and `TraceJoint`. We need to merge the two, retaining performance when we do not need `log_prob`.
 - Using `EmpiricalDistribution` in `Histogram`, or generalizing it to support `Histogram`.
 - Other improvements.

cc. @eb8680, @fritzo - Let us discuss any requirements to generalize this for #915. 

Tests: Tests added in `test_empirical.py`, and HMC/NUTS tests are modified.

PS: Let us restrict the review to discussing design requirements, if possible. I will change the label once this is ready for a full review.