### PR TITLE
Fix sphinx links to pyro primitives

### DIFF
--- a/docs/source/primitives.rst
+++ b/docs/source/primitives.rst
@@ -1,7 +1,21 @@
 Primitives
 ==========
 
-.. automodule:: pyro.primitives
+.. autofunction:: pyro.sample
+.. autofunction:: pyro.param
+.. autofunction:: pyro.module
+.. autofunction:: pyro.random_module
+
+.. autoclass:: pyro.irange
     :members:
     :undoc-members:
-    :show-inheritance:
+
+.. autoclass:: pyro.iarange
+    :members:
+    :undoc-members:
+
+.. autofunction:: pyro.get_param_store
+.. autofunction:: pyro.clear_param_store
+
+.. autofunction:: pyro.validation_enabled
+.. autofunction:: pyro.enable_validation


### PR DESCRIPTION
## Tested

- generated docs locally and ensured that links work