### PR TITLE
Turn off distributions arg check during HMC step size adaptation

### DIFF
--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -11,11 +11,12 @@ from pyro.distributions.sparse_mvn import SparseMultivariateNormal
 from pyro.distributions.torch import *  # noqa F403
 from pyro.distributions.torch import __all__ as torch_dists
 from pyro.distributions.torch_distribution import TorchDistribution
-from pyro.distributions.util import enable_validation, is_validation_enabled
+from pyro.distributions.util import enable_validation, is_validation_enabled, validation_enabled
 
 __all__ = [
     "enable_validation",
     "is_validation_enabled",
+    "validation_enabled",
     "Delta",
     "Distribution",
     "Empirical",

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import numbers
+from contextlib import contextmanager
 
 import torch
 import torch.distributions as torch_dist
@@ -221,3 +222,13 @@ def enable_validation(is_validate):
 
 def is_validation_enabled():
     return _VALIDATION_ENABLED
+
+
+@contextmanager
+def validation_enabled(is_validate=True):
+    distribution_validation_status = is_validation_enabled()
+    try:
+        enable_validation(is_validate)
+        yield
+    finally:
+        enable_validation(distribution_validation_status)

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -38,7 +38,8 @@ class MCMC(TracePosterior):
         for t in range(1, self.warmup_steps + self.num_samples + 1):
             trace = self.kernel.sample(trace)
             if t % logging_interval == 0:
-                self.logger.info("Iteration: {}.".format(t))
+                stage = "WARMUP" if t <= self.warmup_steps else "SAMPLE"
+                self.logger.info("Iteration: {} [{}]".format(t, stage))
                 diagnostic_info = self.kernel.diagnostics()
                 if diagnostic_info is not None:
                     self.logger.info(diagnostic_info)

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -290,9 +290,7 @@ def test_normal_gamma_with_dual_averaging():
     posterior = []
     true_std = torch.tensor([0.5, 2])
     data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
-    # Model temporarily returns NaNs during warmup phase while tuning step size
-    with pyro.validation_enabled(False):
-        for trace, _ in mcmc_run._traces(data):
-            posterior.append(trace.nodes['p_latent']['value'])
+    for trace, _ in mcmc_run._traces(data):
+        posterior.append(trace.nodes['p_latent']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
     assert_equal(posterior_mean, true_std, prec=0.02)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -166,9 +166,7 @@ def test_bernoulli_beta_with_dual_averaging():
     posterior = []
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
-    # Model temporarily returns NaNs during warmup phase while tuning step size
-    with pyro.validation_enabled(False):
-        for trace, _ in mcmc_run._traces(data):
-            posterior.append(trace.nodes['p_latent']['value'])
+    for trace, _ in mcmc_run._traces(data):
+        posterior.append(trace.nodes['p_latent']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
     assert_equal(posterior_mean.data, true_probs.data, prec=0.01)


### PR DESCRIPTION
 - Turn off distributions arg checking during warmup phase. While writing the tutorial, I realized that the warnings during the adaptation phase are spurious, and it is clunky to keep toggling validation check when we are in warmup phase vs. otherwise.
 - Introduces a context manager for toggling off distributions validation.
 - Minor logging related changes - specify whether we are in WARMUP/SAMPLE stage.