### PR TITLE
Fix setup.py packages list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 install:
     # Install PyTorch wheel using the install script
     - bash scripts/install_pytorch.sh
-    - pip install -e .[test]
+    - pip install .[test]
     - pip freeze
 
 branches:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 import os
-from setuptools import setup
+from setuptools import find_packages, setup
 
 PROJECT_PATH = os.path.dirname(os.path.abspath(__file__))
 VERSION = """
@@ -65,7 +65,7 @@ setup(
     version=version,
     description='A Python library for probabilistic modeling and inference',
     long_description=long_description,
-    packages=['pyro'],
+    packages=find_packages(include=['pyro', 'pyro.*']),
     url='http://pyro.ai',
     author='Uber AI Labs',
     author_email='pyro@uber.com',


### PR DESCRIPTION
As of #993 Pyro dev cannot be pip installed except in editable mode, due to an incorrect specification of packages in setup.py 