### PR TITLE
Use internally hosted baseball dataset for example

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -56,8 +56,7 @@ logging.basicConfig(format='%(message)s', level=logging.INFO)
 # Enable validation checks
 pyro.enable_validation(True)
 pyro.set_rng_seed(1)
-DATA_URL = "http://www.swarthmore.edu/NatSci/peverso1/Sports%20Data/" + \
-           "JamesSteinData/Efron-Morris%20Baseball/EfronMorrisBB.txt"
+DATA_URL = "https://d2fefpcigoriu7.cloudfront.net/datasets/EfronMorrisBB.txt"
 
 
 # ===================================


### PR DESCRIPTION
I noticed that a recent build failed while fetching the `baseball` dataset. Moving this to our S3 folder `datasets`, which we can also use to host other datasets in tutorials/examples.