### PR TITLE
Updating docker file to build latest PyTorch master

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,10 +13,8 @@ ARG ostype=Linux
 # Configurable settings
 ENV USER_NAME pyromancer
 ENV CONDA_DIR /opt/conda
-ENV WORK_DIR /workspace
+ENV WORK_DIR /home/${USER_NAME}/workspace
 ENV PATH ${CONDA_DIR}/bin:${PATH}
-
-COPY install.sh /install.sh
 
 # Install linux utils
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -27,26 +25,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# Change to default user
+RUN bash -c 'if [ ${ostype} == Linux ]; then groupadd -r --gid ${gid} ${USER_NAME}; fi && \
+    useradd -r --create-home --shell /bin/bash --uid ${uid} --gid ${gid} ${USER_NAME}' && \
+    mkdir -p ${CONDA_DIR} ${WORK_DIR} && chown ${USER_NAME} ${CONDA_DIR} ${WORK_DIR}
+USER ${USER_NAME}
+
 # Install conda
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
-    chmod +x ~/miniconda.sh && \
-    ~/miniconda.sh -b -p ${CONDA_DIR} && \
+RUN curl -o ~/miniconda.sh -O \
+    https://repo.continuum.io/miniconda/Miniconda${python_version%%.*}-latest-Linux-x86_64.sh && \
+    bash ~/miniconda.sh -f -b -p ${CONDA_DIR} && \
     rm ~/miniconda.sh
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
-# Change to default user
-RUN bash -c 'if [ ${ostype} == Linux ]; then groupadd -r --gid ${gid} ${USER_NAME}; fi && \
-    useradd -r --create-home --shell /bin/bash --uid ${uid} --gid ${gid} ${USER_NAME}'
+# Move to home directory; and copy the install script
 WORKDIR ${WORK_DIR}
-RUN chown ${USER_NAME} ${WORK_DIR} ${CONDA_DIR} -R
-USER ${USER_NAME}
+COPY install.sh ${WORK_DIR}/install.sh
 
-# Install python 2/3; and other packages
-RUN conda install -y python=${python_version} && \
-    conda install -y jupyter matplotlib
-
-# Install PyTorch and Pyro
-RUN bash /install.sh
+# Install python 2/3, Pytorch and Pyro
+RUN cd ${WORK_DIR} && conda update -n base conda -c defaults && bash install.sh
 
 # Run Jupyter notebook
 # (Ref: http://jupyter-notebook.readthedocs.io/en/latest/public_server.html#docker-cmd)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,7 +2,7 @@
 
 DOCKER_FILE=Dockerfile
 BASE_IMG=ubuntu:16.04
-BASE_CUDA_IMG=nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
+BASE_CUDA_IMG=nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04
 DOCKER_CMD=docker
 DOCKER_GPU_CMD=nvidia-docker
 DOCKER_WORK_DIR=/workspace/shared

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -7,14 +7,16 @@ set -xe
 if [ ${pytorch_branch} = "release" ]
 then
     conda install -y pytorch torchvision -c pytorch
-    if [ ${cuda} ]; then conda install -y cuda90 -c pytorch; fi
+    if [ ${cuda} = 1 ]; then conda install -y cuda90 -c pytorch; fi
 else
-    conda install -y numpy pyyaml mkl setuptools cmake cffi
-    if [ ${cuda} ]; then conda install -y cuda90 -c pytorch; fi
+    conda install -y numpy pyyaml mkl mkl-include setuptools cmake cffi typing
+    pip install --upgrade pip
+    pip install jupyter matplotlib
+    if [ ${cuda} = 1 ]; then conda install -y cuda90 -c pytorch; fi
     git clone --recursive https://github.com/pytorch/pytorch.git
-    cd pytorch && git checkout ${pytorch_branch}
+    pushd pytorch && git checkout ${pytorch_branch}
     python setup.py install
-    cd ..
+    popd
 fi
 
 

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -27,8 +27,6 @@ if [ ${pyro_branch} = "release" ]
 then
     pip install pyro-ppl
 else
-    conda install -y numpy pyyaml mkl setuptools cmake cffi
-    conda install -y -c soumith magma-cuda90
     git clone https://github.com/uber/pyro.git
     (cd pyro && git checkout ${pyro_branch} && pip install -e .)
 fi


### PR DESCRIPTION
Fixes #1010. Due to some recent changes, installing Miniconda2 and later changing to python3 via `conda install python=3.6` or vice-versa isn't possible due to some incompatible libraries that are installed in the conda environment. To keep the complexity low, I am justing installing the correct Miniconda version to begin with (rather than introducing a new environment). The user is of course free to later create a new environment if needed.

Additionally :
 - Fixes the build script used by the Dockerfile to work with PyTorch master.
 - Makes the build faster - reorganizes the build so that we are executing most installation instructions under `pyromancer`. I was seeing that `chowning` the conda directory later took a really long time as the indexer would have to go through a lot of files. 

Checked that it works on python 2.7 / 3.6.