### PR TITLE
Fix bayesian regression example and re-enable testing

### DIFF
--- a/examples/bayesian_regression.py
+++ b/examples/bayesian_regression.py
@@ -73,10 +73,12 @@ def model(data):
 
 
 def guide(data):
-    w_loc = torch.randn(1, p, requires_grad=True).type_as(data)
+    w_loc = torch.randn(1, p).type_as(data)
+    w_loc.requires_grad = True
     w_log_sig = torch.tensor((-3.0 * torch.ones(1, p) + 0.05 * torch.randn(1, p)).type_as(data),
                              requires_grad=True)
-    b_loc = torch.randn(1, requires_grad=True).type_as(data)
+    b_loc = torch.randn(1).type_as(data)
+    b_loc.requires_grad = True
     b_log_sig = torch.tensor((-3.0 * torch.ones(1) + 0.05 * torch.randn(1)).type_as(data.data), requires_grad=True)
     # register learnable params in the param store
     mw_param = pyro.param("guide_mean_weight", w_loc)

--- a/examples/bayesian_regression.py
+++ b/examples/bayesian_regression.py
@@ -74,12 +74,9 @@ def model(data):
 
 def guide(data):
     w_loc = torch.randn(1, p).type_as(data)
-    w_loc.requires_grad = True
-    w_log_sig = torch.tensor((-3.0 * torch.ones(1, p) + 0.05 * torch.randn(1, p)).type_as(data),
-                             requires_grad=True)
+    w_log_sig = (-3.0 * torch.ones(1, p) + 0.05 * torch.randn(1, p)).type_as(data)
     b_loc = torch.randn(1).type_as(data)
-    b_loc.requires_grad = True
-    b_log_sig = torch.tensor((-3.0 * torch.ones(1) + 0.05 * torch.randn(1)).type_as(data.data), requires_grad=True)
+    b_log_sig = (-3.0 * torch.ones(1) + 0.05 * torch.randn(1)).type_as(data.data)
     # register learnable params in the param store
     mw_param = pyro.param("guide_mean_weight", w_loc)
     sw_param = softplus(pyro.param("guide_log_scale_weight", w_log_sig))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -57,8 +57,6 @@ def make_ids(examples):
 @pytest.mark.stage("test_examples")
 @pytest.mark.parametrize('example,args', CPU_EXAMPLES, ids=make_ids(CPU_EXAMPLES))
 def test_cpu(example, args):
-    if example == 'bayesian_regression.py':
-        pytest.skip("Failure on PyTorch master - https://github.com/uber/pyro/issues/953")
     example = os.path.join(EXAMPLES_DIR, example)
     check_call([sys.executable, example] + args)
 


### PR DESCRIPTION
Fixes the bayesian regression example from #953 using @colesbury's suggestion.

Pasting @colesbury's comment which explains the issue:

> The issue is that w_mu is that the `type_as` comes after the requires_grad assignment, so w_mu is no longer a leaf variable. The existing code is equivalent to:

```python
w_mu_hidden = torch.randn(1, p, requires_grad=True)  # leaf variable (optimizable)
w_mu = w_mu_hidden.type_as(data)  # backprops to of w_mu_hidden via backward type conversion
```