### PR TITLE
Implement coregionalization kernel for contrib.gp

### DIFF
--- a/docs/source/contrib.gp.rst
+++ b/docs/source/contrib.gp.rst
@@ -81,6 +81,12 @@ Kernels
     :show-inheritance:
     :member-order: bysource
 
+.. automodule:: pyro.contrib.gp.kernels.coregionalize
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 Likelihoods
 -----------
 

--- a/pyro/contrib/gp/kernels/__init__.py
+++ b/pyro/contrib/gp/kernels/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from pyro.contrib.gp.kernels.brownian import Brownian
+from pyro.contrib.gp.kernels.coregionalize import Coregionalize
 from pyro.contrib.gp.kernels.dot_product import DotProduct, Linear, Polynomial
 from pyro.contrib.gp.kernels.isotropic import RBF, Exponential, Isotropy, Matern32, Matern52, RationalQuadratic
 from pyro.contrib.gp.kernels.kernel import (Combination, Exponent, Kernel, Product, Sum, Transforming, VerticalScaling,
@@ -10,9 +11,10 @@ from pyro.contrib.gp.kernels.static import Constant, WhiteNoise
 
 __all__ = [
     "Brownian",
-    "Cosine",
     "Combination",
     "Constant",
+    "Coregionalize",
+    "Cosine",
     "DotProduct",
     "Exponent",
     "Exponential",
@@ -24,8 +26,8 @@ __all__ = [
     "Periodic",
     "Polynomial",
     "Product",
-    "RationalQuadratic",
     "RBF",
+    "RationalQuadratic",
     "Sum",
     "Transforming",
     "VerticalScaling",

--- a/pyro/contrib/gp/kernels/coregionalize.py
+++ b/pyro/contrib/gp/kernels/coregionalize.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+from torch.nn import Parameter
+
+from .kernel import Kernel
+
+
+class Coregionalize(Kernel):
+    r"""
+    A kernel for the linear model of coregionalization :math:`x R R^T z^T`
+    where :math:`R` is an ``input_dim``-by-``rank`` regionalization matrix
+    where typically ``rank < input_dim``.
+
+    :param int input_dim: Number of feature dimensions of inputs.
+    :param str name: Name of the kernel.
+    :param torch.Tensor regions: An optional ``(input_dim, rank)`` shaped
+        matrix that maps features to ``rank``-many regions. If unspecified,
+        this will be randomly initialized.
+    :param int rank: Optional rank. This is only used if ``regions`` is
+        unspecified. If unspecified, ``rank`` defaults to ``input_dim``.
+    :param list active_dims: List of feature dimensions of the input which the
+        kernel acts on.
+    """
+
+    def __init__(self, input_dim, regions=None, rank=None, active_dims=None, name="coregionalize"):
+        super(Coregionalize, self).__init__(input_dim, active_dims, name)
+        if regions is None:
+            if rank is None:
+                rank = input_dim
+            regions = torch.randn(input_dim, rank) / rank ** 0.5
+        if regions.dim() != 2 or regions.shape[0] != input_dim:
+            raise ValueError("Expected region.shape == ({},r), actual {}".format(regions.shape))
+        self.regions = Parameter(regions)
+
+    def forward(self, X, Z=None, diag=False):
+        regions = self.get_param("regions")
+        X = self._slice_input(X)
+        Xc = X.matmul(regions)
+        if diag:
+            return (Xc ** 2).sum(-1)
+        elif Z is None:
+            Zc = Xc
+        else:
+            Z = self._slice_input(Z)
+            Zc = Z.matmul(regions)
+        return Xc.matmul(Zc.t())


### PR DESCRIPTION
This implements a `Coregionalize` kernel to learn low-rank covariance structure among features.

The typical use case is for modeling correlations among outputs of a multi-output GP, where outputs are coded as distinct data points with on-hot coded features denoting which output each datapoint represents.

## Tested

- added examples to test_kernels.py
- trained an example model with weekly data coded as on-hot vector, and verified that `Coregionalize` performs similarly to `Periodic`.