### PR TITLE
Point to PyTorch official release in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
 
 install:
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
-          pip install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp27-cp27mu-linux_x86_64.whl
+          pip install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp27-cp27mu-linux_x86_64.whl;
       else
-          pip install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp35-cp35m-linux_x86_64.whl
+          pip install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp35-cp35m-linux_x86_64.whl;
       fi
     - pip install .[test]
     - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ env:
         - PYTHONPATH=$PWD:$PYTHONPATH
 
 install:
-    # Install PyTorch wheel using the install script
-    - bash scripts/install_pytorch.sh
+    - pip install torch
     - pip install .[test]
     - pip freeze
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,11 @@ env:
         - PYTHONPATH=$PWD:$PYTHONPATH
 
 install:
-    - pip install torch
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
+          pip install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp27-cp27mu-linux_x86_64.whl
+      else
+          pip install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp35-cp35m-linux_x86_64.whl
+      fi
     - pip install .[test]
     - pip freeze
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Alternatively, build PyTorch following instructions in the PyTorch
 ```sh
 git clone --recursive https://github.com/pytorch/pytorch
 cd pytorch
-git checkout 38aaa63  # <---- a well-tested commit
+git checkout 200fb22  # <---- a well-tested commit
 ```
 On Linux:
 ```sh


### PR DESCRIPTION
 - Use latest release for CI.
 - Wheels are updated (same as `v0.4.0`), in case anyone runs `bash scripts/install_pytorch.sh`.