### PR TITLE
Improve support for custom losses in SVI

### DIFF
--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -5,6 +5,7 @@ import torch
 import pyro
 import pyro.poutine as poutine
 from pyro.infer.elbo import ELBO
+from pyro.infer.util import torch_item
 
 
 class SVI(object):
@@ -67,7 +68,7 @@ class SVI(object):
         Evaluate the loss function. Any args or kwargs are passed to the model and guide.
         """
         with torch.no_grad():
-            return self.loss(self.model, self.guide, *args, **kwargs)
+            return torch_item(self.loss(self.model, self.guide, *args, **kwargs))
 
     def step(self, *args, **kwargs):
         """
@@ -92,4 +93,4 @@ class SVI(object):
         # zero gradients
         pyro.infer.util.zero_grads(params)
 
-        return loss
+        return torch_item(loss)

--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -67,7 +67,7 @@ class SVI(object):
         Evaluate the loss function. Any args or kwargs are passed to the model and guide.
         """
         with torch.no_grad():
-            return self.loss.loss(self.model, self.guide, *args, **kwargs)
+            return self.loss(self.model, self.guide, *args, **kwargs)
 
     def step(self, *args, **kwargs):
         """
@@ -80,7 +80,7 @@ class SVI(object):
         """
         # get loss and compute gradients
         with poutine.trace(param_only=True) as param_capture:
-            loss = self.loss.loss_and_grads(self.model, self.guide, *args, **kwargs)
+            loss = self.loss_and_grads(self.model, self.guide, *args, **kwargs)
 
         params = set(site["value"].unconstrained()
                      for site in param_capture.trace.nodes.values())

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import warnings
 
-import pyro
 import pyro.poutine as poutine
 from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
@@ -124,15 +123,14 @@ class Trace_ELBO(ELBO):
             elbo += elbo_particle / self.num_particles
 
             # collect parameters to train from model and guide
-            trainable_params = set(site["value"].unconstrained()
-                                   for trace in (model_trace, guide_trace)
-                                   for site in trace.nodes.values()
-                                   if site["type"] == "param")
+            trainable_params = len(set(site["value"].unconstrained()
+                                       for trace in (model_trace, guide_trace)
+                                       for site in trace.nodes.values()
+                                       if site["type"] == "param")) > 0
 
             if trainable_params and getattr(surrogate_elbo_particle, 'requires_grad', False):
                 surrogate_loss_particle = -surrogate_elbo_particle / self.num_particles
                 surrogate_loss_particle.backward()
-                # pyro.get_param_store().mark_params_active(trainable_params)
 
         loss = -elbo
         if torch_isnan(loss):

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -123,10 +123,9 @@ class Trace_ELBO(ELBO):
             elbo += elbo_particle / self.num_particles
 
             # collect parameters to train from model and guide
-            trainable_params = len(set(site["value"].unconstrained()
-                                       for trace in (model_trace, guide_trace)
-                                       for site in trace.nodes.values()
-                                       if site["type"] == "param")) > 0
+            trainable_params = any(site["type"] == "param"
+                                   for trace in (model_trace, guide_trace)
+                                   for site in trace.nodes.values())
 
             if trainable_params and getattr(surrogate_elbo_particle, 'requires_grad', False):
                 surrogate_loss_particle = -surrogate_elbo_particle / self.num_particles

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -122,17 +122,20 @@ class Trace_ELBO(ELBO):
                         surrogate_elbo_particle = surrogate_elbo_particle + (site * score_function_term).sum()
 
             elbo += elbo_particle / self.num_particles
-
-            # collect parameters to train from model and guide
-            trainable_params = set(site["value"].unconstrained()
-                                   for trace in (model_trace, guide_trace)
-                                   for site in trace.nodes.values()
-                                   if site["type"] == "param")
-
-            if trainable_params and getattr(surrogate_elbo_particle, 'requires_grad', False):
+            if getattr(surrogate_elbo_particle, 'requires_grad', False):
                 surrogate_loss_particle = -surrogate_elbo_particle / self.num_particles
                 surrogate_loss_particle.backward()
-                pyro.get_param_store().mark_params_active(trainable_params)
+
+            # # collect parameters to train from model and guide
+            # trainable_params = set(site["value"].unconstrained()
+            #                        for trace in (model_trace, guide_trace)
+            #                        for site in trace.nodes.values()
+            #                        if site["type"] == "param")
+
+            # if trainable_params and getattr(surrogate_elbo_particle, 'requires_grad', False):
+            #     surrogate_loss_particle = -surrogate_elbo_particle / self.num_particles
+            #     surrogate_loss_particle.backward()
+            #     pyro.get_param_store().mark_params_active(trainable_params)
 
         loss = -elbo
         if torch_isnan(loss):

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -122,20 +122,17 @@ class Trace_ELBO(ELBO):
                         surrogate_elbo_particle = surrogate_elbo_particle + (site * score_function_term).sum()
 
             elbo += elbo_particle / self.num_particles
-            if getattr(surrogate_elbo_particle, 'requires_grad', False):
+
+            # collect parameters to train from model and guide
+            trainable_params = set(site["value"].unconstrained()
+                                   for trace in (model_trace, guide_trace)
+                                   for site in trace.nodes.values()
+                                   if site["type"] == "param")
+
+            if trainable_params and getattr(surrogate_elbo_particle, 'requires_grad', False):
                 surrogate_loss_particle = -surrogate_elbo_particle / self.num_particles
                 surrogate_loss_particle.backward()
-
-            # # collect parameters to train from model and guide
-            # trainable_params = set(site["value"].unconstrained()
-            #                        for trace in (model_trace, guide_trace)
-            #                        for site in trace.nodes.values()
-            #                        if site["type"] == "param")
-
-            # if trainable_params and getattr(surrogate_elbo_particle, 'requires_grad', False):
-            #     surrogate_loss_particle = -surrogate_elbo_particle / self.num_particles
-            #     surrogate_loss_particle.backward()
-            #     pyro.get_param_store().mark_params_active(trainable_params)
+                # pyro.get_param_store().mark_params_active(trainable_params)
 
         loss = -elbo
         if torch_isnan(loss):

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import warnings
 
-import pyro
 import pyro.poutine as poutine
 from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
@@ -128,15 +127,14 @@ class TraceEnum_ELBO(ELBO):
             elbo += elbo_particle.item() / self.num_particles
 
             # collect parameters to train from model and guide
-            trainable_params = set(site["value"].unconstrained()
-                                   for trace in (model_trace, guide_trace)
-                                   for site in trace.nodes.values()
-                                   if site["type"] == "param")
+            trainable_params = len(set(site["value"].unconstrained()
+                                       for trace in (model_trace, guide_trace)
+                                       for site in trace.nodes.values()
+                                       if site["type"] == "param")) > 0
 
             if trainable_params and elbo_particle.requires_grad:
                 loss_particle = -elbo_particle
                 (loss_particle / self.num_particles).backward()
-                # pyro.get_param_store().mark_params_active(trainable_params)
 
         loss = -elbo
         if torch_isnan(loss):

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -127,16 +127,20 @@ class TraceEnum_ELBO(ELBO):
 
             elbo += elbo_particle.item() / self.num_particles
 
-            # collect parameters to train from model and guide
-            trainable_params = set(site["value"].unconstrained()
-                                   for trace in (model_trace, guide_trace)
-                                   for site in trace.nodes.values()
-                                   if site["type"] == "param")
-
-            if trainable_params and elbo_particle.requires_grad:
+            if elbo_particle.requires_grad:
                 loss_particle = -elbo_particle
                 (loss_particle / self.num_particles).backward()
-                pyro.get_param_store().mark_params_active(trainable_params)
+
+            # # collect parameters to train from model and guide
+            # trainable_params = set(site["value"].unconstrained()
+            #                        for trace in (model_trace, guide_trace)
+            #                        for site in trace.nodes.values()
+            #                        if site["type"] == "param")
+
+            # if trainable_params and elbo_particle.requires_grad:
+            #     loss_particle = -elbo_particle
+            #     (loss_particle / self.num_particles).backward()
+            #     pyro.get_param_store().mark_params_active(trainable_params)
 
         loss = -elbo
         if torch_isnan(loss):

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -127,10 +127,9 @@ class TraceEnum_ELBO(ELBO):
             elbo += elbo_particle.item() / self.num_particles
 
             # collect parameters to train from model and guide
-            trainable_params = len(set(site["value"].unconstrained()
-                                       for trace in (model_trace, guide_trace)
-                                       for site in trace.nodes.values()
-                                       if site["type"] == "param")) > 0
+            trainable_params = any(site["type"] == "param"
+                                   for trace in (model_trace, guide_trace)
+                                   for site in trace.nodes.values())
 
             if trainable_params and elbo_particle.requires_grad:
                 loss_particle = -elbo_particle

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -261,15 +261,14 @@ class TraceGraph_ELBO(ELBO):
             surrogate_elbo += surrogate_elbo_term
 
         # collect parameters to train from model and guide
-        trainable_params = set(site["value"].unconstrained()
-                               for trace in (model_trace, guide_trace)
-                               for site in trace.nodes.values()
-                               if site["type"] == "param")
+        trainable_params = len(set(site["value"].unconstrained()
+                                   for trace in (model_trace, guide_trace)
+                                   for site in trace.nodes.values()
+                                   if site["type"] == "param")) > 0
 
         if trainable_params:
             surrogate_loss = -surrogate_elbo
             torch_backward(weight * (surrogate_loss + baseline_loss))
-            # pyro.get_param_store().mark_params_active(trainable_params)
 
         loss = -elbo
         if torch_isnan(loss):

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -269,7 +269,7 @@ class TraceGraph_ELBO(ELBO):
         if trainable_params:
             surrogate_loss = -surrogate_elbo
             torch_backward(weight * (surrogate_loss + baseline_loss))
-            pyro.get_param_store().mark_params_active(trainable_params)
+            # pyro.get_param_store().mark_params_active(trainable_params)
 
         loss = -elbo
         if torch_isnan(loss):

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -261,10 +261,9 @@ class TraceGraph_ELBO(ELBO):
             surrogate_elbo += surrogate_elbo_term
 
         # collect parameters to train from model and guide
-        trainable_params = len(set(site["value"].unconstrained()
-                                   for trace in (model_trace, guide_trace)
-                                   for site in trace.nodes.values()
-                                   if site["type"] == "param")) > 0
+        trainable_params = any(site["type"] == "param"
+                               for trace in (model_trace, guide_trace)
+                               for site in trace.nodes.values())
 
         if trainable_params:
             surrogate_loss = -surrogate_elbo

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -35,7 +35,6 @@ class ParamStoreDict(object):
         """
         self._params = {}  # dictionary from param name to param
         self._param_to_name = {}  # dictionary from unconstrained param to param name
-        self._active_params = set()  # set of all currently active params
         self._constraints = {}  # dictionary from param name to constraint object
 
     def clear(self):
@@ -44,7 +43,6 @@ class ParamStoreDict(object):
         """
         self._params = {}
         self._param_to_name = {}
-        self._active_params = set()
         self._constraints = {}
 
     def named_parameters(self):
@@ -59,33 +57,6 @@ class ParamStoreDict(object):
         Get all parameter names in the ParamStore
         """
         return self._params.keys()
-
-    def get_active_params(self):
-        """
-        :returns: all active params in the ParamStore
-        :rtype: set
-        """
-        return self._active_params
-
-    def mark_params_active(self, params):
-        """
-        :param params: iterable of params the user wishes to mark as active in the ParamStore.
-            this information is used to determine which parameters are being optimized,
-            e.g. in the context of pyro.infer.SVI
-        """
-        assert(all([p in self._param_to_name for p in params])), \
-            "some of these parameters are not in the ParamStore"
-        self._active_params.update(set(params))
-
-    def mark_params_inactive(self, params):
-        """
-        :param params: iterable of params the user wishes to mark as inactive in the ParamStore.
-            this information is used to determine which parameters are being optimized,
-            e.g. in the context of pyro.infer.SVI
-        """
-        assert(all([p in self._param_to_name for p in params])), \
-            "some of these parameters are not in the ParamStore"
-        self._active_params.difference_update(set(params))
 
     def replace_param(self, param_name, new_param, old_param):
         """

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -23,10 +23,11 @@ from .trace_poutine import TraceMessenger
 ############################################
 
 
-def trace(fn=None, graph_type=None):
+def trace(fn=None, graph_type=None, param_only=None):
     """
     :param fn: a stochastic function (callable containing pyro primitive calls)
     :param graph_type: string that specifies the kind of graph to construct
+    :param param_only: if true, only records params and not samples
     :returns: stochastic function wrapped in a TraceHandler
     :rtype: pyro.poutine.TraceHandler
 
@@ -38,7 +39,7 @@ def trace(fn=None, graph_type=None):
 
     Adds trace data structure site constructors to primitive stacks
     """
-    msngr = TraceMessenger(graph_type=graph_type)
+    msngr = TraceMessenger(graph_type=graph_type, param_only=param_only)
     return msngr(fn) if fn is not None else msngr
 
 

--- a/pyro/poutine/trace_poutine.py
+++ b/pyro/poutine/trace_poutine.py
@@ -41,7 +41,7 @@ class TraceMessenger(Messenger):
     We can also use this for visualization.
     """
 
-    def __init__(self, graph_type=None, param_only=False):
+    def __init__(self, graph_type=None, param_only=None):
         """
         :param string graph_type: string that specifies the type of graph
             to construct (currently only "flat" or "dense" supported)

--- a/pyro/poutine/trace_poutine.py
+++ b/pyro/poutine/trace_poutine.py
@@ -45,6 +45,7 @@ class TraceMessenger(Messenger):
         """
         :param string graph_type: string that specifies the type of graph
             to construct (currently only "flat" or "dense" supported)
+        :param param_only: boolean that specifies whether to record sample sites
         """
         super(TraceMessenger, self).__init__()
         if graph_type is None:
@@ -65,6 +66,10 @@ class TraceMessenger(Messenger):
         Adds appropriate edges based on cond_indep_stack information
         upon exiting the context.
         """
+        if self.param_only:
+            for node in list(self.trace.nodes.values()):
+                if node["type"] != "param":
+                    self.trace.remove_node(node["name"])
         if self.graph_type == "dense":
             identify_dense_edges(self.trace)
         return super(TraceMessenger, self).__exit__(*args, **kwargs)
@@ -175,7 +180,7 @@ class TraceHandler(Handler):
                                       name="_INPUT", type="args",
                                       args=args, kwargs=kwargs)
             ret = self.fn(*args, **kwargs)
-        self.msngr.trace.add_node("_RETURN", name="_RETURN", type="return", value=ret)
+            self.msngr.trace.add_node("_RETURN", name="_RETURN", type="return", value=ret)
         return ret
 
     @property

--- a/pyro/poutine/trace_poutine.py
+++ b/pyro/poutine/trace_poutine.py
@@ -41,7 +41,7 @@ class TraceMessenger(Messenger):
     We can also use this for visualization.
     """
 
-    def __init__(self, graph_type=None):
+    def __init__(self, graph_type=None, param_only=False):
         """
         :param string graph_type: string that specifies the type of graph
             to construct (currently only "flat" or "dense" supported)
@@ -49,8 +49,16 @@ class TraceMessenger(Messenger):
         super(TraceMessenger, self).__init__()
         if graph_type is None:
             graph_type = "flat"
+        if param_only is None:
+            param_only = False
         assert graph_type in ("flat", "dense")
         self.graph_type = graph_type
+        self.param_only = param_only
+        self.trace = Trace(graph_type=self.graph_type)
+
+    def __enter__(self):
+        self.trace = Trace(graph_type=self.graph_type)
+        return super(TraceMessenger, self).__enter__()
 
     def __exit__(self, *args, **kwargs):
         """
@@ -79,10 +87,11 @@ class TraceMessenger(Messenger):
 
     def _reset(self):
         tr = Trace(graph_type=self.graph_type)
-        tr.add_node("_INPUT",
-                    name="_INPUT", type="input",
-                    args=self.trace.nodes["_INPUT"]["args"],
-                    kwargs=self.trace.nodes["_INPUT"]["kwargs"])
+        if "_INPUT" in self.trace.nodes:
+            tr.add_node("_INPUT",
+                        name="_INPUT", type="input",
+                        args=self.trace.nodes["_INPUT"]["args"],
+                        kwargs=self.trace.nodes["_INPUT"]["kwargs"])
         self.trace = tr
         super(TraceMessenger, self)._reset()
 
@@ -129,6 +138,8 @@ class TraceMessenger(Messenger):
         return None
 
     def _postprocess_message(self, msg):
+        if msg["type"] == "sample" and self.param_only:
+            return None
         val = msg["value"]
         site = msg.copy()
         site.update(value=val)
@@ -159,11 +170,11 @@ class TraceHandler(Handler):
         stores the arguments and return value of the function in special sites,
         and returns self.fn's return value
         """
-        self.msngr.trace = Trace(graph_type=self.msngr.graph_type)
-        self.msngr.trace.add_node("_INPUT",
-                                  name="_INPUT", type="args",
-                                  args=args, kwargs=kwargs)
-        ret = super(TraceHandler, self).__call__(*args, **kwargs)
+        with self.msngr:
+            self.msngr.trace.add_node("_INPUT",
+                                      name="_INPUT", type="args",
+                                      args=args, kwargs=kwargs)
+            ret = self.fn(*args, **kwargs)
         self.msngr.trace.add_node("_RETURN", name="_RETURN", type="return", value=ret)
         return ret
 

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -84,6 +84,10 @@ class TraceHandlerTests(NormalNormalNormalHandlerTestCase):
         assert_equal(model_trace.nodes["latent1"]["value"],
                      model_trace.nodes["_RETURN"]["value"])
 
+    def test_trace_param_only(self):
+        model_trace = poutine.trace(self.model, param_only=True).get_trace()
+        assert all(site["type"] == "param" for site in model_trace.nodes.values())
+
 
 class ReplayHandlerTests(NormalNormalNormalHandlerTestCase):
 


### PR DESCRIPTION
This PR removes a bit of cruft in SVI so that it's easier to work with custom losses.  In particular, it:
1. Removes `ParamStoreDict.mark_param_active()` and related machinery
2. Replaces that machinery with a `poutine.trace` in `SVI.step` so that users can simply define a loss and not worry about moving parameters around
3. Adds a `param_only` flag to `TraceMessenger` that allows `poutine.trace` to record only parameter sites
4. Removes the restriction in `SVI` requiring `loss` to be an `ELBO` object
5. Restores a default value for `SVI.loss_and_grads` (calling backward on the result of `SVI.loss`)

The upshot is that now, to create a custom loss, all that's needed is to define it as a function that takes in a model, guide, and any other arguments necessary to compute it and returns a differentiable scalar loss value.  For example:
```python
def simple_elbo(model, guide, *args, **kwargs):
    guide_trace = poutine.trace(guide).get_trace(*args, **kwargs)
    model_trace = poutine.trace(
        poutine.replay(model, trace=guide_trace)).get_trace(*args, **kwargs)
    return -1*(model_trace.log_prob_sum() - guide_trace.log_prob_sum())

svi = SVI(model, guide, optim, loss=simple_elbo)
losses = []
for i in range(N):
    losses.append(svi.step())
```