### PR TITLE
rm tag+commit versioning in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,6 @@
 import os
-import re
 import sys
+from pyro import __version__
 
 import sphinx_rtd_theme
 
@@ -65,11 +65,7 @@ author = u'Uber AI Labs'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-#
-# get the latest git tag with  the latest commit
-# eg pyro-0.1.2-g4c52460
-# this only matters if you host manually
-version = re.sub('^v', '', os.popen('git describe --tags').read().strip())
+version = __version__
 
 # release version
 release = version


### PR DESCRIPTION
this was so you could see what commit of docs you were building before `pyro.__version__` had all that juicy metadata