### PR TITLE
Add circular von Mises distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -74,6 +74,13 @@ SparseMultivariateNormal
     :undoc-members:
     :show-inheritance:
 
+VonMises
+--------
+.. automodule:: pyro.distributions.von_mises
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Transformed Distributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -1,17 +1,18 @@
 from __future__ import absolute_import, division, print_function
 
 from pyro.distributions.delta import Delta
-from pyro.distributions.empirical import Empirical
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.empirical import Empirical
 from pyro.distributions.half_cauchy import HalfCauchy
 from pyro.distributions.iaf import InverseAutoregressiveFlow
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
 from pyro.distributions.rejector import Rejector
 from pyro.distributions.sparse_mvn import SparseMultivariateNormal
-from pyro.distributions.torch import *  # noqa F403
 from pyro.distributions.torch import __all__ as torch_dists
+from pyro.distributions.torch import *  # noqa F403
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.util import enable_validation, is_validation_enabled, validation_enabled
+from pyro.distributions.von_mises import VonMises
 
 __all__ = [
     "enable_validation",
@@ -26,6 +27,7 @@ __all__ = [
     "Rejector",
     "SparseMultivariateNormal",
     "TorchDistribution",
+    "VonMises",
 ]
 
 # Import all torch distributions from `pyro.distributions.torch_distribution`

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -1,0 +1,65 @@
+from __future__ import absolute_import, division, print_function
+
+import math
+
+import torch
+from torch.distributions import constraints
+from torch.distributions.utils import broadcast_all
+
+from pyro.distributions import TorchDistribution
+
+
+def _eval_poly(y, coef):
+    coef = list(coef)
+    result = coef.pop()
+    while coef:
+        result = coef.pop() + y * result
+    return result
+
+
+_COEF_SMALL = [1.0, 3.5156229, 3.0899424, 1.2067492, 0.2659732, 0.360768e-1, 0.45813e-2]
+_COEF_LARGE = [0.39894228, 0.1328592e-1, 0.225319e-2, -0.157565e-2, 0.916281e-2,
+               -0.2057706e-1, 0.2635537e-1, -0.1647633e-1,  0.392377e-2]
+
+
+def _log_modified_bessel_fn_0(x):
+    """
+    Returns ``log(I0(x))`` for ``x > 0``.
+    """
+    # compute small solution
+    y = (x / 3.75).pow(2)
+    small = _eval_poly(y, _COEF_SMALL).log()
+
+    # compute large solution
+    y = 3.75 / x
+    large = x - 0.5 * x.log() + _eval_poly(y, _COEF_LARGE).log()
+
+    mask = (x < 3.75)
+    result = large
+    if mask.any():
+        result[mask] = small[mask]
+    return result
+
+
+class VonMises(TorchDistribution):
+    """
+    A circular von Mises distribution.
+
+    Currently only :meth:`log_prob` is implemented.
+
+    :param torch.Tensor loc: an angle in radians.
+    :param torch.Tensor concentration: concentration parameter
+    """
+    arg_constraints = {'loc': constraints.real, 'concentration': constraints.positive}
+    support = constraints.real
+
+    def __init__(self, loc, concentration, validate_args=None):
+        self.loc, self.concentration = broadcast_all(loc, concentration)
+        batch_shape = self.loc.shape
+        event_shape = torch.Size()
+        super(VonMises, self).__init__(batch_shape, event_shape, validate_args)
+
+    def log_prob(self, value):
+        log_prob = self.concentration * torch.cos(value - self.loc)
+        log_prob = log_prob - math.log(2 * math.pi) - _log_modified_bessel_fn_0(self.concentration)
+        return log_prob

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -215,6 +215,17 @@ continuous_dists = [
                  'test_data': [[0.54], [0.35]]}
             ],
             scipy_arg_fn=lambda loc, scale: ((), {"loc": np.array(loc), "scale": np.array(scale)})),
+    Fixture(pyro_dist=dist.VonMises,
+            scipy_dist=sp.vonmises,
+            examples=[
+                {'loc': [0.5], 'concentration': [1.2],
+                 'test_data': [1.0]},
+                {'loc': [0.5, 3.0], 'concentration': [2.0, 0.5],
+                 'test_data': [[1.0, 2.0], [1.0, 2.0]]},
+                {'loc': [[0.5], [0.3]], 'concentration': [[2.0], [0.5]],
+                 'test_data': [[1.0], [2.0]]}
+            ],
+            scipy_arg_fn=lambda loc, concentration: ((), {"loc": np.array(loc), "kappa": np.array(concentration)})),
 ]
 
 discrete_dists = [

--- a/tests/distributions/test_von_mises.py
+++ b/tests/distributions/test_von_mises.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import, division, print_function
+
+import math
+
+import pytest
+import torch
+
+from pyro.distributions import VonMises
+
+
+@pytest.mark.parametrize('concentration', [0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0, 100.0])
+def test_log_prob_normalized(concentration):
+    grid = torch.linspace(0, 2 * math.pi, steps=50000)
+    prob = VonMises(0.0, concentration).log_prob(grid).exp()
+    norm = prob.mean().item() * 2 * math.pi
+    assert abs(norm - 1) < 1e-3, norm


### PR DESCRIPTION
This is useful for observation of circular data.

 This PR implements only `.log_prob()`. Even without `.sample()` this is a useful distribution to have.

## Tested

- added to existing tests against scipy version
- added a test of normalization