### PR TITLE
Correct caption for image in VAE tutorial

### DIFF
--- a/tutorial/source/vae.ipynb
+++ b/tutorial/source/vae.ipynb
@@ -552,7 +552,7 @@
     "<figure>\n",
     "<img src=\"_static/img/vae_plots/test_elbo_vae.png\"  style=\"width: 550px;\">\n",
     "<figcaption>\n",
-    "<font size=\"+1\"><b>Figure 3:</b> How the test ELBO evolves over the course of training </font>(the horizontal axis is the number of training epochs divided by 5).\n",
+    "<font size=\"+1\"><b>Figure 3:</b> How the test ELBO evolves over the course of training. </font>\n",
     "</figcaption>\n",
     "</figure>\n",
     "</center>"


### PR DESCRIPTION
I had forgotten to update the caption for the VAE plot - which is simply the number of training epochs, not the number of epochs divided by 5. 