### PR TITLE
Testing for CUDA compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ test-all: lint FORCE
 	  | xargs pytest -vx --nbval-lax
 
 test-cuda: lint FORCE
-	PYRO_TENSOR_TYPE=torch.cuda.DoubleTensor pytest -vx -n 8 --stage unit
+	CUDA_TEST=1 PYRO_TENSOR_TYPE=torch.cuda.DoubleTensor pytest -vx -n 8 --stage unit
+	CUDA_TEST=1 pytest -vx -n 8 tests/test_examples.py::test_cuda
 
 clean: FORCE
 	git clean -dfx -e pyro-egg.info

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ test-all: lint FORCE
 	  | xargs pytest -vx --nbval-lax
 
 test-cuda: lint FORCE
-	CUDA_TEST=1 PYRO_TENSOR_TYPE=torch.cuda.DoubleTensor pytest -vx -n 8 --stage unit
-	CUDA_TEST=1 pytest -vx -n 8 tests/test_examples.py::test_cuda
+	CUDA_TEST=1 PYRO_TENSOR_TYPE=torch.cuda.DoubleTensor pytest -vx -n 4 --stage unit
+	CUDA_TEST=1 pytest -vx -n 4 tests/test_examples.py::test_cuda
 
 clean: FORCE
 	git clean -dfx -e pyro-egg.info

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -208,7 +208,7 @@ class NUTS(HMC):
         #     `A Conceptual Introduction to Hamiltonian Monte Carlo` by Michael Betancourt.
         joint_prob = torch.exp(-energy_current)
         if joint_prob == 0:
-            slice_var = torch.tensor(0.0)
+            slice_var = energy_current.new_tensor(0.0)
         else:
             slice_var = pyro.sample("slicevar_t={}".format(self._t),
                                     dist.Uniform(torch.zeros(1), joint_prob))

--- a/pyro/nn/auto_reg_nn.py
+++ b/pyro/nn/auto_reg_nn.py
@@ -73,7 +73,7 @@ class AutoRegressiveNN(nn.Module):
 
         if permutation is None:
             # a permutation is chosen at random
-            self.permutation = torch.randperm(input_dim)
+            self.permutation = torch.randperm(input_dim, device=torch.device('cpu'))
         else:
             # the permutation is chosen by the user
             self.permutation = permutation

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -127,7 +127,8 @@ class _Subsample(Distribution):
         if subsample_size == self.size:
             result = torch.LongTensor(list(range(self.size)))
         else:
-            result = torch.randperm(self.size)[:self.subsample_size]
+            # torch.randperm does not have a CUDA implementation
+            result = torch.randperm(self.size, device=torch.device('cpu'))[:self.subsample_size]
         return result.cuda() if self.use_cuda else result
 
     def log_prob(self, x):

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -162,12 +162,9 @@ def set_rng_seed(rng_seed):
     :param int rng_seed: The seed value.
     """
     torch.manual_seed(rng_seed)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed(rng_seed)
     random.seed(rng_seed)
     try:
         import numpy as np
-
         np.random.seed(rng_seed)
     except ImportError:
         pass

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -162,6 +162,8 @@ def set_rng_seed(rng_seed):
     :param int rng_seed: The seed value.
     """
     torch.manual_seed(rng_seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(rng_seed)
     random.seed(rng_seed)
     try:
         import numpy as np

--- a/tests/contrib/autoguide/test_inference.py
+++ b/tests/contrib/autoguide/test_inference.py
@@ -44,8 +44,10 @@ class AutoGaussianChain(GaussianChain):
         self.setup_chain(N)
         self.compute_target(N)
         self.guide = AutoMultivariateNormal(self.model)
-        logger.debug("target advi_loc: {}".format(self.target_advi_mus[1:].detach().numpy()))
-        logger.debug("target advi_diag_cov: {}".format(self.target_advi_diag_cov[1:].detach().numpy()))
+        logger.debug("target advi_loc: {}"
+                     .format(self.target_advi_mus[1:].detach().cpu().numpy()))
+        logger.debug("target advi_diag_cov: {}"
+                     .format(self.target_advi_diag_cov[1:].detach().cpu().numpy()))
 
         # TODO speed up with parallel num_particles > 1
         adam = optim.Adam({"lr": .0005, "betas": (0.95, 0.999)})
@@ -56,10 +58,12 @@ class AutoGaussianChain(GaussianChain):
             assert np.isfinite(loss), loss
 
             if k % 1000 == 0 and k > 0 or k == n_steps - 1:
-                logger.debug("[step {}] guide mean parameter: {}".format(k, pyro.param("advi_loc").detach().numpy()))
+                logger.debug("[step {}] guide mean parameter: {}"
+                             .format(k, pyro.param("advi_loc").detach().cpu().numpy()))
                 L = pyro.param("advi_scale_tril")
                 diag_cov = torch.mm(L, L.t()).diag()
-                logger.debug("[step {}] advi_diag_cov: {}".format(k, diag_cov.detach().numpy()))
+                logger.debug("[step {}] advi_diag_cov: {}"
+                             .format(k, diag_cov.detach().cpu().numpy()))
 
         assert_equal(pyro.param("advi_loc"), self.target_advi_mus[1:], prec=0.05,
                      msg="guide mean off")

--- a/tests/distributions/test_omt_mvn.py
+++ b/tests/distributions/test_omt_mvn.py
@@ -35,7 +35,7 @@ def test_mean_gradient(sample_shape, L21, omega1, L11, L22=0.8, L33=0.9, omega2=
     z = dist.rsample(sample_shape)
     torch.cos((omega*z).sum(-1)).mean().backward()
 
-    computed_grad = off_diag.grad.data.numpy()[1, 0]
+    computed_grad = off_diag.grad.data.cpu().numpy()[1, 0]
     analytic = analytic_grad(L11=L11, L22=L22, L21=L21, omega1=omega1, omega2=omega2)
     assert(off_diag.grad.size() == off_diag.size())
     assert(loc.grad.size() == loc.size())

--- a/tests/distributions/test_rejector.py
+++ b/tests/distributions/test_rejector.py
@@ -153,5 +153,5 @@ def test_shape_augmented_beta(alpha, beta):
     mean_beta_grad = betas.grad.mean().item()
     expected_alpha_grad = beta / (alpha + beta) ** 2
     expected_beta_grad = -alpha / (alpha + beta) ** 2
-    assert_equal(mean_alpha_grad, expected_alpha_grad, prec=0.01, msg='bad grad for alpha')
-    assert_equal(mean_beta_grad, expected_beta_grad, prec=0.01, msg='bad grad for beta')
+    assert_equal(mean_alpha_grad, expected_alpha_grad, prec=0.02, msg='bad grad for alpha')
+    assert_equal(mean_beta_grad, expected_beta_grad, prec=0.02, msg='bad grad for beta')

--- a/tests/distributions/test_von_mises.py
+++ b/tests/distributions/test_von_mises.py
@@ -10,7 +10,7 @@ from pyro.distributions import VonMises
 
 @pytest.mark.parametrize('concentration', [0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0, 100.0])
 def test_log_prob_normalized(concentration):
-    grid = torch.linspace(0, 2 * math.pi, steps=50000)
+    grid = torch.arange(0, 2 * math.pi, 1e-4)
     prob = VonMises(0.0, concentration).log_prob(grid).exp()
     norm = prob.mean().item() * 2 * math.pi
     assert abs(norm - 1) < 1e-3, norm

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -195,7 +195,7 @@ def test_bernoulli_beta():
     for trace, _ in mcmc_run._traces(data):
         posterior.append(trace.nodes['p_latent']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean, true_probs, prec=0.01)
+    assert_equal(posterior_mean, true_probs, prec=0.05)
 
 
 def test_normal_gamma():
@@ -214,7 +214,7 @@ def test_normal_gamma():
     for trace, _ in mcmc_run._traces(data):
         posterior.append(trace.nodes['p_latent']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean, true_std, prec=0.02)
+    assert_equal(posterior_mean, true_std, prec=0.05)
 
 
 @pytest.mark.xfail(reason='log_abs_det_jacobian not implemented for StickBreakingTransform')
@@ -273,7 +273,7 @@ def test_bernoulli_beta_with_dual_averaging():
     for trace, _ in mcmc_run._traces(data):
         posterior.append(trace.nodes['p_latent']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean, true_probs, prec=0.01)
+    assert_equal(posterior_mean, true_probs, prec=0.05)
 
 
 @pytest.mark.filterwarnings("ignore:Encountered NAN")
@@ -293,4 +293,4 @@ def test_normal_gamma_with_dual_averaging():
     for trace, _ in mcmc_run._traces(data):
         posterior.append(trace.nodes['p_latent']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean, true_std, prec=0.02)
+    assert_equal(posterior_mean, true_std, prec=0.05)

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -61,13 +61,13 @@ TEST_CASES = [
     T(
         GaussianChain(dim=10, chain_len=3, num_obs=1),
         num_samples=800,
-        warmup_steps=50,
+        warmup_steps=200,
         hmc_params={'step_size': 0.5,
                     'num_steps': 4},
         expected_means=[0.25, 0.50, 0.75],
         expected_precs=[1.33, 1, 1.33],
         mean_tol=0.06,
-        std_tol=0.06,
+        std_tol=0.08,
     ),
     T(
         GaussianChain(dim=10, chain_len=4, num_obs=1),
@@ -176,7 +176,7 @@ def test_logistic_regression():
     for trace, _ in mcmc_run._traces(data):
         posterior.append(trace.nodes['beta']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.05)
+    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.1)
 
 
 def test_bernoulli_beta():
@@ -254,7 +254,7 @@ def test_logistic_regression_with_dual_averaging():
     for trace, _ in mcmc_run._traces(data):
         posterior.append(trace.nodes['beta']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.05)
+    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.1)
 
 
 def test_bernoulli_beta_with_dual_averaging():

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -19,9 +19,7 @@ logging.basicConfig(format='%(levelname)s %(message)s')
 logger = logging.getLogger('pyro')
 logger.setLevel(logging.INFO)
 
-TEST_CASES[0] = TEST_CASES[0]._replace(mean_tol=0.04, std_tol=0.04)
-TEST_CASES[1] = TEST_CASES[1]._replace(mean_tol=0.04, std_tol=0.04)
-T2 = T(*TEST_CASES[2].values)._replace(num_samples=600, warmup_steps=100)
+T2 = T(*TEST_CASES[2].values)._replace(num_samples=800, warmup_steps=200)
 TEST_CASES[2] = pytest.param(*T2, marks=pytest.mark.skipif(
     'CI' in os.environ and os.environ['CI'] == 'true', reason='Slow test - skip on CI'))
 T3 = T(*TEST_CASES[3].values)._replace(num_samples=700, warmup_steps=100)
@@ -90,7 +88,7 @@ def test_logistic_regression():
     for trace, _ in mcmc_run._traces(data):
         posterior.append(trace.nodes['beta']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.05)
+    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.1)
 
 
 def test_bernoulli_beta():
@@ -149,7 +147,7 @@ def test_logistic_regression_with_dual_averaging():
     for trace, _ in mcmc_run._traces(data):
         posterior.append(trace.nodes['beta']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.05)
+    assert_equal(rmse(true_coefs, posterior_mean).item(), 0.0, prec=0.1)
 
 
 @pytest.mark.filterwarnings("ignore:Encountered NAN")

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -107,7 +107,7 @@ def test_bernoulli_beta():
     for trace, _ in mcmc_run._traces(data):
         posterior.append(trace.nodes['p_latent']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean.data, true_probs.data, prec=0.01)
+    assert_equal(posterior_mean.data, true_probs.data, prec=0.02)
 
 
 def test_normal_gamma():
@@ -126,7 +126,7 @@ def test_normal_gamma():
     for trace, _ in mcmc_run._traces(data):
         posterior.append(trace.nodes['p_latent']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean, true_std, prec=0.02)
+    assert_equal(posterior_mean, true_std, prec=0.05)
 
 
 def test_logistic_regression_with_dual_averaging():
@@ -167,4 +167,4 @@ def test_bernoulli_beta_with_dual_averaging():
     for trace, _ in mcmc_run._traces(data):
         posterior.append(trace.nodes['p_latent']['value'])
     posterior_mean = torch.mean(torch.stack(posterior), 0)
-    assert_equal(posterior_mean.data, true_probs.data, prec=0.01)
+    assert_equal(posterior_mean.data, true_probs.data, prec=0.03)

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -25,7 +25,7 @@ def test_subsample_gradient(Elbo, reparameterized, subsample):
     data = torch.tensor([-0.5, 2.0])
     subsample_size = 1 if subsample else len(data)
     num_particles = 50000
-    precision = 0.05
+    precision = 0.06
     Normal = dist.Normal if reparameterized else fakes.NonreparameterizedNormal
 
     def model(subsample):
@@ -67,7 +67,7 @@ def test_iarange(Elbo, reparameterized):
     pyro.clear_param_store()
     data = torch.tensor([-0.5, 2.0])
     num_particles = 20000
-    precision = 0.05
+    precision = 0.06
     Normal = dist.Normal if reparameterized else fakes.NonreparameterizedNormal
 
     def model():

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -167,7 +167,7 @@ class PoissonGammaTests(TestCase):
         self.n_data = len(self.data)
         data_sum = self.data.sum(0)
         self.alpha_n = self.alpha0 + data_sum  # posterior alpha
-        self.beta_n = self.beta0 + torch.tensor(self.n_data)  # posterior beta
+        self.beta_n = self.beta0 + torch.tensor(float(self.n_data))  # posterior beta
 
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, 10000)
@@ -199,9 +199,9 @@ class PoissonGammaTests(TestCase):
             svi.step()
 
         assert_equal(pyro.param("alpha_q"), self.alpha_n, prec=0.2, msg='{} vs {}'.format(
-            pyro.param("alpha_q").detach().numpy(), self.alpha_n.detach().numpy()))
+            pyro.param("alpha_q").detach().cpu().numpy(), self.alpha_n.detach().cpu().numpy()))
         assert_equal(pyro.param("beta_q"), self.beta_n, prec=0.15, msg='{} vs {}'.format(
-            pyro.param("beta_q").detach().numpy(), self.beta_n.detach().numpy()))
+            pyro.param("beta_q").detach().cpu().numpy(), self.beta_n.detach().cpu().numpy()))
 
 
 @pytest.mark.stage("integration", "integration_batch_1")
@@ -220,7 +220,7 @@ def test_exponential_gamma(gamma_dist, n_steps, elbo_impl):
     beta0 = torch.tensor(1.0)
     n_data = 2
     data = torch.tensor([3.0, 2.0])  # two observations
-    alpha_n = alpha0 + torch.tensor(n_data)  # posterior alpha
+    alpha_n = alpha0 + torch.tensor(float(n_data))  # posterior alpha
     beta_n = beta0 + torch.sum(data)  # posterior beta
 
     def model():
@@ -244,9 +244,9 @@ def test_exponential_gamma(gamma_dist, n_steps, elbo_impl):
         svi.step()
 
     assert_equal(pyro.param("alpha_q"), alpha_n, prec=0.15, msg='{} vs {}'.format(
-        pyro.param("alpha_q").detach().numpy(), alpha_n.detach().numpy()))
+        pyro.param("alpha_q").detach().cpu().numpy(), alpha_n.detach().cpu().numpy()))
     assert_equal(pyro.param("beta_q"), beta_n, prec=0.15, msg='{} vs {}'.format(
-        pyro.param("beta_q").detach().numpy(), beta_n.detach().numpy()))
+        pyro.param("beta_q").detach().cpu().numpy(), beta_n.detach().cpu().numpy()))
 
 
 @pytest.mark.stage("integration", "integration_batch_2")
@@ -264,7 +264,7 @@ class BernoulliBetaTests(TestCase):
         self.beta_n = self.beta0 - data_sum + torch.tensor(self.n_data)
         # posterior beta
         self.log_alpha_n = torch.log(self.alpha_n)
-        self.log_beta_n = torch.log(self.beta_n)
+        self.log_beta_n = torch.log(float(self.beta_n))
 
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, 10000)

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -261,7 +261,7 @@ class BernoulliBetaTests(TestCase):
         self.batch_size = 4
         data_sum = self.data.sum()
         self.alpha_n = self.alpha0 + data_sum  # posterior alpha
-        self.beta_n = self.beta0 - data_sum + torch.tensor(self.n_data)
+        self.beta_n = self.beta0 - data_sum + torch.tensor(float(self.n_data))
         # posterior beta
         self.log_alpha_n = torch.log(self.alpha_n)
         self.log_beta_n = torch.log(self.beta_n)

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -264,7 +264,7 @@ class BernoulliBetaTests(TestCase):
         self.beta_n = self.beta0 - data_sum + torch.tensor(self.n_data)
         # posterior beta
         self.log_alpha_n = torch.log(self.alpha_n)
-        self.log_beta_n = torch.log(float(self.beta_n))
+        self.log_beta_n = torch.log(self.beta_n)
 
     def test_elbo_reparameterized(self):
         self.do_elbo_test(True, 10000)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,7 +30,7 @@ CPU_EXAMPLES = [
 CUDA_EXAMPLES = [
     ['air/main.py', '--num-steps=1', '--cuda'],
     ['bayesian_regression.py', '--num-epochs=1', '--cuda'],
-    ['contrib/gp/sv-dkl.py', '--epochs=1', '--num_inducing=4', '--cuda'],
+    ['contrib/gp/sv-dkl.py', '--epochs=1', '--num-inducing=4', '--cuda'],
     ['dmm/dmm.py', '--num-epochs=1', '--cuda'],
     ['dmm/dmm.py', '--num-epochs=1', '--num-iafs=1', '--cuda'],
     ['vae/vae.py', '--num-epochs=1', '--cuda'],


### PR DESCRIPTION
Some changes to our tests/code to ensure that unit tests and examples can run on CUDA. This does not tackle the `_standard_gamma` patching (for running on CUDA) which is needed for tests that use gamma, dirichlet, chi2 etc.
 - Some functions like `torch.linspace` and `torch.randperm` throw an error when we call them with a default cuda tensor type. I am either fixing the device type to CPU, or using `torch.arange` instead of `torch.linspace`.
 - Adjusting the precision threshold for CUDA, and fixing the cuda rng seed.