### PR TITLE
Update to NUTS/HMC docstrings

### DIFF
--- a/docs/source/mcmc.rst
+++ b/docs/source/mcmc.rst
@@ -1,9 +1,4 @@
 MCMC
 ====
 
-.. automodule:: pyro.infer.mcmc
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 .. include:: pyro.infer.mcmc.txt

--- a/docs/source/pyro.infer.mcmc.txt
+++ b/docs/source/pyro.infer.mcmc.txt
@@ -1,4 +1,6 @@
-.. automodule:: pyro.infer.mcmc.mcmc
+MCMC
+----
+.. autoclass:: pyro.infer.mcmc.MCMC
     :members:
     :undoc-members:
     :show-inheritance:
@@ -6,7 +8,7 @@
 HMC
 ---
 
-.. automodule:: pyro.infer.mcmc.hmc
+.. autoclass:: pyro.infer.mcmc.HMC
     :members:
     :undoc-members:
     :show-inheritance:
@@ -14,7 +16,7 @@ HMC
 NUTS
 ----
 
-.. automodule:: pyro.infer.mcmc.nuts
+.. autoclass:: pyro.infer.mcmc.NUTS
     :members:
     :undoc-members:
     :show-inheritance:

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -20,7 +20,7 @@ class HMC(TraceKernel):
     Simple Hamiltonian Monte Carlo kernel, where ``step_size`` and ``num_steps``
     need to be explicitly specified by the user.
 
-    References
+    **References**
 
     [1] `MCMC Using Hamiltonian Dynamics`,
     Radford M. Neal
@@ -44,6 +44,24 @@ class HMC(TraceKernel):
         If not specified and the model has sites with constrained support,
         automatic transformations will be applied, as specified in
         :mod:`torch.distributions.constraint_registry`.
+
+    Example::
+
+        true_coefs = torch.tensor([1., 2., 3.])
+        data = torch.randn(2000, 3)
+        dim = 3
+        labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
+
+        def model(data):
+            coefs_mean = torch.zeros(dim)
+            coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(3)))
+            y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
+            return y
+
+        hmc_kernel = HMC(model, step_size=0.0855, num_steps=4)
+        mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
+        posterior = EmpiricalMarginal(mcmc_run, 'beta')
+        print(posterior.mean)
     """
 
     def __init__(self, model, step_size=None, trajectory_length=None,


### PR DESCRIPTION
One of the users on our Slack distribution channel mentioned a small issue with the example in the NUTS docstring, so taking the opportunity to clean up the docstrings for HMC and NUTS.

 - Added the same example to HMC, and ensured that both are working. Updated to use EmpiricalMarginal.
 - Also pointing to the `baseball.py` example which is important as it is not something that users would discover easily otherwise.