### PR TITLE
add clipped nn to docs

### DIFF
--- a/docs/source/pyro.nn.txt
+++ b/docs/source/pyro.nn.txt
@@ -6,3 +6,10 @@ AutoRegressiveNN
     :undoc-members:
     :show-inheritance:
 
+ClippedNN
+----------------
+.. automodule:: pyro.nn.clipped_nn
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/pyro/nn/clipped_nn.py
+++ b/pyro/nn/clipped_nn.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 
 class ClippedSoftmax(nn.Softmax):
     """
-    a wrapper around `nn.Softmax` that scales its output
+    a wrapper around :class:`torch.nn.Softmax` that scales its output
     from `[0,1]` to `[epsilon,1-(n-1)*epsilon]`
     where n is the output dimension of Softmax
     """
@@ -21,7 +21,7 @@ class ClippedSoftmax(nn.Softmax):
 
 class ClippedSigmoid(nn.Sigmoid):
     """
-    a wrapper around `nn.Sigmoid` that scales its output
+    a wrapper around :class:`torch.nn.Sigmoid` that scales its output
     from `[0,1]` to `[epsilon,1-epsilon]`
     """
     def __init__(self, epsilon, *args, **kwargs):


### PR DESCRIPTION
this was omitted from the docs. it's still used in examples like ss-vae

@fritzo are these clipped non-linearities still needed or can this be handled by pytorch 0.4?