### PR TITLE
Add .median(), .quantiles() to ADVI implementations

### DIFF
--- a/pyro/infer/advi.py
+++ b/pyro/infer/advi.py
@@ -189,7 +189,7 @@ class ADVIMultivariateNormal(ADVI):
 
         :param quantiles: A list of requested quantiles between 0 and 1.
         :type quantiles: torch.Tensor or list
-        :return: A dictionary mapping sample site name to median tensor.
+        :return: A dictionary mapping sample site name to a list of quantile values.
         :rtype: dict
         """
         loc = pyro.param("advi_loc")
@@ -252,7 +252,7 @@ class ADVIDiagonalNormal(ADVI):
 
         :param quantiles: A list of requested quantiles between 0 and 1.
         :type quantiles: torch.Tensor or list
-        :return: A dictionary mapping sample site name to median tensor.
+        :return: A dictionary mapping sample site name to a list of quantile values.
         :rtype: dict
         """
         loc = pyro.param("advi_loc")

--- a/pyro/infer/advi.py
+++ b/pyro/infer/advi.py
@@ -77,6 +77,22 @@ class ADVI(object):
         """
         raise NotImplementedError
 
+    def _unpack_latent(self, latent):
+        """
+        Unpacks a packed latent tensor, iterating over tuples of the form::
+
+            (site, unconstrained_value)
+        """
+        pos = 0
+        for name, site in self.prototype_trace.nodes.items():
+            if site["type"] == "sample" and not site["is_observed"]:
+                unconstrained_shape = self._unconstrained_shapes[name]
+                size = _product(unconstrained_shape)
+                unconstrained_value = latent[pos:pos + size].view(unconstrained_shape)
+                yield site, unconstrained_value
+                pos += size
+        assert pos == len(latent)
+
     def guide(self, *args, **kwargs):
         """
         An automatic guide with the same ``*args, **kwargs`` as the base ``model``.
@@ -88,7 +104,6 @@ class ADVI(object):
         if self.prototype_trace is None:
             self._setup_prototype(*args, **kwargs)
 
-        result = {}
         latent = self.sample_latent(*args, **kwargs)
 
         # create all iaranges
@@ -96,25 +111,19 @@ class ADVI(object):
                     for frame in sorted(self._iaranges.values())}
 
         # unpack latent samples
-        pos = 0
-        for name, site in self.prototype_trace.nodes.items():
-            if site["type"] == "sample" and not site["is_observed"]:
-                unconstrained_shape = self._unconstrained_shapes[name]
-                size = _product(unconstrained_shape)
-                unconstrained_value = latent[pos:pos + size].view(unconstrained_shape)
-                pos += size
-                transform = biject_to(site["fn"].support)
-                value = transform(unconstrained_value)
-                log_density = transform.inv.log_abs_det_jacobian(value, unconstrained_value)
-                log_density = sum_rightmost(log_density, log_density.dim() - value.dim() + site["fn"].event_dim)
-                delta_dist = dist.Delta(value, log_density=log_density, event_dim=site["fn"].event_dim)
+        result = {}
+        for site, unconstrained_value in self._unpack_latent(latent):
+            name = site["name"]
+            transform = biject_to(site["fn"].support)
+            value = transform(unconstrained_value)
+            log_density = transform.inv.log_abs_det_jacobian(value, unconstrained_value)
+            log_density = sum_rightmost(log_density, log_density.dim() - value.dim() + site["fn"].event_dim)
+            delta_dist = dist.Delta(value, log_density=log_density, event_dim=site["fn"].event_dim)
 
-                with ExitStack() as stack:
-                    for frame in self._cond_indep_stacks[name]:
-                        stack.enter_context(iaranges[frame.name])
-                    result[name] = pyro.sample(name, delta_dist)
-
-        assert pos == len(latent)
+            with ExitStack() as stack:
+                for frame in self._cond_indep_stacks[name]:
+                    stack.enter_context(iaranges[frame.name])
+                result[name] = pyro.sample(name, delta_dist)
 
         return result
 
@@ -161,6 +170,17 @@ class ADVIMultivariateNormal(ADVI):
                                 constraint=constraints.lower_cholesky)
         return pyro.sample("_advi_latent", dist.MultivariateNormal(loc, scale_tril=scale_tril))
 
+    def median(self, *args, **kwargs):
+        """
+        Returns the posterior median value of each latent variable.
+
+        :return: A dictionary mapping sample site name to median tensor.
+        :rtype: dict
+        """
+        latent = pyro.param("advi_loc", torch.zeros(self.latent_dim))
+        return {site["name"]: biject_to(site["fn"].support)(unconstrained_value)
+                for site, unconstrained_value in self._unpack_latent(latent)}
+
 
 class ADVIDiagonalNormal(ADVI):
     """
@@ -190,3 +210,14 @@ class ADVIDiagonalNormal(ADVI):
         scale = pyro.param("advi_scale", torch.ones(self.latent_dim),
                            constraint=constraints.positive)
         return pyro.sample("_advi_latent", dist.Normal(loc, scale).reshape(extra_event_dims=1))
+
+    def median(self, *args, **kwargs):
+        """
+        Returns the posterior median value of each latent variable.
+
+        :return: A dictionary mapping sample site name to median tensor.
+        :rtype: dict
+        """
+        latent = pyro.param("advi_loc", torch.zeros(self.latent_dim))
+        return {site["name"]: biject_to(site["fn"].support)(unconstrained_value)
+                for site, unconstrained_value in self._unpack_latent(latent)}

--- a/tests/infer/test_advi.py
+++ b/tests/infer/test_advi.py
@@ -52,9 +52,9 @@ def test_shapes(advi_class, trace_graph, enum_discrete):
 def test_median(advi_class):
 
     def model():
-        pyro.sample("z1", dist.Normal(0.0, 1.0))
-        pyro.sample("z2", dist.LogNormal(0.0, 1.0))
-        pyro.sample("z3", dist.Beta(2.0, 2.0))
+        pyro.sample("x", dist.Normal(0.0, 1.0))
+        pyro.sample("y", dist.LogNormal(0.0, 1.0))
+        pyro.sample("z", dist.Beta(2.0, 2.0))
 
     advi = advi_class(model)
     infer = SVI(advi.model, advi.guide, Adam({'lr': 0.01}), 'ELBO')
@@ -62,6 +62,40 @@ def test_median(advi_class):
         infer.step()
 
     median = advi.median()
-    assert_equal(median["z1"], torch.tensor(0.0), prec=0.1)
-    assert_equal(median["z2"], torch.tensor(1.0), prec=0.1)
-    assert_equal(median["z3"], torch.tensor(0.5), prec=0.1)
+    assert_equal(median["x"], torch.tensor(0.0), prec=0.1)
+    assert_equal(median["y"], torch.tensor(1.0), prec=0.1)
+    assert_equal(median["z"], torch.tensor(0.5), prec=0.1)
+
+
+@pytest.mark.parametrize("advi_class", [ADVIMultivariateNormal, ADVIDiagonalNormal])
+def test_quantiles(advi_class):
+
+    def model():
+        pyro.sample("x", dist.Normal(0.0, 1.0))
+        pyro.sample("y", dist.LogNormal(0.0, 1.0))
+        pyro.sample("z", dist.Beta(2.0, 2.0))
+
+    advi = advi_class(model)
+    infer = SVI(advi.model, advi.guide, Adam({'lr': 0.01}), 'ELBO')
+    for _ in range(100):
+        infer.step()
+
+    quantiles = advi.quantiles([0.1, 0.5, 0.9])
+    median = advi.median()
+    for name in ["x", "y", "z"]:
+        assert_equal(median[name], quantiles[name][1])
+
+    assert torch.tensor(-3.0) < quantiles["x"][0]
+    assert quantiles["x"][0] + 1.0 < quantiles["x"][1]
+    assert quantiles["x"][1] + 1.0 < quantiles["x"][2]
+    assert quantiles["x"][2] < 3.0
+
+    assert torch.tensor(0.01) < quantiles["y"][0]
+    assert quantiles["y"][0] * 2.0 < quantiles["y"][1]
+    assert quantiles["y"][1] * 2.0 < quantiles["y"][2]
+    assert quantiles["y"][2] < 100.0
+
+    assert torch.tensor(0.01) < quantiles["z"][0]
+    assert quantiles["z"][0] + 0.1 < quantiles["z"][1]
+    assert quantiles["z"][1] + 0.1 < quantiles["z"][2]
+    assert quantiles["z"][2] < 0.99

--- a/tests/infer/test_advi.py
+++ b/tests/infer/test_advi.py
@@ -7,7 +7,9 @@ import torch
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-from pyro.infer import ELBO, ADVIDiagonalNormal, ADVIMultivariateNormal
+from pyro.infer import ELBO, SVI, ADVIDiagonalNormal, ADVIMultivariateNormal
+from pyro.optim import Adam
+from tests.common import assert_equal
 
 
 @pytest.mark.parametrize("advi_class", [ADVIMultivariateNormal, ADVIDiagonalNormal])
@@ -44,3 +46,22 @@ def test_shapes(advi_class, trace_graph, enum_discrete):
     elbo = ELBO.make(trace_graph=trace_graph, enum_discrete=enum_discrete)
     loss = elbo.loss(advi.model, advi.guide)
     assert np.isfinite(loss), loss
+
+
+@pytest.mark.parametrize("advi_class", [ADVIMultivariateNormal, ADVIDiagonalNormal])
+def test_median(advi_class):
+
+    def model():
+        pyro.sample("z1", dist.Normal(0.0, 1.0))
+        pyro.sample("z2", dist.LogNormal(0.0, 1.0))
+        pyro.sample("z3", dist.Beta(2.0, 2.0))
+
+    advi = advi_class(model)
+    infer = SVI(advi.model, advi.guide, Adam({'lr': 0.01}), 'ELBO')
+    for _ in range(100):
+        infer.step()
+
+    median = advi.median()
+    assert_equal(median["z1"], torch.tensor(0.0), prec=0.1)
+    assert_equal(median["z2"], torch.tensor(1.0), prec=0.1)
+    assert_equal(median["z3"], torch.tensor(0.5), prec=0.1)


### PR DESCRIPTION
Resolves #973

This adds methods `.median()` and `.quantiles()` to our mean-field and multivariate-normal ADVI implementations. These are useful for diagnosing latent variable distributions. It is difficult to expose a `.mean()` or `.variance()` method because we parameterize in the unconstrained space, whereas moments make sense in the constrained space.

Note this refactors to reuse a nice `._unpack_latent()` method, which simplifies the `.guide()` method.

## Tested

- added unit tests of three different constraint types