### PR TITLE
fail docs build on warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    ?= -E
+SPHINXOPTS    ?= -E -W
 SPHINXBUILD   = python -msphinx
 APIDOC        = sphinx-apidoc
 SPHINXPROJ    = Pyro

--- a/pyro/infer/advi.py
+++ b/pyro/infer/advi.py
@@ -39,7 +39,7 @@ class ADVI(object):
 
     Reference:
     [1] 'Automatic Differentiation Variational Inference',
-        Alp Kucukelbir, Dustin Tran, Rajesh Ranganath, Andrew Gelman, David M. Blei
+    Alp Kucukelbir, Dustin Tran, Rajesh Ranganath, Andrew Gelman, David M. Blei
     """
     def __init__(self, model):
         self.prototype_trace = None

--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -24,6 +24,9 @@ class DiGraph(networkx.DiGraph):
     node_dict_factory = collections.OrderedDict
 
     def fresh_copy(self):
+        """
+        Returns a new ``DiGraph`` instance.
+        """
         return DiGraph()
 
 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,8 @@ setup(
     author='Uber AI Labs',
     author_email='pyro@uber.com',
     install_requires=[
+        # if you add any additional libraries, please also
+        # add them to `docs/requirements.txt`
         'contextlib2',
         'graphviz>=0.8',
         'networkx>=2.0.0',
@@ -95,7 +97,7 @@ setup(
             'pytest',
             'pytest-xdist',
             'scipy>=0.19.0',
-            'sphinx',
+            'sphinx==1.6.3',
             'sphinx_rtd_theme',
             'yapf',
         ],

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
             'pytest',
             'pytest-xdist',
             'scipy>=0.19.0',
-            'sphinx==1.6.3',
+            'sphinx',
             'sphinx_rtd_theme',
             'yapf',
         ],


### PR DESCRIPTION
travis will now catch docs errors that rtd [cannot](https://github.com/rtfd/readthedocs-build/issues/25) [catch](https://github.com/rtfd/readthedocs-build/issues/7) and prevent silent fails like #964