### PR TITLE
torch.nograd() for evaluate_loss

### DIFF
--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import torch
+
 import pyro
 from pyro.infer.elbo import ELBO
 

--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -61,7 +61,7 @@ class SVI(object):
 
         Evaluate the loss function. Any args or kwargs are passed to the model and guide.
         """
-        with torch.nograd():
+        with torch.no_grad():
             return self.loss(self.model, self.guide, *args, **kwargs)
 
     def step(self, *args, **kwargs):

--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -61,7 +61,8 @@ class SVI(object):
 
         Evaluate the loss function. Any args or kwargs are passed to the model and guide.
         """
-        return self.loss(self.model, self.guide, *args, **kwargs)
+        with torch.nograd():
+            return self.loss(self.model, self.guide, *args, **kwargs)
 
     def step(self, *args, **kwargs):
         """

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -108,7 +108,7 @@ def gmm_model(data, verbose=False):
         z = pyro.sample("z_{}".format(i), dist.Bernoulli(p))
         z = z.long()
         if verbose:
-            logger.debug("M{} z_{} = {}".format("  " * i, i, z.numpy()))
+            logger.debug("M{} z_{} = {}".format("  " * i, i, z.cpu().numpy()))
         pyro.sample("x_{}".format(i), dist.Normal(mus[z], scale), obs=data[i])
 
 
@@ -118,7 +118,7 @@ def gmm_guide(data, verbose=False):
         z = pyro.sample("z_{}".format(i), dist.Bernoulli(p))
         z = z.long()
         if verbose:
-            logger.debug("G{} z_{} = {}".format("  " * i, i, z.numpy()))
+            logger.debug("G{} z_{} = {}".format("  " * i, i, z.cpu().numpy()))
 
 
 @pytest.mark.parametrize("data_size", [1, 2, 3])
@@ -398,7 +398,7 @@ def test_elbo_irange(irange_dim, enumerate1, enumerate2):
 @pytest.mark.parametrize("outer_dim", [2])
 def test_elbo_iarange_iarange(outer_dim, inner_dim, enumerate1, enumerate2, enumerate3, enumerate4):
     pyro.clear_param_store()
-    num_particles = 1 if all([enumerate1, enumerate2, enumerate3, enumerate4]) else 50000
+    num_particles = 1 if all([enumerate1, enumerate2, enumerate3, enumerate4]) else 100000
     q = pyro.param("q", torch.tensor(0.75, requires_grad=True))
     p = 0.2693204236205713  # for which kl(Bernoulli(q), Bernoulli(p)) = 0.5
 
@@ -454,7 +454,7 @@ def test_elbo_iarange_iarange(outer_dim, inner_dim, enumerate1, enumerate2, enum
 @pytest.mark.parametrize("outer_dim", [3])
 def test_elbo_iarange_irange(outer_dim, inner_dim, enumerate1, enumerate2, enumerate3):
     pyro.clear_param_store()
-    num_particles = 1 if all([enumerate1, enumerate2, enumerate3]) else 50000
+    num_particles = 1 if all([enumerate1, enumerate2, enumerate3]) else 100000
     q = pyro.param("q", torch.tensor(0.75, requires_grad=True))
     p = 0.2693204236205713  # for which kl(Bernoulli(q), Bernoulli(p)) = 0.5
 
@@ -750,8 +750,8 @@ def test_non_mean_field_normal_bern_elbo_gradient(pi1, pi2, pi3):
 @pytest.mark.parametrize("enumerate1", [None, "sequential", "parallel"])
 def test_elbo_rsvi(enumerate1):
     pyro.clear_param_store()
-    num_particles = 10000
-    prec = 0.003 if enumerate1 else 0.01
+    num_particles = 20000
+    prec = 0.01 if enumerate1 else 0.02
     q = pyro.param("q", torch.tensor(0.5, requires_grad=True))
     a = pyro.param("a", torch.tensor(1.5, requires_grad=True))
     kl1 = kl_divergence(dist.Bernoulli(q), dist.Bernoulli(0.25))
@@ -836,7 +836,7 @@ def test_elbo_hmm_in_model(enumerate1, num_steps):
         actual = value.grad
         expected = expected_unconstrained_grads[name]
         assert_equal(actual, expected, msg=''.join([
-            '\nexpected {}.grad = {}'.format(name, expected.numpy()),
+            '\nexpected {}.grad = {}'.format(name, expected.cpu().numpy()),
             '\n  actual {}.grad = {}'.format(name, actual.detach().cpu().numpy()),
         ]))
 
@@ -906,6 +906,6 @@ def test_elbo_hmm_in_guide(enumerate1, num_steps):
         actual = value.grad
         expected = torch.tensor(expected_grads[num_steps][name])
         assert_equal(actual, expected, msg=''.join([
-            '\nexpected {}.grad = {}'.format(name, expected.numpy()),
+            '\nexpected {}.grad = {}'.format(name, expected.cpu().numpy()),
             '\n  actual {}.grad = {}'.format(name, actual.detach().cpu().numpy()),
         ]))

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -750,7 +750,7 @@ def test_non_mean_field_normal_bern_elbo_gradient(pi1, pi2, pi3):
 @pytest.mark.parametrize("enumerate1", [None, "sequential", "parallel"])
 def test_elbo_rsvi(enumerate1):
     pyro.clear_param_store()
-    num_particles = 20000
+    num_particles = 40000
     prec = 0.01 if enumerate1 else 0.02
     q = pyro.param("q", torch.tensor(0.5, requires_grad=True))
     a = pyro.param("a", torch.tensor(1.5, requires_grad=True))


### PR DESCRIPTION
there used to be 'volatile' but no more...

(i meant to do this a long time ago but kept forgetting... was reminded when i ran into memory blow-ups during evaluation)