### PR TITLE
support train parameters outside model/guide pair

### DIFF
--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -95,6 +95,7 @@ class Trace_ELBO(ELBO):
         Performs backward on the latter. Num_particle many samples are used to form the estimators.
         """
         elbo = 0.0
+        current_active_params = pyro.get_param_store().get_active_params()
         # grab a trace from the generator
         for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
             elbo_particle = 0
@@ -132,7 +133,8 @@ class Trace_ELBO(ELBO):
                                    for site in trace.nodes.values()
                                    if site["type"] == "param")
 
-            if trainable_params and getattr(surrogate_elbo_particle, 'requires_grad', False):
+            if (trainable_params or current_active_params) and getattr(surrogate_elbo_particle,
+                                                                       'requires_grad', False):
                 surrogate_loss_particle = -surrogate_elbo_particle / self.num_particles
                 surrogate_loss_particle.backward()
                 pyro.get_param_store().mark_params_active(trainable_params)

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -110,6 +110,7 @@ class TraceEnum_ELBO(ELBO):
         Performs backward on the ELBO of each particle.
         """
         elbo = 0.0
+        current_active_params = pyro.get_param_store().get_active_params()
         for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
             elbo_particle = _compute_dice_elbo(model_trace, guide_trace)
             if is_identically_zero(elbo_particle):
@@ -123,7 +124,7 @@ class TraceEnum_ELBO(ELBO):
                                    for site in trace.nodes.values()
                                    if site["type"] == "param")
 
-            if trainable_params and elbo_particle.requires_grad:
+            if (trainable_params or current_active_params) and elbo_particle.requires_grad:
                 loss_particle = -elbo_particle
                 (loss_particle / self.num_particles).backward()
                 pyro.get_param_store().mark_params_active(trainable_params)

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -281,7 +281,9 @@ class TraceGraph_ELBO(ELBO):
                                for site in trace.nodes.values()
                                if site["type"] == "param")
 
-        if trainable_params:
+        current_active_params = pyro.get_param_store().get_active_params()
+
+        if (trainable_params or current_active_params):
             surrogate_loss = -surrogate_elbo
             torch_backward(weight * (surrogate_loss + baseline_loss))
             pyro.get_param_store().mark_params_active(trainable_params)

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -73,9 +73,10 @@ class ParamStoreDict(object):
             this information is used to determine which parameters are being optimized,
             e.g. in the context of pyro.infer.SVI
         """
-        assert(all([p in self._param_to_name for p in params])), \
+        params_set = set(params)
+        assert(all([p in self._param_to_name for p in params_set])), \
             "some of these parameters are not in the ParamStore"
-        self._active_params.update(set(params))
+        self._active_params.update(params_set)
 
     def mark_params_inactive(self, params):
         """
@@ -83,9 +84,10 @@ class ParamStoreDict(object):
             this information is used to determine which parameters are being optimized,
             e.g. in the context of pyro.infer.SVI
         """
-        assert(all([p in self._param_to_name for p in params])), \
+        params_set = set(params)
+        assert(all([p in self._param_to_name for p in params_set])), \
             "some of these parameters are not in the ParamStore"
-        self._active_params.difference_update(set(params))
+        self._active_params.difference_update(set(params_set))
 
     def replace_param(self, param_name, new_param, old_param):
         """


### PR DESCRIPTION
I made a small change to address https://github.com/uber/pyro/issues/995. After this, we can register an nn.Module outside of model/guide pair and still be able to learn its parameters by using `pyro.get_params_store().mark_params_active(params)`. It also fixes a bug when `params` is a generator.