### PR TITLE
Add links to PyTorch optimizers in sphinx docs

### DIFF
--- a/docs/source/pyro.optim.txt
+++ b/docs/source/pyro.optim.txt
@@ -13,3 +13,11 @@ ClippedAdam
     :members:
     :undoc-members:
     :show-inheritance:
+
+PyTorch Optimizers
+------------------
+
+.. automodule:: pyro.optim
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -9,69 +9,71 @@ from .optim import PyroOptim
 
 def Adam(optim_args):
     """
-    A wrapper for torch.optim.Adam
+    A wrapper for :class:`torch.optim.Adam`.
     """
     return PyroOptim(torch.optim.Adam, optim_args)
 
 
 def Adadelta(optim_args):
     """
-    A wrapper for torch.optim.Adadelta
+    A wrapper for :class:`torch.optim.Adadelta`.
     """
     return PyroOptim(torch.optim.Adadelta, optim_args)
 
 
 def Adagrad(optim_args):
     """
-    A wrapper for torch.optim.Adagrad
+    A wrapper for :class:`torch.optim.Adagrad`.
     """
     return PyroOptim(torch.optim.Adagrad, optim_args)
 
 
 def AdagradRMSProp(optim_args):
     """
-    A wrapper for an optimizer that is a mash-up of Adagrad and RMSProp
+    A wrapper for an optimizer that is a mash-up of
+    :class:`~torch.optim.Adagrad` and :class:`~torch.optim.RMSProp`.
     """
     return PyroOptim(pt_AdagradRMSProp, optim_args)
 
 
 def Adamax(optim_args):
     """
-    A wrapper for torch.optim.Adamax
+    A wrapper for :class:`torch.optim.Adamax`.
     """
     return PyroOptim(torch.optim.Adamax, optim_args)
 
 
 def ASGD(optim_args):
     """
-    A wrapper for torch.optim.ASGD
+    A wrapper for :class:`torch.optim.ASGD`.
     """
     return PyroOptim(torch.optim.ASGD, optim_args)
 
 
 def RMSprop(optim_args):
     """
-    A wrapper for torch.optim.RMSprop
+    A wrapper for :class:`torch.optim.RMSprop`.
     """
     return PyroOptim(torch.optim.RMSprop, optim_args)
 
 
 def Rprop(optim_args):
     """
-    A wrapper for torch.optim.Rprop
+    A wrapper for :class:`torch.optim.Rprop`.
     """
     return PyroOptim(torch.optim.Rprop, optim_args)
 
 
 def SGD(optim_args):
     """
-    A wrapper for torch.optim.SGD
+    A wrapper for :class:`torch.optim.SGD`.
     """
     return PyroOptim(torch.optim.SGD, optim_args)
 
 
 def ClippedAdam(optim_args):
     """
-    A wrapper for a modification of the Adam optimization algorithm that supports gradient clipping
+    A wrapper for a modification of the :class:`~torch.optim.Adam`
+    optimization algorithm that supports gradient clipping.
     """
     return PyroOptim(pt_ClippedAdam, optim_args)


### PR DESCRIPTION
This adds a "PyTorch Optimizers" section to our sphinx docs. This section is populated by brief descriptions of all optimizers available in Pyro, with links to upstream PyTorch docs. This follows our pattern of wrapping PyTorch distributions and linking to their upstream docs.

Preview: http://fritzo.org/temp/pytorch/html/optimization.html