### PR TITLE
Refactoring imports for a few Pyro modules

### DIFF
--- a/docs/source/pyro.optim.txt
+++ b/docs/source/pyro.optim.txt
@@ -1,23 +1,15 @@
-PyroOptim
----------
+Pyro Optimizers
+---------------
 
 .. automodule:: pyro.optim.optim
     :members:
     :undoc-members:
     :show-inheritance:
 
-ClippedAdam
-------------
+Pytorch Optimizers
+------------------
 
-.. automodule:: pyro.optim.clipped_adam
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-Pyro Optimizers
----------------
-
-.. automodule:: pyro.optim
+.. automodule:: pyro.optim.pytorch_optimizers
     :members:
     :undoc-members:
     :show-inheritance:

--- a/pyro/contrib/__init__.py
+++ b/pyro/contrib/__init__.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from . import gp
-from . import named
+from pyro.contrib import gp
+from pyro.contrib import named
 
-# flake8: noqa
+
+__all__ = [
+    "gp",
+    "named",
+]

--- a/pyro/contrib/gp/__init__.py
+++ b/pyro/contrib/gp/__init__.py
@@ -1,9 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
 
-from . import kernels
-from . import likelihoods
-from . import models
-from . import util
+from pyro.contrib.gp import kernels
+from pyro.contrib.gp import likelihoods
+from pyro.contrib.gp import models
+from pyro.contrib.gp import util
 
-# flake8: noqa
+__all__ = [
+    "kernels",
+    "likelihoods",
+    "models",
+    "util"
+]

--- a/pyro/contrib/gp/__init__.py
+++ b/pyro/contrib/gp/__init__.py
@@ -10,5 +10,5 @@ __all__ = [
     "kernels",
     "likelihoods",
     "models",
-    "util"
+    "util",
 ]

--- a/pyro/contrib/gp/kernels/__init__.py
+++ b/pyro/contrib/gp/kernels/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-
 from pyro.contrib.gp.kernels.brownian import Brownian
 from pyro.contrib.gp.kernels.dot_product import DotProduct, Linear, Polynomial
 from pyro.contrib.gp.kernels.isotropic import (Exponential, Isotropy, Matern32, Matern52,
@@ -12,25 +11,25 @@ from pyro.contrib.gp.kernels.static import Constant, WhiteNoise
 
 __all__ = [
     "Brownian",
+    "Cosine",
+    "Combination",
+    "Constant",
     "DotProduct",
-    "Linear",
-    "Polynomial",
+    "Exponent",
     "Exponential",
     "Isotropy",
+    "Kernel",
+    "Linear",
     "Matern32",
     "Matern52",
+    "Periodic",
+    "Polynomial",
+    "Product",
     "RationalQuadratic",
     "RBF",
-    "Combination",
-    "Exponent",
-    "Kernel",
-    "Product",
     "Sum",
     "Transforming",
     "VerticalScaling",
     "Warping",
-    "Cosine",
-    "Periodic",
-    "Constant",
-    "WhiteNoise"
+    "WhiteNoise",
 ]

--- a/pyro/contrib/gp/kernels/__init__.py
+++ b/pyro/contrib/gp/kernels/__init__.py
@@ -1,12 +1,36 @@
 from __future__ import absolute_import, division, print_function
 
-from .brownian import Brownian
-from .dot_product import DotProduct, Linear, Polynomial
-from .isotropic import (Exponential, Isotropy, Matern32, Matern52, RationalQuadratic,
-                        RBF)
-from .kernel import (Combination, Exponent, Kernel, Product, Sum, Transforming,
-                     VerticalScaling, Warping)
-from .periodic import Cosine, Periodic
-from .static import Constant, WhiteNoise
 
-# flake8: noqa
+from pyro.contrib.gp.kernels.brownian import Brownian
+from pyro.contrib.gp.kernels.dot_product import DotProduct, Linear, Polynomial
+from pyro.contrib.gp.kernels.isotropic import (Exponential, Isotropy, Matern32, Matern52,
+                                               RationalQuadratic, RBF)
+from pyro.contrib.gp.kernels.kernel import (Combination, Exponent, Kernel, Product, Sum,
+                                            Transforming, VerticalScaling, Warping)
+from pyro.contrib.gp.kernels.periodic import Cosine, Periodic
+from pyro.contrib.gp.kernels.static import Constant, WhiteNoise
+
+__all__ = [
+    "Brownian",
+    "DotProduct",
+    "Linear",
+    "Polynomial",
+    "Exponential",
+    "Isotropy",
+    "Matern32",
+    "Matern52",
+    "RationalQuadratic",
+    "RBF",
+    "Combination",
+    "Exponent",
+    "Kernel",
+    "Product",
+    "Sum",
+    "Transforming",
+    "VerticalScaling",
+    "Warping",
+    "Cosine",
+    "Periodic",
+    "Constant",
+    "WhiteNoise"
+]

--- a/pyro/contrib/gp/likelihoods/__init__.py
+++ b/pyro/contrib/gp/likelihoods/__init__.py
@@ -9,5 +9,5 @@ __all__ = [
     "Binary",
     "Gaussian",
     "Likelihood",
-    "MultiClass"
+    "MultiClass",
 ]

--- a/pyro/contrib/gp/likelihoods/__init__.py
+++ b/pyro/contrib/gp/likelihoods/__init__.py
@@ -1,8 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-from .binary import Binary
-from .gaussian import Gaussian
-from .likelihood import Likelihood
-from .multi_class import MultiClass
+from pyro.contrib.gp.likelihoods.binary import Binary
+from pyro.contrib.gp.likelihoods.gaussian import Gaussian
+from pyro.contrib.gp.likelihoods.likelihood import Likelihood
+from pyro.contrib.gp.likelihoods.multi_class import MultiClass
 
-# flake8: noqa
+__all__ = [
+    "Binary",
+    "Gaussian",
+    "Likelihood",
+    "MultiClass"
+]

--- a/pyro/contrib/gp/models/__init__.py
+++ b/pyro/contrib/gp/models/__init__.py
@@ -1,9 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
-from .model import GPModel
-from .gpr import GPRegression
-from .sgpr import SparseGPRegression
-from .svgp import SparseVariationalGP
-from .vgp import VariationalGP
+from pyro.contrib.gp.models.model import GPModel
+from pyro.contrib.gp.models.gpr import GPRegression
+from pyro.contrib.gp.models.sgpr import SparseGPRegression
+from pyro.contrib.gp.models.svgp import SparseVariationalGP
+from pyro.contrib.gp.models.vgp import VariationalGP
 
-# flake8: noqa
+__all__ = [
+    "GPModel",
+    "GPRegression",
+    "SparseGPRegression",
+    "SparseVariationalGP",
+    "VariationalGP"
+]

--- a/pyro/contrib/gp/models/__init__.py
+++ b/pyro/contrib/gp/models/__init__.py
@@ -11,5 +11,5 @@ __all__ = [
     "GPRegression",
     "SparseGPRegression",
     "SparseVariationalGP",
-    "VariationalGP"
+    "VariationalGP",
 ]

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -1,9 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-# Import all distributions from `pyro.distributions.torch`
-# to enable imports inside other distribution classes.
-from pyro.distributions.torch import *
-
 from pyro.distributions.delta import Delta
 from pyro.distributions.empirical import Empirical
 from pyro.distributions.distribution import Distribution
@@ -12,7 +8,25 @@ from pyro.distributions.iaf import InverseAutoregressiveFlow
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
 from pyro.distributions.rejector import Rejector
 from pyro.distributions.sparse_mvn import SparseMultivariateNormal
+from pyro.distributions.torch import *  # noqa F403
+from pyro.distributions.torch import __all__ as torch_dists
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.util import enable_validation, is_validation_enabled
 
-# flake8: noqa
+__all__ = [
+    "Delta",
+    "Empirical",
+    "Distribution",
+    "HalfCauchy",
+    "InverseAutoregressiveFlow",
+    "OMTMultivariateNormal",
+    "Rejector",
+    "SparseMultivariateNormal",
+    "TorchDistribution",
+    "enable_validation",
+    "is_validation_enabled",
+]
+
+# Import all torch distributions from `pyro.distributions.torch_distribution`
+__all__.extend(torch_dists)
+del torch_dists

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -14,17 +14,17 @@ from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.util import enable_validation, is_validation_enabled
 
 __all__ = [
+    "enable_validation",
+    "is_validation_enabled",
     "Delta",
-    "Empirical",
     "Distribution",
+    "Empirical",
     "HalfCauchy",
     "InverseAutoregressiveFlow",
     "OMTMultivariateNormal",
     "Rejector",
     "SparseMultivariateNormal",
     "TorchDistribution",
-    "enable_validation",
-    "is_validation_enabled",
 ]
 
 # Import all torch distributions from `pyro.distributions.torch_distribution`

--- a/pyro/distributions/omt_mvn.py
+++ b/pyro/distributions/omt_mvn.py
@@ -5,7 +5,7 @@ from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 
-from pyro.distributions import MultivariateNormal
+from pyro.distributions.torch import MultivariateNormal
 from pyro.distributions.util import sum_leftmost
 
 

--- a/pyro/distributions/testing/rejection_exponential.py
+++ b/pyro/distributions/testing/rejection_exponential.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import torch
 
-from pyro.distributions import Exponential
+from pyro.distributions.torch import Exponential
 from pyro.distributions.rejector import Rejector
 from pyro.distributions.util import copy_docs_from
 from torch.distributions.utils import broadcast_all

--- a/pyro/nn/__init__.py
+++ b/pyro/nn/__init__.py
@@ -1,4 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-from .auto_reg_nn import AutoRegressiveNN, MaskedLinear  # noqa: F401
-from .clipped_nn import ClippedSigmoid, ClippedSoftmax  # noqa: F401
+from pyro.nn.auto_reg_nn import AutoRegressiveNN, MaskedLinear
+from pyro.nn.clipped_nn import ClippedSigmoid, ClippedSoftmax
+
+__all__ = [
+    "AutoRegressiveNN",
+    "ClippedSigmoid",
+    "ClippedSoftmax",
+    "MaskedLinear"
+]

--- a/pyro/nn/__init__.py
+++ b/pyro/nn/__init__.py
@@ -7,5 +7,5 @@ __all__ = [
     "AutoRegressiveNN",
     "ClippedSigmoid",
     "ClippedSoftmax",
-    "MaskedLinear"
+    "MaskedLinear",
 ]

--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -6,8 +6,8 @@ from pyro.optim.pytorch_optimizers import __all__ as pytorch_optims
 
 
 __all__ = [
-    "PyroOptim",
     "AdagradRMSProp",
-    "ClippedAdam"
+    "ClippedAdam",
+    "PyroOptim",
 ]
 __all__.extend(pytorch_optims)

--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -1,40 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-import torch
-
-from .clipped_adam import ClippedAdam as pt_ClippedAdam
-from .adagrad_rmsprop import AdagradRMSProp as pt_AdagradRMSProp
-from .optim import PyroOptim
+from pyro.optim.optim import PyroOptim, AdagradRMSProp, ClippedAdam
+from pyro.optim.pytorch_optimizers import *  # noqa F403
+from pyro.optim.pytorch_optimizers import __all__ as pytorch_optims
 
 
-def AdagradRMSProp(optim_args):
-    """
-    A wrapper for an optimizer that is a mash-up of
-    :class:`~torch.optim.Adagrad` and :class:`~torch.optim.RMSprop`.
-    """
-    return PyroOptim(pt_AdagradRMSProp, optim_args)
-
-
-def ClippedAdam(optim_args):
-    """
-    A wrapper for a modification of the :class:`~torch.optim.Adam`
-    optimization algorithm that supports gradient clipping.
-    """
-    return PyroOptim(pt_ClippedAdam, optim_args)
-
-
-# Programmatically load all optimizers from PyTorch.
-for _name, _Optim in torch.optim.__dict__.items():
-    if not isinstance(_Optim, type):
-        continue
-    if not issubclass(_Optim, torch.optim.Optimizer):
-        continue
-    if _Optim is torch.optim.Optimizer:
-        continue
-
-    _PyroOptim = (lambda _Optim: lambda optim_args: PyroOptim(_Optim, optim_args))(_Optim)
-    _PyroOptim.__name__ = _name
-    _PyroOptim.__doc__ = 'Wraps :class:`torch.optim.{}` with :class:`~pyro.optim.optim.PyroOptim`.'.format(_name)
-
-    locals()[_name] = _PyroOptim
-    del _PyroOptim
+__all__ = [
+    "PyroOptim",
+    "AdagradRMSProp",
+    "ClippedAdam"
+]
+__all__.extend(pytorch_optims)

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -4,11 +4,13 @@ import torch
 
 import pyro
 from pyro.params import module_from_param_with_module_name, user_param_name
+from pyro.optim.clipped_adam import ClippedAdam as pt_ClippedAdam
+from pyro.optim.adagrad_rmsprop import AdagradRMSProp as pt_AdagradRMSProp
 
 
 class PyroOptim(object):
     """
-    A wrapper for torch.optim.Optimizer objects that helps managing with dynamically generated parameters
+    A wrapper for torch.optim.Optimizer objects that helps with managing dynamically generated parameters.
 
     :param optim_constructor: a torch.optim.Optimizer
     :param optim_args: a dictionary of learning arguments for the optimizer or a callable that returns
@@ -114,3 +116,19 @@ class PyroOptim(object):
             return opt_dict
         else:
             return self.pt_optim_args
+
+
+def AdagradRMSProp(optim_args):
+    """
+    A wrapper for an optimizer that is a mash-up of
+    :class:`~torch.optim.Adagrad` and :class:`~torch.optim.RMSprop`.
+    """
+    return PyroOptim(pt_AdagradRMSProp, optim_args)
+
+
+def ClippedAdam(optim_args):
+    """
+    A wrapper for a modification of the :class:`~torch.optim.Adam`
+    optimization algorithm that supports gradient clipping.
+    """
+    return PyroOptim(pt_ClippedAdam, optim_args)

--- a/pyro/optim/pytorch_optimizers.py
+++ b/pyro/optim/pytorch_optimizers.py
@@ -1,0 +1,21 @@
+import torch
+
+from pyro.optim import PyroOptim
+
+__all__ = []
+# Programmatically load all optimizers from PyTorch.
+for _name, _Optim in torch.optim.__dict__.items():
+    if not isinstance(_Optim, type):
+        continue
+    if not issubclass(_Optim, torch.optim.Optimizer):
+        continue
+    if _Optim is torch.optim.Optimizer:
+        continue
+
+    _PyroOptim = (lambda _Optim: lambda optim_args: PyroOptim(_Optim, optim_args))(_Optim)
+    _PyroOptim.__name__ = _name
+    _PyroOptim.__doc__ = 'Wraps :class:`torch.optim.{}` with :class:`~pyro.optim.optim.PyroOptim`.'.format(_name)
+
+    locals()[_name] = _PyroOptim
+    __all__.append(_name)
+    del _PyroOptim


### PR DESCRIPTION
Addresses #981 for `nn`, `distributions` and `optim` modules.

Additionally, it does the following.
 - Changes `__init__.py` for modules so that:
   - The classes/functions that form the public API are explicitly declared in an `__all__` variable.
   - All remaining code is migrated to other classes. This is to prevent namespace pollution (and unwitting circular imports). e.g. The following (earlier working) code will throw an error now: `from pyro.optim import torch`. This separation makes it easier to generate docs too.
 - Since we are using `__all__`, the linter is happy. As such `noqa` is removed from `__init__.py`, and flake8 checks these files for unused imports.
 - Uses absolute imports in all files.


