### PR TITLE
Add support for ELBO object as loss arg to SVI

### DIFF
--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -6,16 +6,9 @@ from pyro.infer.enum import config_enumerate
 from pyro.infer.importance import Importance
 from pyro.infer.search import Search
 from pyro.infer.svi import SVI
+from pyro.infer.trace_elbo import Trace_ELBO
+from pyro.infer.traceenum_elbo import TraceEnum_ELBO
+from pyro.infer.tracegraph_elbo import TraceGraph_ELBO
+from pyro.infer.util import enable_validation, is_validation_enabled
 
 # flake8: noqa
-
-_VALIDATION_ENABLED = False
-
-
-def enable_validation(is_validate):
-    global _VALIDATION_ENABLED
-    _VALIDATION_ENABLED = is_validate
-
-
-def is_validation_enabled():
-    return _VALIDATION_ENABLED

--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-import copy
-
 import pyro
-from pyro.infer import ELBO
+from pyro.infer.elbo import ELBO
 
 
 class SVI(object):
@@ -34,37 +32,18 @@ class SVI(object):
         self.optim = optim
 
         if isinstance(loss, str):
-            assert loss in ["ELBO"], "The only built-in loss currently supported by SVI is ELBO"
-
             if loss == "ELBO":
                 self.ELBO = ELBO.make(**kwargs)
                 self.loss = self.ELBO.loss
                 self.loss_and_grads = self.ELBO.loss_and_grads
             else:
-                raise NotImplementedError
-
-        else:  # the user provided a loss function
-            self.loss = loss
-            if loss_and_grads is None:
-                # default implementation of loss_and_grads:
-                # marks all parameters in param store as active
-                # and calls backward() on loss
-                # TODO: clean this up
-
-                self._loss = copy.copy(loss)
-
-                def new_loss(model, guide, *args, **kwargs):
-                    return self._loss(model, guide, *args, **kwargs).item()
-
-                self.loss = new_loss
-
-                def loss_and_grads(model, guide, *args, **kwargs):
-                    _loss = self._loss(model, guide, *args, **kwargs)
-                    _loss.backward()
-                    pyro.get_param_store().mark_params_active(pyro.get_param_store().get_all_param_names())
-                    return _loss
-
-            self.loss_and_grads = loss_and_grads
+                raise NotImplementedError("The only built-in loss currently supported by SVI is ELBO")
+        elif isinstance(loss, ELBO):
+            self.ELBO = loss
+            self.loss = self.ELBO.loss
+            self.loss_and_grads = self.ELBO.loss_and_grads
+        else:
+            raise TypeError("Unsupported loss type {}".format(type(loss)))
 
     def __call__(self, *args, **kwargs):
         """

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -3,12 +3,11 @@ from __future__ import absolute_import, division, print_function
 import warnings
 
 import pyro
-import pyro.infer as infer
 import pyro.poutine as poutine
 from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import iter_discrete_traces
-from pyro.infer.util import Dice
+from pyro.infer.util import Dice, is_validation_enabled
 from pyro.poutine import EnumerateMessenger
 from pyro.poutine.util import prune_subsample_sites
 from pyro.util import check_model_guide_match, check_site_shape, check_traceenum_requirements, torch_isnan
@@ -62,16 +61,16 @@ class TraceEnum_ELBO(ELBO):
                 model_trace = poutine.trace(poutine.replay(model, guide_trace),
                                             graph_type="flat").get_trace(*args, **kwargs)
 
-                if infer.is_validation_enabled():
+                if is_validation_enabled():
                     check_model_guide_match(model_trace, guide_trace, self.max_iarange_nesting)
                 guide_trace = prune_subsample_sites(guide_trace)
                 model_trace = prune_subsample_sites(model_trace)
-                if infer.is_validation_enabled():
+                if is_validation_enabled():
                     check_traceenum_requirements(model_trace, guide_trace)
 
                 model_trace.compute_log_prob()
                 guide_trace.compute_score_parts()
-                if infer.is_validation_enabled():
+                if is_validation_enabled():
                     for site in model_trace.nodes.values():
                         if site["type"] == "sample":
                             check_site_shape(site, self.max_iarange_nesting)

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -7,12 +7,11 @@ import networkx
 import torch
 
 import pyro
-import pyro.infer as infer
 import pyro.poutine as poutine
 from pyro.distributions.util import is_identically_zero
 from pyro.infer import ELBO
 from pyro.infer.util import (MultiFrameTensor, get_iarange_stacks, torch_backward,
-                             torch_data_sum, detach_iterable)
+                             torch_data_sum, detach_iterable, is_validation_enabled)
 from pyro.poutine.util import prune_subsample_sites
 from pyro.util import check_model_guide_match, check_site_shape, torch_isnan
 
@@ -200,7 +199,7 @@ class TraceGraph_ELBO(ELBO):
                                         graph_type="dense").get_trace(*args, **kwargs)
             model_trace = poutine.trace(poutine.replay(model, guide_trace),
                                         graph_type="dense").get_trace(*args, **kwargs)
-            if infer.is_validation_enabled():
+            if is_validation_enabled():
                 check_model_guide_match(model_trace, guide_trace)
             guide_trace = prune_subsample_sites(guide_trace)
             model_trace = prune_subsample_sites(model_trace)
@@ -255,7 +254,7 @@ class TraceGraph_ELBO(ELBO):
         # and score function terms (if present) so that they are available below
         model_trace.compute_log_prob()
         guide_trace.compute_score_parts()
-        if infer.is_validation_enabled():
+        if is_validation_enabled():
             for site in model_trace.nodes.values():
                 if site["type"] == "sample":
                     check_site_shape(site, self.max_iarange_nesting)

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -9,6 +9,17 @@ import torch
 from pyro.distributions.util import is_identically_zero
 from pyro.poutine.util import site_is_subsample
 
+_VALIDATION_ENABLED = False
+
+
+def enable_validation(is_validate):
+    global _VALIDATION_ENABLED
+    _VALIDATION_ENABLED = is_validate
+
+
+def is_validation_enabled():
+    return _VALIDATION_ENABLED
+
 
 def torch_data_sum(x):
     """

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -179,8 +179,8 @@ def test_svi_step_smoke(model, guide, enumerate1):
 
     guide = config_enumerate(guide, default=enumerate1)
     optimizer = pyro.optim.Adam({"lr": .001})
-    inference = SVI(model, guide, optimizer, loss="ELBO",
-                    enum_discrete=True, max_iarange_nesting=1)
+    elbo = TraceEnum_ELBO(max_iarange_nesting=1)
+    inference = SVI(model, guide, optimizer, loss=elbo)
     inference.step(data)
 
 

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -12,7 +12,7 @@ import pyro.distributions as dist
 import pyro.optim as optim
 from pyro.distributions.testing import fakes
 from pyro.distributions.testing.rejection_gamma import ShapeAugmentedGamma
-from pyro.infer.svi import SVI
+from pyro.infer import SVI, Trace_ELBO
 from tests.common import assert_equal
 
 
@@ -75,7 +75,8 @@ class NormalNormalTests(TestCase):
             pyro.sample("loc_latent", Normal(loc_q, sig_q).reshape(extra_event_dims=1))
 
         adam = optim.Adam({"lr": .001})
-        svi = SVI(model, guide, adam, loss="ELBO", trace_graph=False)
+        elbo = Trace_ELBO()
+        svi = SVI(model, guide, adam, loss=elbo)
 
         for k in range(n_steps):
             svi.step()


### PR DESCRIPTION
Addresses #1014, #981

This is the first small PR in a sequence of refactoring PRs to address #1014.

1. Adds support for using custom `loss` object in SVI using an `ELBO` instance.
2. Drops support for using a custom `loss` callable (use an `ELBO` instance instead, some day we may support more general objects)
3. Moves `is_validation_enabled` from `pyro.infer` to `pyro.infer.util` to avoid cyclic dependency.

## Tested

Added a couple invocations of `SVI(..., loss=Trace*_ELBO(...))` to existing tests. Remaining tests will be migrated in follow-up PRs.