### PR TITLE
Adding implementation for EmpiricalDistribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -46,6 +46,13 @@ Delta
     :undoc-members:
     :show-inheritance:
 
+EmpiricalDistribution
+----------------------
+.. automodule:: pyro.distributions.empirical
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 HalfCauchy
 ----------
 .. automodule:: pyro.distributions.half_cauchy

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 from pyro.distributions.torch import *
 
 from pyro.distributions.delta import Delta
+from pyro.distributions.empirical import Empirical
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.half_cauchy import HalfCauchy
 from pyro.distributions.iaf import InverseAutoregressiveFlow

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -29,7 +29,8 @@ class Empirical(TorchDistribution):
         self._weights_buffer = []
         super(TorchDistribution, self).__init__(batch_shape=torch.Size(), validate_args=validate_args)
 
-    def _append_from_buffer(self, tensor, buffer):
+    @staticmethod
+    def _append_from_buffer(tensor, buffer):
         """
         Append values from the buffer to the finalized tensor, along the
         leftmost dimension.
@@ -157,3 +158,7 @@ class Empirical(TorchDistribution):
         for _ in range(self._samples.dim() - 1):
             weights = weights.unsqueeze(-1)
         return (log_sum_exp(weights, scale=deviation_squared, dim=0) - log_sum_exp(weights, dim=0)).exp()
+
+    def enumerate_support(self):
+        self._finalize()
+        return self._samples

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -1,0 +1,158 @@
+from __future__ import absolute_import, division, print_function
+
+import numbers
+
+import math
+import torch
+
+from pyro.distributions.torch_distribution import TorchDistribution
+from pyro.distributions.torch import Categorical
+from pyro.distributions.util import copy_docs_from, is_validation_enabled
+from pyro.distributions.util import log_sum_exp
+
+
+@copy_docs_from(TorchDistribution)
+class Empirical(TorchDistribution):
+    r"""
+    Empirical distribution associated with the sampled data.
+    """
+
+    arg_constraints = {}
+
+    def __init__(self):
+        self._samples = None
+        self._log_weights = None
+        self._categorical = None
+        self._samples_buffer = []
+        self._weights_buffer = []
+        super(TorchDistribution, self).__init__()
+
+    def _append_from_buffer(self, tensor, buffer):
+        """
+        Append values from the buffer to the finalized tensor, along the
+        leftmost dimension.
+
+        :param torch.Tensor tensor: tensor containing existing values.
+        :param list buffer: list of new values.
+        :return: tensor with new values appended at the bottom.
+        """
+        buffer_tensor = torch.stack(buffer, dim=0)
+        return torch.cat([tensor, buffer_tensor], dim=0)
+
+    def _finalize(self):
+        """
+        Appends values collected in the samples/weights buffers to their
+        corresponding tensors.
+        """
+        if not self._samples_buffer:
+            return
+        self._samples = self._append_from_buffer(self._samples, self._samples_buffer)
+        self._log_weights = self._append_from_buffer(self._log_weights, self._weights_buffer)
+        self._categorical = Categorical(logits=self._log_weights)
+        # Reset buffers.
+        self._samples_buffer, self._weights_buffer = [], []
+
+    @property
+    def sample_size(self):
+        """
+        Number of samples that constitute the empirical distribution.
+
+        :return int: number of samples collected.
+        """
+        self._finalize()
+        if self._samples is None:
+            return 0
+        return self._samples.size(0)
+
+    def add(self, value, log_weight=None, weight=None):
+        """
+        Adds a new data point to the sample. The values in successive calls to ``add``
+        must have the same tensor shape and size. Optionally, an importance weight
+        can be specified via ``log_weight`` or ``weight`` (default value of `1`
+        is used if not specified).
+
+        :param torch.Tensor value: tensor to add to the sample.
+        :param torch.Tensor weight: log weight (optional) corresponding to the sample.
+        :param torch.Tensor log_weight: weight (optional) corresponding to the sample.
+        """
+        if is_validation_enabled():
+            if weight is not None and log_weight is not None:
+                raise ValueError("Only one of ```weight`` or ``log_weight`` should be specified.")
+            if torch.is_tensor(weight) and weight.dim() > 0:
+                raise ValueError("``weight.dim() > 0``, but weight should be a scalar.")
+
+        weight_type = torch.Tensor if value.dtype in (torch.int32, torch.int64) else value.type()
+        # Apply default weight of 1.0.
+        if log_weight is None and weight is None:
+            log_weight = torch.tensor(1.0).type(weight_type).log()
+        elif weight is not None and log_weight is None:
+            log_weight = math.log(weight)
+        if isinstance(log_weight, numbers.Number):
+            log_weight = torch.tensor(log_weight).type(weight_type)
+
+        # Seed the container tensors with the correct tensor types
+        if self._samples is None:
+            self._samples = value.new()
+            self._log_weights = log_weight.new()
+        # Append to the buffer list
+        self._samples_buffer.append(value)
+        self._weights_buffer.append(log_weight)
+
+    def sample(self, sample_shape=torch.Size()):
+        self._finalize()
+        idxs = self._categorical.sample(sample_shape=sample_shape)
+        return self._samples[idxs]
+
+    def log_prob(self, value):
+        """
+        Returns the log of the probability mass function evaluated at ``value``.
+        Note that this currently only supports scoring single values and not
+        a tensor of values.
+
+        :param torch.Tensor value: scalar or tensor value to be scored.
+        """
+        if is_validation_enabled():
+            if value.size() != self.event_shape:
+                raise ValueError("``value.size()`` must be {}".format(self.event_shape))
+        self._finalize()
+        selection_mask = self._samples.eq(value).contiguous().view(self.sample_size, -1)
+        # Return -Inf if value is outside the support.
+        if not selection_mask.any():
+            return self._log_weights.new_zeros(torch.Size()).log()
+        idxs = torch.arange(self.sample_size)[selection_mask.min(dim=-1)[0]]
+        log_probs = self._categorical.log_prob(idxs)
+        return log_sum_exp(log_probs)
+
+    @property
+    def batch_shape(self):
+        return torch.Size()
+
+    @property
+    def event_shape(self):
+        self._finalize()
+        if self._samples is None:
+            return None
+        return self._samples.size()[1:]
+
+    @property
+    def mean(self):
+        self._finalize()
+        if self._samples.dtype in (torch.int32, torch.int64):
+            raise ValueError("Mean for discrete empirical distribution undefined. Consider converting samples " +
+                             "to ``torch.float32`` or ``torch.float64``.")
+        weights = self._log_weights
+        for _ in range(self._samples.dim() - 1):
+            weights = weights.unsqueeze(-1)
+        return (log_sum_exp(weights, scale=self._samples, dim=0) - log_sum_exp(weights, dim=0)).exp()
+
+    @property
+    def variance(self):
+        self._finalize()
+        if self._samples.dtype in (torch.int32, torch.int64):
+            raise ValueError("Variance for discrete empirical distribution undefined. Consider converting samples " +
+                             "to ``torch.float32`` or ``torch.float64``.")
+        deviation_squared = torch.pow(self._samples - self.mean, 2)
+        weights = self._log_weights
+        for _ in range(self._samples.dim() - 1):
+            weights = weights.unsqueeze(-1)
+        return (log_sum_exp(weights, scale=deviation_squared, dim=0) - log_sum_exp(weights, dim=0)).exp()

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -66,14 +66,16 @@ class Empirical(TorchDistribution):
 
     def add(self, value, log_weight=None, weight=None):
         """
-        Adds a new data point to the sample. The values in successive calls to ``add``
-        must have the same tensor shape and size. Optionally, an importance weight
-        can be specified via ``log_weight`` or ``weight`` (default value of `1`
-        is used if not specified).
+        Adds a new data point to the sample. The values in successive calls to
+        ``add`` must have the same tensor shape and size. Optionally, an
+        importance weight can be specified via ``log_weight`` or ``weight``
+        (default value of `1` is used if not specified).
 
         :param torch.Tensor value: tensor to add to the sample.
-        :param torch.Tensor weight: log weight (optional) corresponding to the sample.
-        :param torch.Tensor log_weight: weight (optional) corresponding to the sample.
+        :param torch.Tensor weight: log weight (optional) corresponding
+            to the sample.
+        :param torch.Tensor log_weight: weight (optional) corresponding
+            to the sample.
         """
         if is_validation_enabled():
             if weight is not None and log_weight is not None:

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -328,8 +328,8 @@ def log_sum_exp(tensor, scale=1.0, dim=-1):
     summing is done along the dimension specified by ``dim``.
 
     :param torch.Tensor tensor: Input tensor.
-    :param torch.Tensor scale: Optional scale factor for each ``exp(tensor)``. Must be
-        broadcastable to tensor.
+    :param torch.Tensor scale: Optional scale factor for each ``exp(tensor)``.
+        Must be broadcastable to tensor.
     :param dim: Dimension to be summed out.
     """
     max_val = tensor.max(dim)[0]

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import numbers
+from functools import update_wrapper
 
 import torch
 import torch.distributions as torch_dist
@@ -319,6 +320,20 @@ def matrix_triangular_solve_compat(b, A, upper=True):
         return A.inverse().matmul(b)
     else:
         return b.trtrs(A, upper=upper)[0].view(b.size())
+
+
+def log_sum_exp(tensor, scale=1.0, dim=-1):
+    """
+    Numerically stable implementation for the `LogSumExp` operation. The
+    summing is done along the dimension specified by ``dim``.
+
+    :param torch.Tensor tensor: Input tensor.
+    :param torch.Tensor scale: Optional scale factor for each ``exp(tensor)``. Must be
+        broadcastable to tensor.
+    :param dim: Dimension to be summed out.
+    """
+    max_val = tensor.max(dim)[0]
+    return max_val + torch.sum(scale * (tensor - max_val.unsqueeze(-1)).exp(), dim=dim).log()
 
 
 def enable_validation(is_validate):

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import numbers
-from functools import update_wrapper
 
 import torch
 import torch.distributions as torch_dist

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -321,15 +321,15 @@ def matrix_triangular_solve_compat(b, A, upper=True):
         return b.trtrs(A, upper=upper)[0].view(b.size())
 
 
-def log_sum_exp(tensor, scale=1.0, dim=-1):
+def log_sum_exp(tensor, dim=-1, scale=1.0):
     """
     Numerically stable implementation for the `LogSumExp` operation. The
     summing is done along the dimension specified by ``dim``.
 
     :param torch.Tensor tensor: Input tensor.
+    :param dim: Dimension to be summed out.
     :param torch.Tensor scale: Optional scale factor for each ``exp(tensor)``.
         Must be broadcastable to tensor.
-    :param dim: Dimension to be summed out.
     """
     max_val = tensor.max(dim)[0]
     return max_val + torch.sum(scale * (tensor - max_val.unsqueeze(-1)).exp(), dim=dim).log()

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -4,6 +4,7 @@ import torch
 
 import pyro.distributions as dist
 import pyro.poutine as poutine
+from pyro.distributions.util import log_sum_exp
 import pyro.util as util
 
 
@@ -53,11 +54,11 @@ class Histogram(dist.Distribution):
                 logits.append(logit)
             else:
                 # Value has already been seen.
-                logits[ix] = util.log_sum_exp(torch.stack([logits[ix], logit]))
+                logits[ix] = log_sum_exp(torch.stack([logits[ix], logit]))
 
         logits = torch.stack(logits).contiguous().view(-1)
-        logits -= util.log_sum_exp(logits)
-        logits = logits - util.log_sum_exp(logits)
+        logits -= log_sum_exp(logits)
+        logits = logits - log_sum_exp(logits)
         d = dist.Categorical(logits=logits)
         return d, values
 
@@ -142,6 +143,6 @@ class TracePosterior(object):
             traces.append(tr)
             logits.append(logit)
         logits = torch.stack(logits).squeeze()
-        logits -= util.log_sum_exp(logits)
+        logits -= log_sum_exp(logits)
         ix = dist.Categorical(logits=logits).sample()
         return traces[ix]

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -175,11 +175,6 @@ def is_inf(x):
     return (x == float('inf')).all()
 
 
-def log_sum_exp(tensor):
-    max_val = tensor.max(dim=-1)[0]
-    return max_val + (tensor - max_val.unsqueeze(-1)).exp().sum(dim=-1).log()
-
-
 def zero_grads(tensors):
     """
     Sets gradients of list of Variables to zero in place

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -1,0 +1,88 @@
+import pytest
+import torch
+
+from pyro.distributions.empirical import Empirical
+from tests.common import assert_equal
+
+
+@pytest.mark.parametrize("size", [torch.Size(), torch.Size((1,)), torch.Size((2, 3))])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_unweighted_mean_and_var(size, dtype):
+    empirical_dist = Empirical()
+    for i in range(5):
+        empirical_dist.add(torch.ones(size, dtype=dtype) * i)
+    true_mean = torch.ones(size) * 2
+    true_var = torch.ones(size) * 2
+    assert_equal(empirical_dist.mean, true_mean)
+    assert_equal(empirical_dist.variance, true_var)
+
+
+@pytest.mark.parametrize("batch_shape", [torch.Size(), torch.Size((1,)), torch.Size((2, 3))])
+@pytest.mark.parametrize("sample_shape", [torch.Size((20,)), torch.Size((20, 3, 4))])
+@pytest.mark.parametrize("dtype", [torch.long, torch.float32, torch.float64])
+def test_unweighted_samples(batch_shape, sample_shape, dtype):
+    empirical_dist = Empirical()
+    for i in range(5):
+        empirical_dist.add(torch.ones(batch_shape, dtype=dtype) * i)
+    samples = empirical_dist.sample(sample_shape=sample_shape)
+    assert_equal(samples.size(), sample_shape + batch_shape)
+    assert_equal(set(samples.view(-1).tolist()), set(range(5)))
+
+
+@pytest.mark.parametrize("batch_shape", [torch.Size(), torch.Size((1,)), torch.Size((2, 3))])
+@pytest.mark.parametrize("dtype", [torch.long, torch.float32, torch.float64])
+def test_log_prob(batch_shape, dtype):
+    empirical_dist = Empirical()
+    for i in range(5):
+        empirical_dist.add(torch.ones(batch_shape, dtype=dtype) * i)
+    sample_to_score = torch.ones(batch_shape, dtype=dtype)
+    log_prob = empirical_dist.log_prob(sample_to_score)
+    assert_equal(log_prob, torch.tensor(0.2).log())
+
+    # Value outside support returns -Inf
+    sample_to_score = torch.ones(batch_shape, dtype=dtype) * 6
+    log_prob = empirical_dist.log_prob(sample_to_score)
+    assert log_prob == -float("inf")
+
+    # Vectorized ``log_prob`` raises ValueError
+    with pytest.raises(ValueError):
+        sample_to_score = torch.ones((3,) + batch_shape, dtype=dtype)
+        empirical_dist.log_prob(sample_to_score)
+
+
+@pytest.mark.parametrize("event_shape", [torch.Size(), torch.Size((1,)), torch.Size((2, 3))])
+@pytest.mark.parametrize("dtype", [torch.long, torch.float32, torch.float64])
+def test_weighted_sample_coherence(event_shape, dtype):
+    samples = [(1.0, 0.5), (0.0, 1.5), (1.0, 0.5), (0.0, 1.5)]
+    empirical_dist = Empirical()
+    for sample, weight in samples:
+        empirical_dist.add(sample * torch.ones(event_shape, dtype=dtype), weight=weight)
+    assert_equal(empirical_dist.event_shape, event_shape)
+    assert_equal(empirical_dist.sample_size, 4)
+    sample_to_score = torch.ones(event_shape, dtype=dtype) * 1.0
+    assert_equal(empirical_dist.log_prob(sample_to_score), torch.tensor(0.25).log())
+    samples = empirical_dist.sample(sample_shape=torch.Size((1000,)))
+    zeros = torch.zeros(event_shape, dtype=dtype)
+    ones = torch.ones(event_shape, dtype=dtype)
+    num_zeros = samples.eq(zeros).contiguous().view(1000, -1).min(dim=-1)[0].float().sum()
+    num_ones = samples.eq(ones).contiguous().view(1000, -1).min(dim=-1)[0].float().sum()
+    assert_equal(num_zeros.item() / 1000, 0.75, prec=0.02)
+    assert_equal(num_ones.item() / 1000, 0.25, prec=0.02)
+
+
+@pytest.mark.parametrize("event_shape", [torch.Size(), torch.Size((1,)), torch.Size((2, 3))])
+@pytest.mark.parametrize("dtype", [torch.long, torch.float32, torch.float64])
+def test_weighted_mean_var(event_shape, dtype):
+    samples = [(1.0, 0.5), (0.0, 1.5), (1.0, 0.5), (0.0, 1.5)]
+    empirical_dist = Empirical()
+    for sample, weight in samples:
+        empirical_dist.add(sample * torch.ones(event_shape, dtype=dtype), weight=weight)
+    if dtype in (torch.float32, torch.float64):
+        true_mean = torch.ones(event_shape, dtype=dtype) * 0.25
+        true_var = torch.ones(event_shape, dtype=dtype) * 0.1875
+        assert_equal(empirical_dist.mean, true_mean)
+        assert_equal(empirical_dist.variance, true_var)
+    else:
+        with pytest.raises(ValueError):
+            mean = empirical_dist.mean
+            var = empirical_dist.variance

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -84,5 +84,5 @@ def test_weighted_mean_var(event_shape, dtype):
         assert_equal(empirical_dist.variance, true_var)
     else:
         with pytest.raises(ValueError):
-            mean = empirical_dist.mean
-            var = empirical_dist.variance
+            empirical_dist.mean
+            empirical_dist.variance


### PR DESCRIPTION
Implements EmpiricalDistribution based on comments and suggestions from @fritzo and @eb8680.

The goal was the following:
 - Have a generic `EmpiricalDistribution` implementation that can accept importance weights.
 - Supporting `log_prob`. However, supporting this should not result in a performance penalty for cases where we do not need to compute `log_prob`. Hence any heavy pre-processing (like tensor comparisons) required when adding samples to support `log_prob` is bypassed.
 - Supporting fast `append` operation, without too much overhead - we append to a buffer which is lazily concatenated to an internal tensor when needed. 
 - Should be possible to re-use the same `EmpiricalDistribution` implementation. e.g. appending some value, computing the mean, appending some more values, re-computing the mean etc. There should be no assumption that the add operation precedes all statistical computation on the samples.

What is currently missing?
 - I have not figured out a way to support vectorized `log_prob`, i.e. the ability to score multiple samples at the same time. Doing so will likely require a different implementation that needs to pre-process samples as they are added, and will be slow. Currently, `log_prob` only accepts single values.

Addresses #942. 

Related: #943 - Alternate sketch that does not support `log_prob` or `importance_weights`.
