### PR TITLE
Refactor examples testing

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,11 +8,49 @@ import pytest
 
 from tests.common import EXAMPLES_DIR, requires_cuda
 
-CPU_EXAMPLES = []
-CUDA_EXAMPLES = []
+CPU_EXAMPLES = [
+    ('air/main.py', ['--num-steps=1']),
+    ('bayesian_regression.py', ['--num-epochs=1']),
+    ('contrib/gp/sv-dkl.py', ['--epochs=1', '--num-inducing=4', '--no-cuda']),
+    ('contrib/named/mixture.py', ['--num-epochs=1']),
+    ('contrib/named/tree_data.py', ['--num-epochs=1']),
+    ('dmm/dmm.py', ['--num-epochs=1']),
+    ('dmm/dmm.py', ['--num-epochs=1', '--num-iafs=1']),
+    ('inclined_plane.py', ['--num-samples=1']),
+    ('schelling.py', ['--num-samples=1']),
+    ('schelling_false.py', ['--num-samples=1']),
+    ('vae/ss_vae_M2.py', ['--num-epochs=1']),
+    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--aux-loss']),
+    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--enum-discrete=parallel']),
+    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--enum-discrete=sequential']),
+    ('vae/vae.py', ['--num-epochs=1']),
+    ('vae/vae_comparison.py', ['--num-epochs=1']),
+]
+
+CUDA_EXAMPLES = [
+    ('air/main.py', ['--num-steps=1', '--cuda']),
+    ('bayesian_regression.py', ['--num-epochs=1', '--cuda']),
+    ('contrib/gp/sv-dkl.py', ['--epochs=1', '--num_inducing=4']),
+    ('dmm/dmm.py', ['--num-epochs=1', '--cuda']),
+    ('dmm/dmm.py', ['--num-epochs=1', '--num-iafs=1', '--cuda']),
+    ('vae/vae.py', ['--num-epochs=1', '--cuda']),
+    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--use-cuda']),
+    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--aux-loss', '--use-cuda']),
+    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--enum-discrete=parallel', '--use-cuda']),
+    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--enum-discrete=sequential', '--use-cuda']),
+]
+
+CPU_EXAMPLES.sort()
+CUDA_EXAMPLES.sort()
 
 
-def discover_examples():
+def make_ids(examples):
+    return ['{} {}'.format(example, ' '.join(args)) for example, args in examples]
+
+
+def test_coverage():
+    cpu_tests = set([name for name, _ in CPU_EXAMPLES])
+    cuda_tests = set([name for name, _ in CUDA_EXAMPLES])
     for root, dirs, files in os.walk(EXAMPLES_DIR):
         for basename in files:
             if not basename.endswith('.py'):
@@ -20,45 +58,12 @@ def discover_examples():
             path = os.path.join(root, basename)
             with open(path) as f:
                 text = f.read()
-            if '--num-epochs' in text:
-                args = ['--num-epochs=1']
-            elif '--num-steps' in text:
-                args = ['--num-steps=1']
-            elif '--num-samples' in text:
-                args = ['--num-samples=1']
-            else:
-                # Either this is not a main file, or we don't know how to run it cheaply.
-                continue
             example = os.path.relpath(path, EXAMPLES_DIR)
-            # TODO: May be worth whitelisting the set of arguments to test
-            # for each example.
-            CPU_EXAMPLES.append((example, args))
-            cuda_args = args + ['--cuda']
-            if '--cuda' in text:
-                CUDA_EXAMPLES.append((example, cuda_args))
-            if '--aux-loss' in text:
-                CPU_EXAMPLES.append((example, args + ['--aux-loss']))
-                if '--cuda' in text:
-                    CUDA_EXAMPLES.append((example, cuda_args + ['--aux-loss']))
-            if '--enum-discrete' in text:
-                CPU_EXAMPLES.append((example, args + ['--enum-discrete=sequential']))
-                CPU_EXAMPLES.append((example, args + ['--enum-discrete=parallel']))
-                if '--cuda' in text:
-                    CUDA_EXAMPLES.append((example, cuda_args + ['--enum-discrete=sequential']))
-                    CUDA_EXAMPLES.append((example, cuda_args + ['--enum-discrete=parallel']))
-            if '--num-iafs' in text:
-                CPU_EXAMPLES.append((example, args + ['--num-iafs=1']))
-                if '--cuda' in text:
-                    CUDA_EXAMPLES.append((example, cuda_args + ['--num-iafs=1']))
-    CPU_EXAMPLES.sort()
-    CUDA_EXAMPLES.sort()
-
-
-discover_examples()
-
-
-def make_ids(examples):
-    return ['{} {}'.format(example, ' '.join(args)) for example, args in examples]
+            if '__main__' in text:
+                if example not in cpu_tests:
+                    pytest.fail('Example: {} not covered in CPU_TESTS.'.format(example))
+                if 'cuda' in text and example not in cuda_tests:
+                    pytest.fail('Example: {} not covered by CUDA_TESTS.'.format(example))
 
 
 @pytest.mark.stage("test_examples")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,39 +9,39 @@ import pytest
 from tests.common import EXAMPLES_DIR, requires_cuda
 
 CPU_EXAMPLES = [
-    ('air/main.py', ['--num-steps=1']),
-    ('bayesian_regression.py', ['--num-epochs=1']),
-    ('contrib/gp/sv-dkl.py', ['--epochs=1', '--num-inducing=4', '--no-cuda']),
-    ('contrib/named/mixture.py', ['--num-epochs=1']),
-    ('contrib/named/tree_data.py', ['--num-epochs=1']),
-    ('dmm/dmm.py', ['--num-epochs=1']),
-    ('dmm/dmm.py', ['--num-epochs=1', '--num-iafs=1']),
-    ('inclined_plane.py', ['--num-samples=1']),
-    ('schelling.py', ['--num-samples=1']),
-    ('schelling_false.py', ['--num-samples=1']),
-    ('vae/ss_vae_M2.py', ['--num-epochs=1']),
-    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--aux-loss']),
-    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--enum-discrete=parallel']),
-    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--enum-discrete=sequential']),
-    ('vae/vae.py', ['--num-epochs=1']),
-    ('vae/vae_comparison.py', ['--num-epochs=1']),
+    ['air/main.py', '--num-steps=1'],
+    ['bayesian_regression.py', '--num-epochs=1'],
+    ['contrib/gp/sv-dkl.py', '--epochs=1', '--num-inducing=4', '--no-cuda'],
+    ['contrib/named/mixture.py', '--num-epochs=1'],
+    ['contrib/named/tree_data.py', '--num-epochs=1'],
+    ['dmm/dmm.py', '--num-epochs=1'],
+    ['dmm/dmm.py', '--num-epochs=1', '--num-iafs=1'],
+    ['inclined_plane.py', '--num-samples=1'],
+    ['schelling.py', '--num-samples=1'],
+    ['schelling_false.py', '--num-samples=1'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1', '--aux-loss'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=parallel'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=sequential'],
+    ['vae/vae.py', '--num-epochs=1'],
+    ['vae/vae_comparison.py', '--num-epochs=1'],
 ]
 
 CUDA_EXAMPLES = [
-    ('air/main.py', ['--num-steps=1', '--cuda']),
-    ('bayesian_regression.py', ['--num-epochs=1', '--cuda']),
-    ('contrib/gp/sv-dkl.py', ['--epochs=1', '--num_inducing=4']),
-    ('dmm/dmm.py', ['--num-epochs=1', '--cuda']),
-    ('dmm/dmm.py', ['--num-epochs=1', '--num-iafs=1', '--cuda']),
-    ('vae/vae.py', ['--num-epochs=1', '--cuda']),
-    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--use-cuda']),
-    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--aux-loss', '--use-cuda']),
-    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--enum-discrete=parallel', '--use-cuda']),
-    ('vae/ss_vae_M2.py', ['--num-epochs=1', '--enum-discrete=sequential', '--use-cuda']),
+    ['air/main.py', '--num-steps=1', '--cuda'],
+    ['bayesian_regression.py', '--num-epochs=1', '--cuda'],
+    ['contrib/gp/sv-dkl.py', '--epochs=1', '--num_inducing=4'],
+    ['dmm/dmm.py', '--num-epochs=1', '--cuda'],
+    ['dmm/dmm.py', '--num-epochs=1', '--num-iafs=1', '--cuda'],
+    ['vae/vae.py', '--num-epochs=1', '--cuda'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1', '--use-cuda'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1', '--aux-loss', '--use-cuda'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=parallel', '--use-cuda'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=sequential', '--use-cuda'],
 ]
 
-CPU_EXAMPLES.sort()
-CUDA_EXAMPLES.sort()
+CPU_EXAMPLES = [(example[0], example[1:]) for example in sorted(CPU_EXAMPLES)]
+CUDA_EXAMPLES = [(example[0], example[1:]) for example in sorted(CUDA_EXAMPLES)]
 
 
 def make_ids(examples):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -11,7 +11,7 @@ from tests.common import EXAMPLES_DIR, requires_cuda
 CPU_EXAMPLES = [
     ['air/main.py', '--num-steps=1'],
     ['bayesian_regression.py', '--num-epochs=1'],
-    ['contrib/gp/sv-dkl.py', '--epochs=1', '--num-inducing=4', '--no-cuda'],
+    ['contrib/gp/sv-dkl.py', '--epochs=1', '--num-inducing=4'],
     ['contrib/named/mixture.py', '--num-epochs=1'],
     ['contrib/named/tree_data.py', '--num-epochs=1'],
     ['dmm/dmm.py', '--num-epochs=1'],
@@ -30,14 +30,14 @@ CPU_EXAMPLES = [
 CUDA_EXAMPLES = [
     ['air/main.py', '--num-steps=1', '--cuda'],
     ['bayesian_regression.py', '--num-epochs=1', '--cuda'],
-    ['contrib/gp/sv-dkl.py', '--epochs=1', '--num_inducing=4'],
+    ['contrib/gp/sv-dkl.py', '--epochs=1', '--num_inducing=4', '--cuda'],
     ['dmm/dmm.py', '--num-epochs=1', '--cuda'],
     ['dmm/dmm.py', '--num-epochs=1', '--num-iafs=1', '--cuda'],
     ['vae/vae.py', '--num-epochs=1', '--cuda'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1', '--use-cuda'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1', '--aux-loss', '--use-cuda'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=parallel', '--use-cuda'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=sequential', '--use-cuda'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1', '--cuda'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1', '--aux-loss', '--cuda'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=parallel', '--cuda'],
+    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=sequential', '--cuda'],
 ]
 
 CPU_EXAMPLES = [(example[0], example[1:]) for example in sorted(CPU_EXAMPLES)]
@@ -62,7 +62,7 @@ def test_coverage():
             if '__main__' in text:
                 if example not in cpu_tests:
                     pytest.fail('Example: {} not covered in CPU_TESTS.'.format(example))
-                if 'cuda' in text and example not in cuda_tests:
+                if '--cuda' in text and example not in cuda_tests:
                     pytest.fail('Example: {} not covered by CUDA_TESTS.'.format(example))
 
 


### PR DESCRIPTION
From our discussion #1019, I thought it might be a good time to refactor `test_examples.py`. It seems that an explicit enumeration is likely to be the most flexible (we can constrain the example as much as we like), and opaque way for us to test examples. 

Also added a coverage test so that we do not miss out on adding examples to `test_examples`. In the process, I realized that we were not testing the `gp` example and cuda versions of `ss-vae`, which is added.