### PR TITLE
Refactor Dice towards support for message passing

### DIFF
--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -28,8 +28,9 @@ def _compute_dice_elbo(model_trace, guide_trace):
             cost = model_site["log_prob"]
             if not model_site["is_observed"]:
                 cost = cost - guide_trace.nodes[name]["log_prob"]
+            dice_prob = dice.get_prob(cost.shape, ordering[name])
             # TODO use score_parts.entropy_term to "stick the landing"
-            elbo = elbo + dice.expectation(cost, ordering[name])
+            elbo = elbo + (dice_prob * cost).sum()
     return elbo
 
 

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -28,7 +28,7 @@ def _compute_dice_elbo(model_trace, guide_trace):
             cost = model_site["log_prob"]
             if not model_site["is_observed"]:
                 cost = cost - guide_trace.nodes[name]["log_prob"]
-            dice_prob = dice.get_prob(cost.shape, ordering[name])
+            dice_prob = dice.in_context(cost.shape, ordering[name])
             # TODO use score_parts.entropy_term to "stick the landing"
             elbo = elbo + (dice_prob * cost).sum()
     return elbo

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -198,11 +198,11 @@ class Dice(object):
         except KeyError:
             pass
 
+        # TODO replace this naive sum-product computation with message passing.
         log_prob = sum(self._get_log_factors(ordinal))
         if isinstance(log_prob, numbers.Number):
             dice_prob = math.exp(log_prob)
         else:
-            # TODO replace this naive sum-product computation with message passing.
             dice_prob = log_prob.exp()
             while dice_prob.dim() > len(shape):
                 dice_prob = dice_prob.sum(0)

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -177,7 +177,7 @@ class Dice(object):
         self._log_factors_cache[target_ordinal] = log_factors
         return log_factors
 
-    def get_prob(self, shape, ordinal):
+    def in_context(self, shape, ordinal):
         """
         Returns the DiCE operator at a given ordinal, summed to given shape.
 


### PR DESCRIPTION
This is a pure-refactoring PR: behavior should be unchanged.

- Generalizes `Dice` to arbitrary dags and moves the `iarange`-based specialization to `TraceEnum_ELBO`. This is really cool since it allows us to encode graph structure in an `ordinal` type and automatically allows `Dice` to be used outside of `TraceEnum_ELBO`.
- Refactors to collect log factors and identifies where a smarter sum-product algorithm could be placed.

## Performance impact

Running `tests/infer/test_enum.py`:

| Before | 48.9 sec |
| -- | -- |
| After | 49.8 sec |