### PR TITLE
Enable HMC tests on constrained distributions with step size adaptation

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -218,8 +218,10 @@ class HMC(TraceKernel):
             # which may be the case for a diverging trajectory (e.g. in the case of
             # evaluating log prob of a value simulated using a large step size for
             # a constrained sample site).
-            accept_prob = (-delta_energy).exp().clamp(max=1).item() if not torch_isnan(delta_energy) \
-                else torch.tensor(0.0)
+            if torch_isnan(delta_energy):
+                accept_prob = delta_energy.new_tensor(0.0)
+            else:
+                accept_prob = (-delta_energy).exp().clamp(max=1).item()
             self._adapt_step_size(accept_prob)
 
         self._t += 1

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -210,7 +210,8 @@ class HMC(TraceKernel):
             z = z_new
 
         if self.adapt_step_size:
-            accept_prob = (-delta_energy).exp().clamp(max=1).item()
+            accept_prob = (-delta_energy).exp().clamp(max=1).item() if not torch_isnan(delta_energy) \
+                else torch.tensor(0.0)
             self._adapt_step_size(accept_prob)
 
         self._t += 1

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -107,9 +107,9 @@ class NUTS(HMC):
         # for a constrained sample site).
         if torch_isnan(energy_new):
             diverging = True
-            accept_prob = torch.tensor(0.0)
+            accept_prob = energy_new.new_tensor(0.0)
         else:
-            diverging = sliced_energy >= self._max_sliced_energy
+            diverging = (sliced_energy >= self._max_sliced_energy)
             delta_energy = energy_new - energy_current
             accept_prob = (-delta_energy).exp().clamp(max=1)
         return _TreeInfo(z_new, r_new, z_grads, z_new, r_new, z_grads,


### PR DESCRIPTION
Small bug-fix so that when `delta_energy` is `NaN` acceptance probability is `0.0` (clamping gives `1.0`) which results in huge step sizes during adaptation, and invalid results. I had to disable validation in the tests because `NaN` is an expected result in this case (see https://github.com/probtorch/pytorch/issues/145 for some discussion on this), so it is okay to disable warnings and run these tests without validation.