### PR TITLE
Simplify ADVI interface (part 2)

### DIFF
--- a/docs/source/contrib.autoguide.rst
+++ b/docs/source/contrib.autoguide.rst
@@ -4,6 +4,7 @@ Automatic Guide Generation
 .. automodule:: pyro.contrib.autoguide.advi
     :members:
     :undoc-members:
+    :special-members: __call__
     :show-inheritance:
     :member-order: bysource
 

--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from pyro.contrib.autoguide.advi import ADVIDiagonalNormal, ADVIDiscreteParallel, ADVIMaster, ADVIMultivariateNormal
+from pyro.contrib.autoguide.advi import AutoDiagonalNormal, AutoDiscreteParallel, AutoGuideList, AutoMultivariateNormal
 
 # flake8: noqa

--- a/pyro/contrib/autoguide/advi.py
+++ b/pyro/contrib/autoguide/advi.py
@@ -28,23 +28,59 @@ def _product(shape):
     return result
 
 
-class ADVIMaster(object):
+class AutoGuide(object):
     """
-    Container class to combine multiple ADVI strategies.
+    Base class for automatic guides.
+
+    Derived classes must implement the :meth:`__call__` method.
+
+    Auto guides can be used individually or combined in an
+    :class:`AutoGuideList` object.
+    """
+    def __init__(self, model):
+        self.master = None
+        self.model = model
+        self.prototype_trace = None
+
+    def __call__(self, *args, **kwargs):
+        """
+        A guide with the same ``*args, **kwargs`` as the base ``model``.
+
+        :return: A dict mapping sample site name to sampled value.
+        :rtype: dict
+        """
+        raise NotImplementedError
+
+    def sample_latent(*args, **kwargs):
+        """
+        Samples an encoded latent given the same ``*args, **kwargs`` as the
+        base ``model``.
+        """
+        pass
+
+    def _create_iaranges(self):
+        if self.master is not None:
+            return self.master().iaranges
+        return {frame.name: pyro.iarange(frame.name, frame.size, dim=frame.dim)
+                for frame in sorted(self._iaranges.values())}
+
+
+class AutoGuideList(AutoGuide):
+    """
+    Container class to combine multiple automatic guides.
 
     Example usage::
 
-        advi = ADVIMaster(my_model)
-        advi.add(ADVIDiagonalNormal(poutine.block(model, hide=["assignment"])))
-        advi.add(ADVIDiscreteParallel(poutine.block(model, expose=["assignment"])))
-        svi = SVI(advi.model, advi.guide, optim, 'ELBO')
+        guide = AutoGuideList(my_model)
+        guide.add(AutoDiagonalNormal(poutine.block(model, hide=["assignment"])))
+        guide.add(AutoDiscreteParallel(poutine.block(model, expose=["assignment"])))
+        svi = SVI(model, guide, optim, 'ELBO')
 
     :param callable model: a Pyro model
     """
     def __init__(self, model):
+        super(AutoGuideList, self).__init__(model)
         self.parts = []
-        self.model = model
-        self.prototype_trace = None
         self._iaranges = {}
         self.iaranges = {}
 
@@ -59,18 +95,18 @@ class ADVIMaster(object):
 
     def add(self, part):
         """
-        Add an ADVI strategy for part of the model. The ADVI strategy should
+        Add an automatic guide for part of the model. The guide should
         have been created by blocking the model to restrict to a subset of
         sample sites. No two parts should operate on any one sample site.
 
-        :param ADVISlave part: an ADVI strategy to add
+        :param AutoGuide part: a partial guide to add
         """
-        assert isinstance(part, ADVISlave), type(part)
+        assert isinstance(part, AutoGuide), type(part)
         self.parts.append(part)
         assert part.master is None
         part.master = weakref.ref(self)
 
-    def guide(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         """
         A composite guide with the same ``*args, **kwargs`` as the base ``model``.
 
@@ -88,7 +124,7 @@ class ADVIMaster(object):
         # run slave guides
         result = {}
         for part in self.parts:
-            result.update(part.guide(*args, **kwargs))
+            result.update(part(*args, **kwargs))
         return result
 
     def _setup_prototype(self, *args, **kwargs):
@@ -104,36 +140,10 @@ class ADVIMaster(object):
                 if frame.vectorized:
                     self._iaranges[frame.name] = frame
                 else:
-                    raise NotImplementedError("ADVI does not support pyro.irange")
+                    raise NotImplementedError("AutoGuideList does not support pyro.irange")
 
 
-class ADVISlave(object):
-    """
-    Base class for ADVI strategies.
-
-    ADVI strategies can be used individually or combined in an
-    :class:`ADVIMaster` object.
-    """
-    def __init__(self, model):
-        self.master = None
-        self.model = model
-        self.prototype_trace = None
-
-    def sample_latent(*args, **kwargs):
-        """
-        Samples an encoded latent given the same ``*args, **kwargs`` as the
-        base ``model``.
-        """
-        pass
-
-    def _create_iaranges(self):
-        if self.master is not None:
-            return self.master().iaranges
-        return {frame.name: pyro.iarange(frame.name, frame.size, dim=frame.dim)
-                for frame in sorted(self._iaranges.values())}
-
-
-class ADVIContinuous(ADVISlave):
+class AutoContinuous(AutoGuide):
     """
     Base class for implementations of continuous-valued Automatic
     Differentiation Variational Inference [1].
@@ -151,9 +161,6 @@ class ADVIContinuous(ADVISlave):
         Alp Kucukelbir, Dustin Tran, Rajesh Ranganath, Andrew Gelman, David M.
         Blei
     """
-    def __init__(self, model):
-        super(ADVIContinuous, self).__init__(model)
-
     def _setup_prototype(self, *args, **kwargs):
         # run the model so we can inspect its structure
         self.prototype_trace = poutine.block(poutine.trace(self.model).get_trace)(*args, **kwargs)
@@ -177,7 +184,7 @@ class ADVIContinuous(ADVISlave):
                 if frame.vectorized:
                     self._iaranges[frame.name] = frame
                 else:
-                    raise NotImplementedError("ADVIContinuous does not support pyro.irange")
+                    raise NotImplementedError("AutoContinuous does not support pyro.irange")
 
         self.latent_dim = sum(_product(shape) for shape in self._unconstrained_shapes.values())
 
@@ -204,7 +211,7 @@ class ADVIContinuous(ADVISlave):
                 pos += size
         assert pos == len(latent)
 
-    def guide(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         """
         An automatic guide with the same ``*args, **kwargs`` as the base ``model``.
 
@@ -236,16 +243,17 @@ class ADVIContinuous(ADVISlave):
         return result
 
 
-class ADVIMultivariateNormal(ADVIContinuous):
+class AutoMultivariateNormal(AutoContinuous):
     """
-    This implementation of ADVI uses a Cholesky factorization of a Multivariate
-    Normal distribution to construct a guide over the entire latent space. The
-    guide does not depend on the model's ``*args, **kwargs``.
+    This implementation of :class:`AutoContinuous` uses a Cholesky
+    factorization of a Multivariate Normal distribution to construct a guide
+    over the entire latent space. The guide does not depend on the model's
+    ``*args, **kwargs``.
 
     Usage::
 
-        advi = ADVIMultivariateNormal(model)
-        svi = SVI(advi.model, advi.guide, ...)
+        guide = AutoMultivariateNormal(model)
+        svi = SVI(model, guide, ...)
 
     By default the mean vector is initialized to zero and the Cholesky factor
     is initialized to the identity.  To change this default behavior the user
@@ -258,7 +266,7 @@ class ADVIMultivariateNormal(ADVIContinuous):
     """
     def sample_latent(self, *args, **kwargs):
         """
-        Samples the (single) multivariate normal latent used in the advi guide.
+        Samples the (single) multivariate normal latent used in the auto guide.
         """
         loc = pyro.param("advi_loc", torch.zeros(self.latent_dim))
         scale_tril = pyro.param("advi_scale_tril", torch.eye(self.latent_dim),
@@ -281,7 +289,7 @@ class ADVIMultivariateNormal(ADVIContinuous):
         """
         Returns posterior quantiles each latent variable. Example::
 
-            print(advi.quantiles([0.05, 0.5, 0.95]))
+            print(guide.quantiles([0.05, 0.5, 0.95]))
 
         :param quantiles: A list of requested quantiles between 0 and 1.
         :type quantiles: torch.Tensor or list
@@ -300,16 +308,16 @@ class ADVIMultivariateNormal(ADVIContinuous):
         return result
 
 
-class ADVIDiagonalNormal(ADVIContinuous):
+class AutoDiagonalNormal(AutoContinuous):
     """
-    This implementation of ADVI uses a Normal distribution with a diagonal
-    covariance matrix to construct a guide over the entire latent space. The
-    guide does not depend on the model's ``*args, **kwargs``.
+    This implementation of :class:`AutoContinuous` uses a Normal distribution
+    with a diagonal covariance matrix to construct a guide over the entire
+    latent space. The guide does not depend on the model's ``*args, **kwargs``.
 
     Usage::
 
-        advi = ADVIDiagonalNormal(model)
-        svi = SVI(advi.model, advi.guide, ...)
+        guide = AutoDiagonalNormal(model)
+        svi = SVI(model, guide, ...)
 
     By default the mean vector is initialized to zero and the scale is
     initialized to the identity.  To change this default behavior the user
@@ -322,7 +330,7 @@ class ADVIDiagonalNormal(ADVIContinuous):
     """
     def sample_latent(self, *args, **kwargs):
         """
-        Samples the (single) diagnoal normal latent used in the advi guide.
+        Samples the (single) diagnoal normal latent used in the auto guide.
         """
         loc = pyro.param("advi_loc", torch.zeros(self.latent_dim))
         scale = pyro.param("advi_scale", torch.ones(self.latent_dim),
@@ -345,7 +353,7 @@ class ADVIDiagonalNormal(ADVIContinuous):
         """
         Returns posterior quantiles each latent variable. Example::
 
-            print(advi.quantiles([0.05, 0.5, 0.95]))
+            print(guide.quantiles([0.05, 0.5, 0.95]))
 
         :param quantiles: A list of requested quantiles between 0 and 1.
         :type quantiles: torch.Tensor or list
@@ -364,10 +372,11 @@ class ADVIDiagonalNormal(ADVIContinuous):
         return result
 
 
-class ADVIDiscreteParallel(ADVISlave):
-    def __init__(self, model):
-        super(ADVIDiscreteParallel, self).__init__(model)
-
+class AutoDiscreteParallel(AutoGuide):
+    """
+    A discrete mean-field guide that learns a latent discrete distribution for
+    each discrete site in the model.
+    """
     def _setup_prototype(self, *args, **kwargs):
         # run the model so we can inspect its structure
         model = config_enumerate(self.model, default="parallel")
@@ -401,9 +410,9 @@ class ADVIDiscreteParallel(ADVISlave):
                 if frame.vectorized:
                     self._iaranges[frame.name] = frame
                 else:
-                    raise NotImplementedError("ADVI does not support pyro.irange")
+                    raise NotImplementedError("AutoDiscreteParallel does not support pyro.irange")
 
-    def guide(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         """
         An automatic guide with the same ``*args, **kwargs`` as the base ``model``.
 

--- a/tests/contrib/autoguide/test_inference.py
+++ b/tests/contrib/autoguide/test_inference.py
@@ -10,7 +10,7 @@ from torch.distributions import biject_to, constraints
 import pyro
 import pyro.distributions as dist
 import pyro.optim as optim
-from pyro.contrib.autoguide import ADVIDiagonalNormal, ADVIMultivariateNormal
+from pyro.contrib.autoguide import AutoDiagonalNormal, AutoMultivariateNormal
 from pyro.infer import SVI, Trace_ELBO
 from tests.common import assert_equal
 from tests.integration_tests.test_conjugate_gaussian_models import GaussianChain
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.stage("integration", "integration_batch_2")
 
 
-# conjugate model to test ADVI logic from end-to-end (this has a non-mean-field posterior)
-class ADVIGaussianChain(GaussianChain):
+# conjugate model to test AutoGuide logic from end-to-end (this has a non-mean-field posterior)
+class AutoGaussianChain(GaussianChain):
 
     # this is gross but we need to convert between different posterior factorizations
     def compute_target(self, N):
@@ -38,91 +38,91 @@ class ADVIGaussianChain(GaussianChain):
         self.do_test_advi(3, reparameterized=True, n_steps=10001)
 
     def do_test_advi(self, N, reparameterized, n_steps):
-        logger.debug("\nGoing to do ADVIGaussianChain test...")
+        logger.debug("\nGoing to do AutoGaussianChain test...")
         pyro.clear_param_store()
         self.setUp()
         self.setup_chain(N)
         self.compute_target(N)
-        self.advi = ADVIMultivariateNormal(self.model)
+        self.guide = AutoMultivariateNormal(self.model)
         logger.debug("target advi_loc: {}".format(self.target_advi_mus[1:].detach().numpy()))
         logger.debug("target advi_diag_cov: {}".format(self.target_advi_diag_cov[1:].detach().numpy()))
 
         # TODO speed up with parallel num_particles > 1
         adam = optim.Adam({"lr": .0005, "betas": (0.95, 0.999)})
-        svi = SVI(self.advi.model, self.advi.guide, adam, loss=Trace_ELBO())
+        svi = SVI(self.model, self.guide, adam, loss=Trace_ELBO())
 
         for k in range(n_steps):
             loss = svi.step(reparameterized)
             assert np.isfinite(loss), loss
 
             if k % 1000 == 0 and k > 0 or k == n_steps - 1:
-                logger.debug("[step {}] advi mean parameter: {}".format(k, pyro.param("advi_loc").detach().numpy()))
+                logger.debug("[step {}] guide mean parameter: {}".format(k, pyro.param("advi_loc").detach().numpy()))
                 L = pyro.param("advi_scale_tril")
                 diag_cov = torch.mm(L, L.t()).diag()
                 logger.debug("[step {}] advi_diag_cov: {}".format(k, diag_cov.detach().numpy()))
 
         assert_equal(pyro.param("advi_loc"), self.target_advi_mus[1:], prec=0.05,
-                     msg="advi mean off")
+                     msg="guide mean off")
         assert_equal(diag_cov, self.target_advi_diag_cov[1:], prec=0.07,
-                     msg="advi covariance off")
+                     msg="guide covariance off")
 
 
-@pytest.mark.parametrize('advi_class', [ADVIDiagonalNormal, ADVIMultivariateNormal])
+@pytest.mark.parametrize('advi_class', [AutoDiagonalNormal, AutoMultivariateNormal])
 def test_advi_diagonal_gaussians(advi_class):
-    n_steps = 3501 if advi_class == ADVIDiagonalNormal else 6001
+    n_steps = 3501 if advi_class == AutoDiagonalNormal else 6001
 
     def model():
         pyro.sample("x", dist.Normal(-0.2, 1.2))
         pyro.sample("y", dist.Normal(0.2, 0.7))
 
-    advi = advi_class(model)
+    guide = advi_class(model)
     adam = optim.Adam({"lr": .001, "betas": (0.95, 0.999)})
-    svi = SVI(advi.model, advi.guide, adam, loss=Trace_ELBO())
+    svi = SVI(model, guide, adam, loss=Trace_ELBO())
 
     for k in range(n_steps):
         loss = svi.step()
         assert np.isfinite(loss), loss
 
-    if advi_class == ADVIMultivariateNormal:
+    if advi_class == AutoMultivariateNormal:
         L = pyro.param("advi_scale_tril")
         diag_cov = torch.mm(L, L.t()).diag()
     else:
         diag_cov = torch.pow(pyro.param("advi_scale"), 2.0)
 
     assert_equal(pyro.param("advi_loc"), torch.tensor([-0.2, 0.2]), prec=0.05,
-                 msg="advi mean off")
+                 msg="guide mean off")
     assert_equal(diag_cov, torch.tensor([1.44, 0.49]), prec=0.08,
-                 msg="advi covariance off")
+                 msg="guide covariance off")
 
 
-@pytest.mark.parametrize('advi_class', [ADVIDiagonalNormal, ADVIMultivariateNormal])
+@pytest.mark.parametrize('advi_class', [AutoDiagonalNormal, AutoMultivariateNormal])
 def test_advi_transform(advi_class):
     n_steps = 3500
 
     def model():
         pyro.sample("x", dist.LogNormal(0.2, 0.7))
 
-    advi = advi_class(model)
+    guide = advi_class(model)
     adam = optim.Adam({"lr": .001, "betas": (0.90, 0.999)})
-    svi = SVI(advi.model, advi.guide, adam, loss=Trace_ELBO())
+    svi = SVI(model, guide, adam, loss=Trace_ELBO())
 
     for k in range(n_steps):
         loss = svi.step()
         assert np.isfinite(loss), loss
 
-    if advi_class == ADVIMultivariateNormal:
+    if advi_class == AutoMultivariateNormal:
         L = pyro.param("advi_scale_tril")
         diag_cov = torch.mm(L, L.t()).diag()
     else:
         diag_cov = torch.pow(pyro.param("advi_scale"), 2.0)
 
     assert_equal(pyro.param("advi_loc"), torch.tensor([0.2]), prec=0.04,
-                 msg="advi mean off")
+                 msg="guide mean off")
     assert_equal(diag_cov, torch.tensor([0.49]), prec=0.04,
-                 msg="advi covariance off")
+                 msg="guide covariance off")
 
 
-@pytest.mark.parametrize('advi_class', [ADVIDiagonalNormal, ADVIMultivariateNormal])
+@pytest.mark.parametrize('advi_class', [AutoDiagonalNormal, AutoMultivariateNormal])
 def test_advi_dirichlet(advi_class):
     num_steps = 2000
     prior = torch.tensor([0.5, 1.0, 1.5, 3.0])
@@ -134,8 +134,8 @@ def test_advi_dirichlet(advi_class):
         with pyro.iarange("data_iarange"):
             pyro.sample("data", dist.Categorical(p).expand_by(data.shape), obs=data)
 
-    advi = advi_class(model)
-    svi = SVI(advi.model, advi.guide, optim.Adam({"lr": .003}), loss="ELBO")
+    guide = advi_class(model)
+    svi = SVI(model, guide, optim.Adam({"lr": .003}), loss="ELBO")
 
     for _ in range(num_steps):
         loss = svi.step(data)

--- a/tests/contrib/autoguide/test_inference.py
+++ b/tests/contrib/autoguide/test_inference.py
@@ -135,7 +135,7 @@ def test_advi_dirichlet(advi_class):
             pyro.sample("data", dist.Categorical(p).expand_by(data.shape), obs=data)
 
     guide = advi_class(model)
-    svi = SVI(model, guide, optim.Adam({"lr": .003}), loss="ELBO")
+    svi = SVI(model, guide, optim.Adam({"lr": .003}), loss=Trace_ELBO())
 
     for _ in range(num_steps):
         loss = svi.step(data)


### PR DESCRIPTION
This is step 2 in refactoring our ADVI interface before 0.2 release (after #1027), as suggested by @eb8680.

After this PR we can simply

```py
def model():
    ...

guide = AutoMultivariateNormal(model)
svi = SVI(model, guide, Adam({}), Trace_ELBO())
```