### PR TITLE
Patch torch to implement cpu->cuda->cpu workarounds

### DIFF
--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import pyro.distributions.torch_patch  # noqa F403
 from pyro.distributions.delta import Delta
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.empirical import Empirical

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+
+
+def _patch(target):
+    parts = target.split('.')
+    assert parts[0] == 'torch'
+    module = torch
+    for part in parts[1:-1]:
+        module = getattr(module, part)
+    name = parts[-1]
+    old_fn = getattr(module, name)
+    old_fn = getattr(old_fn, '_pyro_unpatched', old_fn)  # ensure patching is idempotent
+
+    def decorator(new_fn):
+        new_fn.__name__ = name
+        new_fn._pyro_unpatched = old_fn
+        setattr(module, name, new_fn)
+        return new_fn
+
+    return decorator
+
+
+@_patch('torch._standard_gamma')
+def _torch_standard_gamma(concentration):
+    unpatched_fn = _torch_standard_gamma._pyro_unpatched
+    if concentration.is_cuda:
+        return unpatched_fn(concentration.cpu()).cuda(concentration.get_device())
+    return unpatched_fn(concentration)
+
+
+@_patch('torch.distributions.gamma._standard_gamma')
+def _standard_gamma(concentration):
+    if concentration.is_cuda:
+        return concentration.cpu()._standard_gamma().cuda(concentration.get_device())
+    return concentration._standard_gamma()
+
+
+@_patch('torch._dirichlet_grad')
+def _torch_dirichlet_grad(x, concentration, total):
+    unpatched_fn = _torch_dirichlet_grad._pyro_unpatched
+    if x.is_cuda:
+        return unpatched_fn(x.cpu(), concentration.cpu(), total.cpu()).cuda(x.get_device())
+    return unpatched_fn(x, concentration, total)
+
+
+__all__ = []

--- a/tests/common.py
+++ b/tests/common.py
@@ -62,8 +62,7 @@ def tensors_default_to(host):
     :param str host: Either "cuda" or "cpu".
     """
     assert host in ('cpu', 'cuda'), host
-    old_module = torch.Tensor.__module__
-    name = torch.Tensor.__name__
+    old_module, name = torch.Tensor().type().rsplit('.', 1)
     new_module = 'torch.cuda' if host == 'cuda' else 'torch'
     torch.set_default_tensor_type('{}.{}'.format(new_module, name))
     try:

--- a/tests/distributions/test_cuda.py
+++ b/tests/distributions/test_cuda.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+import torch
+from torch.autograd import grad
 
 from tests.common import assert_equal, requires_cuda, tensors_default_to, xfail_if_not_implemented
 
@@ -13,7 +15,8 @@ def test_sample(dist):
         with tensors_default_to("cpu"):
             params = dist.get_dist_params(idx)
         try:
-            cpu_value = dist.pyro_dist(**params).sample()
+            with xfail_if_not_implemented():
+                cpu_value = dist.pyro_dist(**params).sample()
         except ValueError as e:
             pytest.xfail('CPU version fails: {}'.format(e))
         assert not cpu_value.is_cuda
@@ -28,25 +31,42 @@ def test_sample(dist):
 
 
 @requires_cuda
-def test_log_prob_sum(dist):
+def test_rsample(dist):
+    if not dist.pyro_dist.has_rsample:
+        return
     for idx in range(len(dist.dist_params)):
 
         # Compute CPU value.
         with tensors_default_to("cpu"):
-            data = dist.get_test_data(idx)
             params = dist.get_dist_params(idx)
-        with xfail_if_not_implemented():
-            cpu_value = dist.pyro_dist(**params).log_prob_sum(data)
+            grad_params = [key for key, val in params.items()
+                           if torch.is_tensor(val) and val.dtype in (torch.float32, torch.float64)]
+            for key in grad_params:
+                val = params[key].clone()
+                val.requires_grad = True
+                params[key] = val
+        try:
+            with xfail_if_not_implemented():
+                cpu_value = dist.pyro_dist(**params).rsample()
+                cpu_grads = grad(cpu_value.sum(), [params[key] for key in grad_params])
+        except ValueError as e:
+            pytest.xfail('CPU version fails: {}'.format(e))
         assert not cpu_value.is_cuda
 
         # Compute GPU value.
         with tensors_default_to("cuda"):
-            data = dist.get_test_data(idx)
             params = dist.get_dist_params(idx)
-        cuda_value = dist.pyro_dist(**params).log_prob_sum(data)
+            for key in grad_params:
+                val = params[key].clone()
+                val.requires_grad = True
+                params[key] = val
+        cuda_value = dist.pyro_dist(**params).rsample()
         assert cuda_value.is_cuda
+        assert_equal(cpu_value.size(), cuda_value.size())
 
-        assert_equal(cpu_value, cuda_value.cpu())
+        cuda_grads = grad(cuda_value.sum(), [params[key] for key in grad_params])
+        for cpu_grad, cuda_grad in zip(cpu_grads, cuda_grads):
+            assert_equal(cpu_grad.size(), cuda_grad.size())
 
 
 @requires_cuda


### PR DESCRIPTION
This introduces kludgey workarounds for a few torch.distributions primitives that have no CUDA implementation. This patches the `torch` module in-place.

## Tested

- updated existing tests
- added a `test_rsample` (to test `_dirichlet_grad`)
- removed obsolete `test_log_prob_sum` test