### PR TITLE
Add a decorator interface to poutine

### DIFF
--- a/docs/source/poutine.rst
+++ b/docs/source/poutine.rst
@@ -1,4 +1,4 @@
-Poutines (Pyro Coroutines)
+Poutine (Effect handlers)
 ==========================
 
 .. include:: pyro.poutine.txt

--- a/docs/source/pyro.poutine.txt
+++ b/docs/source/pyro.poutine.txt
@@ -1,4 +1,4 @@
-Poutine
+Handler
 -------
 
 .. automodule:: pyro.poutine.poutine
@@ -6,7 +6,7 @@ Poutine
     :undoc-members:
     :show-inheritance:
 
-BlockPoutine
+BlockHandler
 ------------
 
 .. automodule:: pyro.poutine.block_poutine
@@ -14,7 +14,7 @@ BlockPoutine
     :undoc-members:
     :show-inheritance:
 
-ConditionPoutine
+ConditionHandler
 ----------------
 
 .. automodule:: pyro.poutine.condition_poutine
@@ -22,7 +22,7 @@ ConditionPoutine
     :undoc-members:
     :show-inheritance:
 
-EscapePoutine
+EscapeHandler
 -------------
 
 .. automodule:: pyro.poutine.escape_poutine
@@ -30,7 +30,7 @@ EscapePoutine
     :undoc-members:
     :show-inheritance:
 
-IndepPoutine
+IndepHandler
 ------------
 
 .. automodule:: pyro.poutine.indep_poutine
@@ -38,7 +38,7 @@ IndepPoutine
     :undoc-members:
     :show-inheritance:
 
-LiftPoutine
+LiftHandler
 -----------
 
 .. automodule:: pyro.poutine.lift_poutine
@@ -46,7 +46,7 @@ LiftPoutine
     :undoc-members:
     :show-inheritance:
 
-ReplayPoutine
+ReplayHandler
 -------------
 
 .. automodule:: pyro.poutine.replay_poutine
@@ -54,7 +54,7 @@ ReplayPoutine
     :undoc-members:
     :show-inheritance:
 
-ScalePoutine
+ScaleHandler
 ------------
 
 .. automodule:: pyro.poutine.scale_poutine
@@ -70,7 +70,7 @@ Trace
     :undoc-members:
     :show-inheritance:
 
-TracePoutine
+TraceHandler
 ------------
 
 .. automodule:: pyro.poutine.trace_poutine

--- a/pyro/infer/search.py
+++ b/pyro/infer/search.py
@@ -7,7 +7,7 @@ from six.moves.queue import Queue
 
 class Search(TracePosterior):
     """
-    Trace and Poutine-based implementation of systematic search.
+    Trace and replay-based implementation of systematic search.
 
     :param callable model: Probabilistic model defined as a function.
     :param int max_tries: The maximum number of times to try completing a trace from the queue.

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -9,7 +9,7 @@ from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import iter_discrete_traces
 from pyro.infer.util import Dice
-from pyro.poutine.enumerate_poutine import EnumeratePoutine
+from pyro.poutine import EnumerateMessenger
 from pyro.poutine.util import prune_subsample_sites
 from pyro.util import check_model_guide_match, check_site_shape, check_traceenum_requirements, torch_isnan
 
@@ -55,7 +55,7 @@ class TraceEnum_ELBO(ELBO):
         the result packaged as a trace generator
         """
         # enable parallel enumeration
-        guide = EnumeratePoutine(guide, first_available_dim=self.max_iarange_nesting)
+        guide = EnumerateMessenger(first_available_dim=self.max_iarange_nesting)(guide)
 
         for i in range(self.num_particles):
             for guide_trace in iter_discrete_traces("flat", guide, *args, **kwargs):

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -152,7 +152,7 @@ def scale(fn, scale):
     """
     m = ScaleMessenger(scale=scale)
     # temporary change to preserve API
-    return m(fn) if fn is not None else m
+    return m(fn) if callable(fn) else m
 
 
 #########################################

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -27,12 +27,12 @@ def trace(fn, graph_type=None):
     """
     :param fn: a stochastic function (callable containing pyro primitive calls)
     :param graph_type: string that specifies the kind of graph to construct
-    :returns: stochastic function wrapped in a TracePoutine
-    :rtype: pyro.poutine.TracePoutine
+    :returns: stochastic function wrapped in a TraceHandler
+    :rtype: pyro.poutine.TraceHandler
 
-    Alias for TracePoutine constructor.
+    Alias for TraceHandler constructor.
 
-    Given a callable that contains Pyro primitive calls, return a TracePoutine callable
+    Given a callable that contains Pyro primitive calls, return a TraceHandler callable
     that records the inputs and outputs to those primitive calls
     and their dependencies.
 
@@ -47,10 +47,10 @@ def replay(fn, trace, sites=None):
     :param trace: a Trace data structure to replay against
     :param sites: list or dict of names of sample sites in fn to replay against,
     defaulting to all sites
-    :returns: stochastic function wrapped in a ReplayPoutine
-    :rtype: pyro.poutine.ReplayPoutine
+    :returns: stochastic function wrapped in a ReplayHandler
+    :rtype: pyro.poutine.ReplayHandler
 
-    Alias for ReplayPoutine constructor.
+    Alias for ReplayHandler constructor.
 
     Given a callable that contains Pyro primitive calls,
     return a callable that runs the original, reusing the values at sites in trace
@@ -63,7 +63,7 @@ def lift(fn, prior):
     """
     :param fn: function whose parameters will be lifted to random values
     :param prior: prior function in the form of a Distribution or a dict of stochastic fns
-    :returns: stochastic function wrapped in LiftPoutine
+    :returns: stochastic function wrapped in LiftHandler
 
     Given a stochastic function with param calls and a prior distribution,
     create a stochastic function where all param calls are replaced by sampling from prior.
@@ -79,10 +79,10 @@ def block(fn, hide=None, expose=None, hide_types=None, expose_types=None):
     :param expose: list of site names to be exposed while all others hidden
     :param hide_types: list of site types to be hidden
     :param expose_types: list of site types to be exposed while all others hidden
-    :returns: stochastic function wrapped in a BlockPoutine
-    :rtype: pyro.poutine.BlockPoutine
+    :returns: stochastic function wrapped in a BlockHandler
+    :rtype: pyro.poutine.BlockHandler
 
-    Alias for BlockPoutine constructor.
+    Alias for BlockHandler constructor.
 
     Given a callable that contains Pyro primitive calls,
     selectively hide some of those calls from poutines higher up the stack
@@ -96,9 +96,9 @@ def escape(fn, escape_fn=None):
     :param fn: a stochastic function (callable containing pyro primitive calls)
     :param escape_fn: function that takes a partial trace and a site
     and returns a boolean value to decide whether to exit at that site
-    :returns: stochastic function wrapped in EscapePoutine
+    :returns: stochastic function wrapped in EscapeHandler
 
-    Alias for EscapePoutine constructor.
+    Alias for EscapeHandler constructor.
 
     Given a callable that contains Pyro primitive calls,
     evaluate escape_fn on each site, and if the result is True,
@@ -112,10 +112,10 @@ def condition(fn, data):
     """
     :param fn: a stochastic function (callable containing pyro primitive calls)
     :param data: a dict or a Trace
-    :returns: stochastic function wrapped in a ConditionPoutine
-    :rtype: pyro.poutine.ConditionPoutine
+    :returns: stochastic function wrapped in a ConditionHandler
+    :rtype: pyro.poutine.ConditionHandler
 
-    Alias for ConditionPoutine constructor.
+    Alias for ConditionHandler constructor.
 
     Given a stochastic function with some sample statements
     and a dictionary of observations at names,
@@ -130,7 +130,7 @@ def infer_config(fn, config_fn):
     :param fn: a stochastic function (callable containing pyro primitive calls)
     :param config_fn: a callable taking a site and returning an infer dict
 
-    Alias for :class:`~pyro.poutine.infer_config_poutine.InferConfigPoutine` constructor.
+    Alias for :class:`~pyro.poutine.infer_config_poutine.InferConfigHandler` constructor.
 
     Given a callable that contains Pyro primitive calls
     and a callable taking a trace site and returning a dictionary,
@@ -163,15 +163,15 @@ def do(fn, data):
     """
     :param fn: a stochastic function (callable containing pyro primitive calls)
     :param data: a dict or a Trace
-    :returns: stochastic function wrapped in a BlockPoutine and ConditionPoutine
-    :rtype: pyro.poutine.BlockPoutine
+    :returns: stochastic function wrapped in a BlockHandler and ConditionHandler
+    :rtype: pyro.poutine.BlockHandler
 
     Given a stochastic function with some sample statements
     and a dictionary of values at names,
     set the return values of those sites equal to the values
     and hide them from the rest of the stack
     as if they were hard-coded to those values
-    by using BlockPoutine
+    by using BlockHandler
     """
     return block(condition(fn, data=data), hide=list(data.keys()))
 

--- a/pyro/poutine/block_poutine.py
+++ b/pyro/poutine/block_poutine.py
@@ -12,8 +12,8 @@ class BlockMessenger(Messenger):
     Then any poutine outside of BlockMessenger(fn, hide=["a"])
     will not be applied to site "a" and will only see site "b":
 
-    >>> fn_inner = TraceMessenger(fn)
-    >>> fn_outer = TraceMessenger(BlockMessenger(TraceMessenger(fn), hide=["a"]))
+    >>> fn_inner = TraceMessenger()(fn)
+    >>> fn_outer = TraceMessenger()(BlockMessenger(hide=["a"])(TraceMessenger()(fn)))
     >>> trace_inner = fn_inner.get_trace()
     >>> trace_outer  = fn_outer.get_trace()
     >>> "a" in trace_inner

--- a/pyro/poutine/block_poutine.py
+++ b/pyro/poutine/block_poutine.py
@@ -1,9 +1,35 @@
 from __future__ import absolute_import, division, print_function
 
-from .poutine import Messenger, Poutine
+from .poutine import Messenger
 
 
 class BlockMessenger(Messenger):
+    # TODO fix this docstring
+    """
+    This Messenger selectively hides pyro primitive sites from the outside world.
+
+    For example, suppose the stochastic function fn has two sample sites "a" and "b".
+    Then any poutine outside of BlockMessenger(fn, hide=["a"])
+    will not be applied to site "a" and will only see site "b":
+
+    >>> fn_inner = TraceMessenger(fn)
+    >>> fn_outer = TraceMessenger(BlockMessenger(TraceMessenger(fn), hide=["a"]))
+    >>> trace_inner = fn_inner.get_trace()
+    >>> trace_outer  = fn_outer.get_trace()
+    >>> "a" in trace_inner
+    True
+    >>> "a" in trace_outer
+    False
+    >>> "b" in trace_inner
+    True
+    >>> "b" in trace_outer
+    True
+
+    BlockMessenger has a flexible interface that allows users
+    to specify in several different ways
+    which sites should be hidden or exposed.
+    See the constructor for details.
+    """
 
     def __init__(self,
                  hide_all=True, expose_all=False,
@@ -101,55 +127,3 @@ class BlockMessenger(Messenger):
     def _process_message(self, msg):
         msg["stop"] = self._block_up(msg)
         return None
-
-
-class BlockPoutine(Poutine):
-    """
-    This Poutine selectively hides pyro primitive sites from the outside world.
-
-    For example, suppose the stochastic function fn has two sample sites "a" and "b".
-    Then any poutine outside of BlockPoutine(fn, hide=["a"])
-    will not be applied to site "a" and will only see site "b":
-
-    >>> fn_inner = TracePoutine(fn)
-    >>> fn_outer = TracePoutine(BlockPoutine(TracePoutine(fn), hide=["a"]))
-    >>> trace_inner = fn_inner.get_trace()
-    >>> trace_outer  = fn_outer.get_trace()
-    >>> "a" in trace_inner
-    True
-    >>> "a" in trace_outer
-    False
-    >>> "b" in trace_inner
-    True
-    >>> "b" in trace_outer
-    True
-
-    BlockPoutine has a flexible interface that allows users
-    to specify in several different ways
-    which sites should be hidden or exposed.
-    See the constructor for details.
-    """
-
-    def __init__(self, fn,
-                 hide_all=True, expose_all=False,
-                 hide=None, expose=None,
-                 hide_types=None, expose_types=None):
-        """
-        :param bool hide_all: hide all sites
-        :param bool expose_all: expose all sites normally
-        :param list hide: list of site names to hide, rest will be exposed normally
-        :param list expose: list of site names to expose, rest will be hidden
-        :param list hide_types: list of site types to hide, rest will be exposed normally
-        :param list expose_types: list of site types to expose normally, rest will be hidden
-
-        Constructor for blocking poutine
-        Default behavior: block everything (hide_all == True)
-
-        A site is hidden if at least one of the following holds:
-        1. msg["name"] in hide
-        2. msg["type"] in hide_types
-        3. msg["name"] not in expose and msg["type"] not in expose_types
-        4. hide_all == True
-        """
-        msngr = BlockMessenger(hide_all, expose_all, hide, expose, hide_types, expose_types)
-        super(BlockPoutine, self).__init__(msngr, fn)

--- a/pyro/poutine/condition_poutine.py
+++ b/pyro/poutine/condition_poutine.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .poutine import Messenger, Poutine
+from .poutine import Messenger
 from .trace import Trace
 
 
@@ -44,18 +44,3 @@ class ConditionMessenger(Messenger):
 
     def _pyro_param(self, msg):
         return None
-
-
-class ConditionPoutine(Poutine):
-    """
-    Adds values at observe sites to condition on data and override sampling
-    """
-    def __init__(self, fn, data):
-        """
-        :param fn: a stochastic function (callable containing pyro primitive calls)
-        :param data: a dict or a Trace
-
-        Constructor. Doesn't do much, just stores the stochastic function
-        and the data to condition on.
-        """
-        super(ConditionPoutine, self).__init__(ConditionMessenger(data), fn)

--- a/pyro/poutine/enumerate_poutine.py
+++ b/pyro/poutine/enumerate_poutine.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .poutine import Messenger, Poutine
+from .poutine import Messenger
 
 
 class EnumerateMessenger(Messenger):
@@ -52,23 +52,3 @@ class EnumerateMessenger(Messenger):
 
             msg["value"] = value
             msg["done"] = True
-
-
-class EnumeratePoutine(Poutine):
-    """
-    Enumerates in parallel over discrete sample sites that are configured with
-    ``infer={"enumerate": "parallel"}``.
-
-    :param int first_available_dim: The first tensor dimension (counting
-        from the right) that is available for parallel enumeration. This
-        dimension and all dimensions left may be used internally by Pyro.
-    """
-    def __init__(self, fn, first_available_dim):
-        """
-        :param fn: A stochastic function (callable containing pyro primitive
-            calls).
-        :param int first_available_dim: The first tensor dimension (counting
-            from the right) that is available for parallel enumeration. This
-            dimension and all dimensions left may be used internally by Pyro.
-        """
-        super(EnumeratePoutine, self).__init__(EnumerateMessenger(first_available_dim), fn)

--- a/pyro/poutine/escape_poutine.py
+++ b/pyro/poutine/escape_poutine.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from .util import NonlocalExit
 
-from .poutine import Messenger, Poutine
+from .poutine import Messenger
 
 
 class EscapeMessenger(Messenger):
@@ -37,18 +37,3 @@ class EscapeMessenger(Messenger):
                 raise NonlocalExit(m)
             msg["continuation"] = cont
         return None
-
-
-class EscapePoutine(Poutine):
-    """
-    Poutine that does a nonlocal exit by raising a util.NonlocalExit exception
-    """
-    def __init__(self, fn, escape_fn):
-        """
-        :param fn: a stochastic function (callable containing pyro primitive calls)
-        :param escape_fn: function that takes a msg as input and returns True
-            if the poutine should perform a nonlocal exit at that site.
-
-        Constructor.  Stores fn and escape_fn.
-        """
-        super(EscapePoutine, self).__init__(EscapeMessenger(escape_fn), fn)

--- a/pyro/poutine/indep_poutine.py
+++ b/pyro/poutine/indep_poutine.py
@@ -64,7 +64,7 @@ class IndepMessenger(Messenger):
     This messenger keeps track of stack of independence information declared by
     nested ``irange`` and ``iarange`` contexts. This information is stored in
     a ``cond_indep_stack`` at each sample/observe site for consumption by
-    ``TracePoutine``.
+    ``TraceMessenger``.
     """
     def __init__(self, name, size, dim=None):
         """

--- a/pyro/poutine/infer_config_poutine.py
+++ b/pyro/poutine/infer_config_poutine.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .poutine import Messenger, Poutine
+from .poutine import Messenger
 
 
 class InferConfigMessenger(Messenger):
@@ -42,19 +42,3 @@ class InferConfigMessenger(Messenger):
         """
         msg["infer"].update(self.config_fn(msg))
         return None
-
-
-class InferConfigPoutine(Poutine):
-    """
-    Modifies contents of the infer kwarg at sample sites
-    """
-    def __init__(self, fn, config_fn):
-        """
-        :param fn: a stochastic function (callable containing pyro primitive calls)
-        :param config_fn: a callable taking a site and returning an infer dict
-
-        Constructor. Doesn't do much, just stores the stochastic function
-        and the config_fn.
-        """
-        super(InferConfigPoutine, self).__init__(
-            InferConfigMessenger(config_fn=config_fn), fn)

--- a/pyro/poutine/lift_poutine.py
+++ b/pyro/poutine/lift_poutine.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from pyro import params
 from pyro.distributions import Distribution
 
-from .poutine import Messenger, Poutine
+from .poutine import Messenger
 
 
 class LiftMessenger(Messenger):
@@ -66,24 +66,3 @@ class LiftMessenger(Messenger):
         msg["type"] = "sample"
         msg["is_observed"] = False
         return self._pyro_sample(msg)
-
-
-class LiftPoutine(Poutine):
-    """
-    Poutine which "lifts" parameters to random samples.
-    Given a stochastic function with param calls and a prior,
-    creates a stochastic function where all param calls are
-    replaced by sampling from prior.
-
-    Prior should be a callable or a dict of names to callables.
-    """
-
-    def __init__(self, fn, prior):
-        """
-        :param fn: stochastic function
-        :param prior: prior used to lift parameters. Prior can be of type
-                      dict, pyro.distributions, or a python stochastic fn
-
-        Constructor
-        """
-        super(LiftPoutine, self).__init__(LiftMessenger(prior), fn)

--- a/pyro/poutine/poutine.py
+++ b/pyro/poutine/poutine.py
@@ -13,6 +13,9 @@ class Messenger(object):
     def __init__(self):
         pass
 
+    def __call__(self, fn):
+        return Handler(self, fn)
+
     def __enter__(self):
         """
         :returns: self
@@ -40,7 +43,7 @@ class Messenger(object):
             # However, this isn't strictly necessary,
             # and blocks recursive poutine execution patterns like
             # like calling self.__call__ inside of self.__call__
-            # or with Poutine(...) as p: with p: <BLOCK>
+            # or with Handler(...) as p: with p: <BLOCK>
             # It's hard to imagine use cases for this pattern,
             # but it could in principle be enabled...
             raise ValueError("cannot install a Messenger instance twice")
@@ -111,19 +114,19 @@ class Messenger(object):
         return None
 
 
-class Poutine(object):
+class Handler(object):
     """
     Context manager class that modifies behavior
     and adds side effects to stochastic functions
     i.e. callables containing pyro primitive statements.
 
-    See the Poutine execution model writeup in the documentation
-    for a description of the entire Poutine system.
+    See the Handler execution model writeup in the documentation
+    for a description of the entire Handler system.
 
-    This is the base Poutine class.
+    This is the base Handler class.
     It implements the default behavior for all pyro primitives,
     so that the joint distribution induced by a stochastic function fn
-    is identical to the joint distribution induced by Poutine(fn).
+    is identical to the joint distribution induced by Handler(fn).
     """
 
     def __init__(self, msngr, fn):

--- a/pyro/poutine/replay_poutine.py
+++ b/pyro/poutine/replay_poutine.py
@@ -54,7 +54,7 @@ class ReplayMessenger(Messenger):
         from the stochastic function at the site.
 
         At a sample site that does not appear in self.guide_trace,
-        reverts to default Poutine._pyro_sample behavior with no additional side effects.
+        reverts to default Messenger._pyro_sample behavior with no additional side effects.
         """
         name = msg["name"]
         # case 1: dict, positive: sample from guide

--- a/pyro/poutine/replay_poutine.py
+++ b/pyro/poutine/replay_poutine.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .poutine import Messenger, Poutine
+from .poutine import Messenger
 
 
 class ReplayMessenger(Messenger):
@@ -73,19 +73,3 @@ class ReplayMessenger(Messenger):
 
     def _pyro_param(self, msg):
         return None
-
-
-class ReplayPoutine(Poutine):
-    """
-    Poutine for replaying from an existing execution trace.
-    """
-
-    def __init__(self, fn, guide_trace, sites=None):
-        """
-        :param fn: a stochastic function (callable containing pyro primitive calls)
-        :param guide_trace: a trace whose values should be reused
-
-        Constructor.
-        Stores guide_trace in an attribute.
-        """
-        super(ReplayPoutine, self).__init__(ReplayMessenger(guide_trace, sites), fn)

--- a/pyro/poutine/util.py
+++ b/pyro/poutine/util.py
@@ -25,7 +25,7 @@ class NonlocalExit(Exception):
     """
     Exception for exiting nonlocally from poutine execution.
 
-    Used by poutine.EscapePoutine to return site information.
+    Used by poutine.EscapeMessenger to return site information.
     """
     def __init__(self, site, *args, **kwargs):
         """
@@ -105,7 +105,7 @@ def discrete_escape(trace, msg):
 
     Utility function that checks if a sample site is discrete and not already in a trace.
 
-    Used by EscapePoutine to decide whether to do a nonlocal exit at a site.
+    Used by EscapeMessenger to decide whether to do a nonlocal exit at a site.
     Subroutine for integrating out discrete variables for variance reduction.
     """
     return (msg["type"] == "sample") and \
@@ -122,7 +122,7 @@ def all_escape(trace, msg):
 
     Utility function that checks if a site is not already in a trace.
 
-    Used by EscapePoutine to decide whether to do a nonlocal exit at a site.
+    Used by EscapeMessenger to decide whether to do a nonlocal exit at a site.
     Subroutine for approximately integrating out variables for variance reduction.
     """
     return (msg["type"] == "sample") and \

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -622,7 +622,7 @@ def test_enumerate_poutine(depth, first_available_dim):
         for i in range(depth):
             pyro.sample("a_{}".format(i), Bernoulli(0.5), infer={"enumerate": "parallel"})
 
-    model = poutine.EnumeratePoutine(model, first_available_dim)
+    model = poutine.EnumerateMessenger(first_available_dim)(model)
     model = poutine.trace(model)
 
     for i in range(num_particles):
@@ -645,7 +645,7 @@ def test_replay_enumerate_poutine(depth, first_available_dim):
     def guide():
         pyro.sample("y", y_dist, infer={"enumerate": "parallel"})
 
-    guide = poutine.EnumeratePoutine(guide, depth + first_available_dim)
+    guide = poutine.EnumerateMessenger(depth + first_available_dim)(guide)
     guide = poutine.trace(guide)
     guide_trace = guide.get_trace()
 
@@ -657,7 +657,7 @@ def test_replay_enumerate_poutine(depth, first_available_dim):
         for i in range(depth):
             pyro.sample("b_{}".format(i), Bernoulli(0.5), infer={"enumerate": "parallel"})
 
-    model = poutine.EnumeratePoutine(model, first_available_dim)
+    model = poutine.EnumerateMessenger(first_available_dim)(model)
     model = poutine.replay(model, guide_trace)
     model = poutine.trace(model)
 

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -21,7 +21,7 @@ def eq(x, y, prec=1e-10):
 
 
 # XXX name is a bit silly
-class NormalNormalNormalPoutineTestCase(TestCase):
+class NormalNormalNormalHandlerTestCase(TestCase):
 
     def setUp(self):
         pyro.clear_param_store()
@@ -63,7 +63,7 @@ class NormalNormalNormalPoutineTestCase(TestCase):
         self.partial_sample_sites = {"latent1": "latent1"}
 
 
-class TracePoutineTests(NormalNormalNormalPoutineTestCase):
+class TraceHandlerTests(NormalNormalNormalHandlerTestCase):
 
     def test_trace_full(self):
         guide_trace = poutine.trace(self.guide).get_trace()
@@ -84,7 +84,7 @@ class TracePoutineTests(NormalNormalNormalPoutineTestCase):
                      model_trace.nodes["_RETURN"]["value"])
 
 
-class ReplayPoutineTests(NormalNormalNormalPoutineTestCase):
+class ReplayHandlerTests(NormalNormalNormalHandlerTestCase):
 
     def test_replay_full(self):
         guide_trace = poutine.trace(self.guide).get_trace()
@@ -119,7 +119,7 @@ class ReplayPoutineTests(NormalNormalNormalPoutineTestCase):
             assert_equal(model_trace.nodes[name]["value"], tr2.nodes[name]["value"])
 
 
-class BlockPoutineTests(NormalNormalNormalPoutineTestCase):
+class BlockHandlerTests(NormalNormalNormalHandlerTestCase):
 
     def test_block_full(self):
         model_trace = poutine.trace(poutine.block(self.model)).get_trace()
@@ -195,7 +195,7 @@ class BlockPoutineTests(NormalNormalNormalPoutineTestCase):
         assert "obs" not in guide_trace
 
 
-class QueuePoutineDiscreteTest(TestCase):
+class QueueHandlerDiscreteTest(TestCase):
 
     def setUp(self):
 
@@ -268,7 +268,7 @@ class Model(nn.Module):
         return self.fc(x)
 
 
-class LiftPoutineTests(TestCase):
+class LiftHandlerTests(TestCase):
 
     def setUp(self):
         pyro.clear_param_store()
@@ -376,7 +376,7 @@ class LiftPoutineTests(TestCase):
                 assert not lifted_tr.nodes[key_name]["is_observed"]
 
 
-class QueuePoutineMixedTest(TestCase):
+class QueueHandlerMixedTest(TestCase):
 
     def setUp(self):
 
@@ -426,7 +426,7 @@ class QueuePoutineMixedTest(TestCase):
         assert values[0]["z"] != values[1]["z"]  # Almost surely true.
 
 
-class IndirectLambdaPoutineTests(TestCase):
+class IndirectLambdaHandlerTests(TestCase):
 
     def setUp(self):
 
@@ -470,7 +470,7 @@ class IndirectLambdaPoutineTests(TestCase):
         _test_scale_factor(2, 1, [2.0] * 2)
 
 
-class ConditionPoutineTests(NormalNormalNormalPoutineTestCase):
+class ConditionHandlerTests(NormalNormalNormalHandlerTestCase):
 
     def test_condition(self):
         data = {"latent2": torch.randn(2)}
@@ -533,7 +533,7 @@ class ConditionPoutineTests(NormalNormalNormalPoutineTestCase):
         assert eq(sample_from_do_model, torch.zeros(1))
 
 
-class EscapePoutineTests(TestCase):
+class EscapeHandlerTests(TestCase):
 
     def setUp(self):
 
@@ -584,7 +584,7 @@ class EscapePoutineTests(TestCase):
                 assert "x" not in tem.trace
 
 
-class InferConfigPoutineTests(TestCase):
+class InferConfigHandlerTests(TestCase):
     def setUp(self):
         def model():
             pyro.param("p", torch.zeros(1, requires_grad=True))


### PR DESCRIPTION
This PR adds a decorator interface to all `poutine.*Messenger` classes, so that we can do things like
```python
@poutine.ScaleMessenger(1/1000)
def model():
    ...
```
as requested by @martinjankowiak and @fritzo in #999.  It also removes all `poutine.*Poutine` classes, as they are redundant.

This PR does not break backwards compatibility, but I would like to remove the old interface entirely in a followup PR.  Because of that plan, I have also not updated `poutine`'s documentation yet.

(description edited by @fritzo)