### PR TITLE
Misc fixes to ADVI

### DIFF
--- a/pyro/infer/advi.py
+++ b/pyro/infer/advi.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import torch
-from torch.distributions import constraints, transform_to
+from torch.distributions import biject_to, constraints
 
 import pyro
 import pyro.distributions as dist
@@ -43,9 +43,10 @@ class ADVI(object):
         # run the model so we can inspect its structure
         self.prototype_trace = poutine.block(poutine.trace(self.base_model).get_trace)(*args, **kwargs)
         self.prototype_trace = prune_subsample_sites(self.prototype_trace)
-        self.latent_dim = sum(site["value"].view(-1).size(0)
-                              for site in self.prototype_trace.nodes.values()
-                              if site["type"] == "sample" and not site["is_observed"])
+        self.latent_shapes = {name: biject_to(site["fn"].support).inv(site["value"]).shape
+                              for name, site in self.prototype_trace.nodes.items()
+                              if site["type"] == "sample" and not site["is_observed"]}
+        self.latent_dim = sum(_product(shape) for shape in self.latent_shapes.values())
 
     def sample_latent(self, *args, **kwargs):
         """
@@ -57,23 +58,37 @@ class ADVI(object):
     def guide(self, *args, **kwargs):
         """
         An automatic guide with the same ``*args, **kwargs`` as the base ``model``.
+
+        :return: A dictionary mapping sample site name to sampled value.
+        :rtype: dict
         """
         # if we've never run the model before, do so now so we can inspect the model structure
         if self.prototype_trace is None:
             self._setup_prototype(*args, **kwargs)
 
+        result = {}
         latent = self.sample_latent(*args, **kwargs)
+
+        # unpack latent samples
         pos = 0
         for name, site in self.prototype_trace.nodes.items():
             if site["type"] == "sample" and not site["is_observed"]:
-                shape = site["fn"].shape()
+                shape = self.latent_shapes[name]
                 size = _product(shape)
                 unconstrained_value = latent[pos:pos + size].view(shape)
                 pos += size
-                delta_dist = dist.TransformedDistribution(dist.Delta(unconstrained_value),
-                                                          transform_to(site["fn"].support))
-                pyro.sample(name, delta_dist.reshape(extra_event_dims=site["fn"].event_dim))
+                delta_dist = dist.Delta(unconstrained_value)
+                delta_dist = dist.TransformedDistribution(delta_dist, biject_to(site["fn"].support))
+                delta_dist = delta_dist.reshape(extra_event_dims=site["fn"].event_dim - delta_dist.event_dim)
+                value = pyro.sample(name, delta_dist)
+
+                # work around event_shape bug in TransformedDistribution(_, StickBreakingTransform())
+                delta_dist._event_shape = value.shape[value.dim() - delta_dist.event_dim:]
+
+                result[name] = value
         assert pos == len(latent)
+
+        return result
 
     def model(self, *args, **kwargs):
         """
@@ -106,7 +121,7 @@ class ADVIMultivariateNormal(ADVI):
 
         latent_dim = 10
         pyro.param("advi_loc", torch.randn(latent_dim))
-        pyro.param("advi_cholesky_factor", torch.tril(torch.rand(latent_dim)),
+        pyro.param("advi_scale_tril", torch.tril(torch.rand(latent_dim)),
                    constraint=constraints.lower_cholesky)
     """
     def sample_latent(self, *args, **kwargs):
@@ -114,11 +129,9 @@ class ADVIMultivariateNormal(ADVI):
         Samples the (single) multivariate normal latent used in the advi guide.
         """
         loc = pyro.param("advi_loc", torch.zeros(self.latent_dim))
-        lower_cholesky = pyro.param("advi_lower_cholesky", torch.eye(self.latent_dim),
-                                    constraint=constraints.lower_cholesky)
-        cov = torch.mm(lower_cholesky, lower_cholesky.t())
-        # TODO use Multivariate normal that consumes L directly
-        return pyro.sample("_advi_latent", dist.MultivariateNormal(loc, cov))
+        scale_tril = pyro.param("advi_scale_tril", torch.eye(self.latent_dim),
+                                constraint=constraints.lower_cholesky)
+        return pyro.sample("_advi_latent", dist.MultivariateNormal(loc, scale_tril=scale_tril))
 
 
 class ADVIDiagonalNormal(ADVI):

--- a/tests/integration_tests/test_advi.py
+++ b/tests/integration_tests/test_advi.py
@@ -1,12 +1,13 @@
 import logging
 
+import pytest
 import torch
+from torch.distributions import biject_to, constraints
 
 import pyro
 import pyro.distributions as dist
 import pyro.optim as optim
 import pyro.poutine as poutine
-import pytest
 from pyro.infer import SVI, ADVIDiagonalNormal, ADVIMultivariateNormal
 from tests.common import assert_equal
 from tests.integration_tests.test_conjugate_gaussian_models import GaussianChain
@@ -20,7 +21,6 @@ def test_model():
     pyro.sample("z2", dist.Normal(torch.zeros(3), 2.0 * torch.ones(3)))
 
 
-@pytest.mark.xfail(reason="lack of scalar support in log_abs_det_jacobian")
 @pytest.mark.parametrize("advi_implementation", [ADVIMultivariateNormal, ADVIDiagonalNormal])
 def test_advi_scores(advi_implementation):
     advi = advi_implementation(test_model)
@@ -51,7 +51,6 @@ class ADVIGaussianChain(GaussianChain):
             self.target_advi_diag_cov[n] += 1.0 / self.lambda_posts[n].item()
             self.target_advi_diag_cov[n] += (self.target_kappas[n].item() ** 2) * self.target_advi_diag_cov[n + 1]
 
-    @pytest.mark.xfail(reason="lack of scalar support in log_abs_det_jacobian")
     def test_multivariatate_normal_advi(self):
         self.do_test_advi(3, reparameterized=True, n_steps=10001)
 
@@ -74,7 +73,7 @@ class ADVIGaussianChain(GaussianChain):
 
             if k % 1000 == 0 and k > 0 or k == n_steps - 1:
                 logger.debug("[step {}] advi mean parameter: {}".format(k, pyro.param("advi_loc").detach().numpy()))
-                L = pyro.param("advi_lower_cholesky")
+                L = pyro.param("advi_scale_tril")
                 diag_cov = torch.mm(L, L.t()).diag()
                 logger.debug("[step {}] advi_diag_cov: {}".format(k, diag_cov.detach().numpy()))
 
@@ -84,7 +83,6 @@ class ADVIGaussianChain(GaussianChain):
                      msg="advi covariance off")
 
 
-@pytest.mark.xfail(reason="lack of scalar support in log_abs_det_jacobian")
 @pytest.mark.parametrize('advi_class', [ADVIDiagonalNormal, ADVIMultivariateNormal])
 def test_advi_diagonal_gaussians(advi_class):
     n_steps = 3501 if advi_class == ADVIDiagonalNormal else 6001
@@ -101,7 +99,7 @@ def test_advi_diagonal_gaussians(advi_class):
         svi.step()
 
     if advi_class == ADVIMultivariateNormal:
-        L = pyro.param("advi_lower_cholesky")
+        L = pyro.param("advi_scale_tril")
         diag_cov = torch.mm(L, L.t()).diag()
     else:
         diag_cov = torch.pow(pyro.param("advi_scale"), 2.0)
@@ -127,7 +125,7 @@ def test_advi_transform(advi_class):
         svi.step()
 
     if advi_class == ADVIMultivariateNormal:
-        L = pyro.param("advi_lower_cholesky")
+        L = pyro.param("advi_scale_tril")
         diag_cov = torch.mm(L, L.t()).diag()
     else:
         diag_cov = torch.pow(pyro.param("advi_scale"), 2.0)
@@ -136,3 +134,28 @@ def test_advi_transform(advi_class):
                  msg="advi mean off")
     assert_equal(diag_cov, torch.tensor([0.49]), prec=0.04,
                  msg="advi covariance off")
+
+
+@pytest.mark.xfail(reason="jacobian bug https://github.com/probtorch/pytorch/issues/112")
+@pytest.mark.parametrize('advi_class', [ADVIDiagonalNormal, ADVIMultivariateNormal])
+def test_advi_dirichlet(advi_class):
+    num_steps = 1000
+    prior = torch.tensor([0.1, 0.2, 0.3, 0.4])
+    data = torch.tensor([0, 2]).long()
+    true_posterior = torch.tensor([1.1, 0.2, 1.3, 0.4])
+
+    def model(data):
+        p = pyro.sample("p", dist.Dirichlet(prior))
+        with pyro.iarange("data_iarange"):
+            pyro.sample("data", dist.Categorical(p).reshape(data.shape), obs=data)
+
+    advi = advi_class(model)
+    svi = SVI(advi.model, advi.guide, optim.Adam({"lr": .01}), loss="ELBO")
+
+    for _ in range(num_steps):
+        svi.step(data)
+
+    actual_posterior = biject_to(constraints.simplex)(pyro.param("advi_loc"))
+    assert_equal(actual_posterior, true_posterior, prec=0.01, msg=''.join([
+        '\nexpected {}'.format(true_posterior.detach().cpu().numpy()),
+        '\n  actual {}'.format(actual_posterior.detach().cpu().numpy())]))

--- a/tests/integration_tests/test_advi.py
+++ b/tests/integration_tests/test_advi.py
@@ -136,7 +136,7 @@ def test_advi_transform(advi_class):
                  msg="advi covariance off")
 
 
-@pytest.mark.xfail(reason="jacobian bug https://github.com/probtorch/pytorch/issues/112")
+@pytest.mark.xfail(reason="numerical imprecision of transformed delta distribution")
 @pytest.mark.parametrize('advi_class', [ADVIDiagonalNormal, ADVIMultivariateNormal])
 def test_advi_dirichlet(advi_class):
     num_steps = 1000


### PR DESCRIPTION
- Support scalars in `log_abs_det_jacobian`
- Directly use `scale_tril` argument to `MultivariateNormal`
- Fix shaping issues with `StickBreakingTransform`
- Return a dict mapping sample site name -> value from the `advi.guide()`. This is free to compute and often useful.

## Tested
- unmarked lots of tests that were previously xfailing
- added a test with Dirichlet; it passes the shape part but xfails for another reason (possible bug in stick breaking jacobian)