### PR TITLE
Programmatically wrap all PyTorch optimizers

### DIFF
--- a/docs/source/pyro.optim.txt
+++ b/docs/source/pyro.optim.txt
@@ -14,8 +14,8 @@ ClippedAdam
     :undoc-members:
     :show-inheritance:
 
-PyTorch Optimizers
-------------------
+Pyro Optimizers
+---------------
 
 .. automodule:: pyro.optim
     :members:

--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -7,68 +7,12 @@ from .adagrad_rmsprop import AdagradRMSProp as pt_AdagradRMSProp
 from .optim import PyroOptim
 
 
-def Adam(optim_args):
-    """
-    A wrapper for :class:`torch.optim.Adam`.
-    """
-    return PyroOptim(torch.optim.Adam, optim_args)
-
-
-def Adadelta(optim_args):
-    """
-    A wrapper for :class:`torch.optim.Adadelta`.
-    """
-    return PyroOptim(torch.optim.Adadelta, optim_args)
-
-
-def Adagrad(optim_args):
-    """
-    A wrapper for :class:`torch.optim.Adagrad`.
-    """
-    return PyroOptim(torch.optim.Adagrad, optim_args)
-
-
 def AdagradRMSProp(optim_args):
     """
     A wrapper for an optimizer that is a mash-up of
-    :class:`~torch.optim.Adagrad` and :class:`~torch.optim.RMSProp`.
+    :class:`~torch.optim.Adagrad` and :class:`~torch.optim.RMSprop`.
     """
     return PyroOptim(pt_AdagradRMSProp, optim_args)
-
-
-def Adamax(optim_args):
-    """
-    A wrapper for :class:`torch.optim.Adamax`.
-    """
-    return PyroOptim(torch.optim.Adamax, optim_args)
-
-
-def ASGD(optim_args):
-    """
-    A wrapper for :class:`torch.optim.ASGD`.
-    """
-    return PyroOptim(torch.optim.ASGD, optim_args)
-
-
-def RMSprop(optim_args):
-    """
-    A wrapper for :class:`torch.optim.RMSprop`.
-    """
-    return PyroOptim(torch.optim.RMSprop, optim_args)
-
-
-def Rprop(optim_args):
-    """
-    A wrapper for :class:`torch.optim.Rprop`.
-    """
-    return PyroOptim(torch.optim.Rprop, optim_args)
-
-
-def SGD(optim_args):
-    """
-    A wrapper for :class:`torch.optim.SGD`.
-    """
-    return PyroOptim(torch.optim.SGD, optim_args)
 
 
 def ClippedAdam(optim_args):
@@ -77,3 +21,23 @@ def ClippedAdam(optim_args):
     optimization algorithm that supports gradient clipping.
     """
     return PyroOptim(pt_ClippedAdam, optim_args)
+
+
+# Programmatically load all optimizers from PyTorch.
+for _name, _Optim in torch.optim.__dict__.items():
+    if not isinstance(_Optim, type):
+        continue
+    if not issubclass(_Optim, torch.optim.Optimizer):
+        continue
+    if _Optim is torch.optim.Optimizer:
+        continue
+
+    def _PyroOptim(optim_args):
+        return PyroOptim(_Optim, optim_args)
+
+    _PyroOptim.__name__ = _name
+    _PyroOptim.__doc__ = 'Wraps :class:`torch.optim.{}` with :class:`~pyro.optim.optim.PyroOptim`.'.format(
+        _name, _Optim.__name__)
+
+    locals()[_name] = _PyroOptim
+    del _PyroOptim

--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -32,12 +32,9 @@ for _name, _Optim in torch.optim.__dict__.items():
     if _Optim is torch.optim.Optimizer:
         continue
 
-    def _PyroOptim(optim_args):
-        return PyroOptim(_Optim, optim_args)
-
+    _PyroOptim = (lambda _Optim: lambda optim_args: PyroOptim(_Optim, optim_args))(_Optim)
     _PyroOptim.__name__ = _name
-    _PyroOptim.__doc__ = 'Wraps :class:`torch.optim.{}` with :class:`~pyro.optim.optim.PyroOptim`.'.format(
-        _name, _Optim.__name__)
+    _PyroOptim.__doc__ = 'Wraps :class:`torch.optim.{}` with :class:`~pyro.optim.optim.PyroOptim`.'.format(_name)
 
     locals()[_name] = _PyroOptim
     del _PyroOptim

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from unittest import TestCase
 
+import pytest
 import torch
 
 import pyro
@@ -72,3 +73,9 @@ class OptimTests(TestCase):
         free_param_unchanged = torch.equal(pyro.param(free_param).data, torch.zeros(1))
         fixed_param_unchanged = torch.equal(pyro.param(fixed_param).data, torch.zeros(1))
         assert fixed_param_unchanged and not free_param_unchanged
+
+
+@pytest.mark.parametrize('factory', [optim.Adam, optim.ClippedAdam, optim.RMSprop, optim.SGD])
+def test_autowrap(factory):
+    instance = factory({})
+    assert instance.pt_optim_constructor.__name__ == factory.__name__


### PR DESCRIPTION
Before this PR, we manually wrapped all PyTorch optimizers. After this PR we will automatically load all available PyTorch optimizers (following the method in [pyro.distributions.torch](https://github.com/uber/pyro/blob/dev/pyro/distributions/torch.py#L7)). This PR adds the following new optimizes which were not previously wrapped:
- `LBFGS` (the motivation for this PR)
- `SparseAdam`

Here is the complete list: http://fritzo.org/temp/pytorch/html/optimization.html#module-pyro.optim

Additionally, any optimizers implemented in the future will be immediately available in Pyro.