### PR TITLE
Add posterior predictive class to AbstractInfer

### DIFF
--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from pyro.infer.abstract_infer import EmpiricalMarginal, TracePosterior
+from pyro.infer.abstract_infer import EmpiricalMarginal, PosteriorPredictive, TracePosterior
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import config_enumerate
 from pyro.infer.importance import Importance
@@ -17,6 +17,7 @@ __all__ = [
     "ELBO",
     "Importance",
     "EmpiricalMarginal",
+    "PosteriorPredictive",
     "SVI",
     "TracePosterior",
     "Trace_ELBO",

--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from pyro.infer.abstract_infer import EmpiricalMarginal, TracePredictive, TracePosterior
+from pyro.infer.abstract_infer import EmpiricalMarginal, TracePosterior, TracePredictive
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import config_enumerate
 from pyro.infer.importance import Importance

--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from pyro.infer.abstract_infer import EmpiricalMarginal, PosteriorPredictive, TracePosterior
+from pyro.infer.abstract_infer import EmpiricalMarginal, TracePredictive, TracePosterior
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import config_enumerate
 from pyro.infer.importance import Importance
@@ -17,7 +17,7 @@ __all__ = [
     "ELBO",
     "Importance",
     "EmpiricalMarginal",
-    "PosteriorPredictive",
+    "TracePredictive",
     "SVI",
     "TracePosterior",
     "Trace_ELBO",

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -6,17 +6,21 @@ from six import add_metaclass
 import torch
 
 import pyro.poutine as poutine
-from pyro.distributions import Empirical
+from pyro.distributions import Categorical, Empirical
 
 
 class EmpiricalMarginal(Empirical):
     """
-    :param trace_dist: a TracePosterior instance representing a Monte Carlo posterior.
-
     Marginal distribution, that wraps over a TracePosterior object to provide a
     a marginal over one or more latent sites or the return values of the
     TracePosterior's model. If multiple sites are specified, they must have the
     same tensor shape.
+
+    :param TracePosterior trace_posterior: a TracePosterior instance representing
+        a Monte Carlo posterior.
+    :param list sites: optional list of sites for which we need to generate
+        the marginal distribution for. Note that for multiple sites, the shape
+        for the site values must match.
     """
     def __init__(self, trace_posterior, sites=None, validate_args=None):
         assert isinstance(trace_posterior, TracePosterior), \
@@ -71,3 +75,43 @@ class TracePosterior(object):
             self.exec_traces.append(tr)
             self.log_weights.append(logit)
         return self
+
+
+class PosteriorPredictive(TracePosterior):
+    """
+    Generates and holds traces from the posterior predictive distribution,
+    given model execution traces from the approximate posterior.
+
+    :param model: arbitrary Python callable containing Pyro primitives.
+    :param model_traces: execution traces from the model.
+    :param int num_samples: number of samples to generate.
+    :param list hide_nodes: list of nodes that should be hidden when
+        replaying the model against ``model_traces``. Usually, this
+        corresponds to observed nodes.
+    :param list log_weights: optional importance weights of execution
+        traces to be used during sampling.
+    """
+    def __init__(self, model, model_traces, num_samples, hide_nodes=[], log_weights=None):
+        self.model = model
+        self.model_traces = model_traces
+        self.hide_nodes = hide_nodes
+        self.num_samples = num_samples
+        if not log_weights:
+            log_weights = torch.zeros(len(model_traces,))
+        else:
+            log_weights = torch.tensor(log_weights)
+        self._categorical = Categorical(logits=log_weights)
+        super(PosteriorPredictive, self).__init__()
+
+    def _get_random_pruned_trace(self):
+        random_idx = self._categorical.sample()
+        trace = self.model_traces[random_idx].copy()
+        for node in self.hide_nodes:
+            trace.remove_node(node)
+        return trace
+
+    def _traces(self, *args, **kwargs):
+        for _ in range(self.num_samples):
+            model_trace = self._get_random_pruned_trace()
+            replayed_trace = poutine.trace(poutine.replay(self.model, model_trace)).get_trace(*args, **kwargs)
+            yield (replayed_trace, 0)

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -19,8 +19,9 @@ class EmpiricalMarginal(Empirical):
     :param TracePosterior trace_posterior: a TracePosterior instance representing
         a Monte Carlo posterior.
     :param list sites: optional list of sites for which we need to generate
-        the marginal distribution for. Note that for multiple sites, the shape
-        for the site values must match.
+        the marginal distribution. Note that for multiple sites, the shape
+        for the site values must match (needed by the underlying ``Empirical``
+        class).
     """
     def __init__(self, trace_posterior, sites=None, validate_args=None):
         assert isinstance(trace_posterior, TracePosterior), \
@@ -80,7 +81,10 @@ class TracePosterior(object):
 class PosteriorPredictive(TracePosterior):
     """
     Generates and holds traces from the posterior predictive distribution,
-    given model execution traces from the approximate posterior.
+    given model execution traces from the approximate posterior. This is
+    achieved by constraining latent sites to randomly sampled parameter
+    values from the model execution traces and running the model forward
+    to generate traces with new response ("_RETURN") sites.
 
     :param model: arbitrary Python callable containing Pyro primitives.
     :param model_traces: execution traces from the model.

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from abc import abstractmethod, ABCMeta
-from six import add_metaclass
+from abc import ABCMeta, abstractmethod
 
 import torch
+from six import add_metaclass
 
 import pyro.poutine as poutine
 from pyro.distributions import Categorical, Empirical

--- a/tests/infer/test_abstract_infer.py
+++ b/tests/infer/test_abstract_infer.py
@@ -5,7 +5,7 @@ import torch
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-from pyro.infer import EmpiricalMarginal, PosteriorPredictive
+from pyro.infer import EmpiricalMarginal, TracePredictive
 from pyro.infer.mcmc import MCMC, NUTS
 from tests.common import assert_equal
 
@@ -24,6 +24,6 @@ def test_posterior_predictive():
     conditioned_model = poutine.condition(model, data={"obs": num_success})
     nuts_kernel = NUTS(conditioned_model, adapt_step_size=True)
     mcmc_run = MCMC(nuts_kernel, num_samples=1000, warmup_steps=200).run(num_trials)
-    posterior_predictive = PosteriorPredictive(model, mcmc_run.exec_traces, num_samples=10000).run(num_trials)
+    posterior_predictive = TracePredictive(model, mcmc_run, num_samples=10000).run(num_trials)
     marginal_return_vals = EmpiricalMarginal(posterior_predictive)
     assert_equal(marginal_return_vals.mean, torch.ones(5) * 700, prec=30)

--- a/tests/infer/test_abstract_infer.py
+++ b/tests/infer/test_abstract_infer.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+
+import pyro
+import pyro.distributions as dist
+import pyro.poutine as poutine
+from pyro.infer.mcmc import MCMC, NUTS
+
+
+def model(num_trials):
+    phi_prior = dist.Uniform(num_trials.new_tensor(0.), num_trials.new_tensor(1.))\
+        .expand_by(num_trials.shape[0])
+    success_prob = pyro.sample("phi", phi_prior)
+    return pyro.sample("obs", dist.Binomial(success_prob))
+
+
+def conditioned_model(model, num_trials, num_success):
+    return poutine.condition(model, data={"obs": num_success})(num_trials)
+
+
+def test_posterior_predictive():
+    data = torch.ones(5) * 0.7
+    nuts_kernel = NUTS(model, adapt_step_size=True)
+    mcmc_posterior = MCMC(nuts_kernel)

--- a/tests/infer/test_abstract_infer.py
+++ b/tests/infer/test_abstract_infer.py
@@ -5,21 +5,25 @@ import torch
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
+from pyro.infer import EmpiricalMarginal, PosteriorPredictive
 from pyro.infer.mcmc import MCMC, NUTS
+from tests.common import assert_equal
 
 
 def model(num_trials):
     phi_prior = dist.Uniform(num_trials.new_tensor(0.), num_trials.new_tensor(1.))\
-        .expand_by(num_trials.shape[0])
+        .expand_by([num_trials.shape[0]])
     success_prob = pyro.sample("phi", phi_prior)
-    return pyro.sample("obs", dist.Binomial(success_prob))
-
-
-def conditioned_model(model, num_trials, num_success):
-    return poutine.condition(model, data={"obs": num_success})(num_trials)
+    return pyro.sample("obs", dist.Binomial(num_trials, success_prob))
 
 
 def test_posterior_predictive():
-    data = torch.ones(5) * 0.7
-    nuts_kernel = NUTS(model, adapt_step_size=True)
-    mcmc_posterior = MCMC(nuts_kernel)
+    true_probs = torch.ones(5) * 0.7
+    num_trials = torch.ones(5) * 1000
+    num_success = dist.Binomial(num_trials, true_probs).sample()
+    conditioned_model = poutine.condition(model, data={"obs": num_success})
+    nuts_kernel = NUTS(conditioned_model, adapt_step_size=True)
+    mcmc_run = MCMC(nuts_kernel, num_samples=1000, warmup_steps=200).run(num_trials)
+    posterior_predictive = PosteriorPredictive(model, mcmc_run.exec_traces, num_samples=10000).run(num_trials)
+    marginal_return_vals = EmpiricalMarginal(posterior_predictive)
+    assert_equal(marginal_return_vals.mean, torch.ones(5) * 700, prec=30)


### PR DESCRIPTION
Adds a posterior predictive class that allows us to generate posterior predictive samples given model execution traces and new/old data. These can be wrapped inside marginal to provide an empirical distribution over samples from the posterior predictive distribution.
