### PR TITLE
Upgrade to latest PyTorch master

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Alternatively, build PyTorch following instructions in the PyTorch
 ```sh
 git clone --recursive https://github.com/pytorch/pytorch
 cd pytorch
-git checkout 1807bac  # <---- a well-tested commit
+git checkout 084e3a7  # <---- a well-tested commit
 ```
 On Linux:
 ```sh

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import logging
 
 import pyro.poutine as poutine
-from pyro.poutine import _PYRO_STACK
 from pyro.primitives import clear_param_store, enable_validation, get_param_store, iarange, irange, \
     module, param, sample, random_module, validation_enabled
 from pyro.util import set_rng_seed
@@ -21,7 +20,6 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     "__version__",
-    "_PYRO_STACK",
     "clear_param_store",
     "enable_validation",
     "get_param_store",

--- a/pyro/params/__init__.py
+++ b/pyro/params/__init__.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from pyro.params.param_store import _MODULE_NAMESPACE_DIVIDER, _PYRO_PARAM_STORE, \
-    module_from_param_with_module_name, param_with_module_name, user_param_name
+from pyro.params.param_store import _MODULE_NAMESPACE_DIVIDER, _PYRO_PARAM_STORE  # noqa: F401
+from pyro.params.param_store import module_from_param_with_module_name, param_with_module_name, user_param_name
 
 __all__ = [
-    "_MODULE_NAMESPACE_DIVIDER",
-    "_PYRO_PARAM_STORE",
     "module_from_param_with_module_name",
     "param_with_module_name",
     "user_param_name",

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -112,7 +112,7 @@ class _Subsample(Distribution):
         """
         self.size = size
         self.subsample_size = subsample_size
-        self.use_cuda = torch.Tensor.is_cuda if use_cuda is None else use_cuda
+        self.use_cuda = torch.Tensor().is_cuda if use_cuda is None else use_cuda
 
     def sample(self, sample_shape=torch.Size()):
         """


### PR DESCRIPTION
Updating to latest PyTorch master. Based on suggestions from #1031, cleaning up the `__all__` to remove global variables private to Pyro.