### PR TITLE
Add diagonal component to coregionalization kernel

### DIFF
--- a/pyro/contrib/gp/kernels/coregionalize.py
+++ b/pyro/contrib/gp/kernels/coregionalize.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import torch
+from torch.distributions import constraints
 from torch.nn import Parameter
 
 from .kernel import Kernel
@@ -9,14 +10,19 @@ from .kernel import Kernel
 class Coregionalize(Kernel):
     r"""
     A kernel for the linear model of coregionalization
-    :math:`k(x,z) = x^T R R^T z` where :math:`R` is an
-    ``input_dim``-by-``rank`` matrix and typically ``rank < input_dim``.
+    :math:`k(x,z) = x^T (C C^T + D) z` where :math:`C` is an
+    ``input_dim``-by-``rank`` matrix and typically ``rank < input_dim``,
+    and ``D`` is a diagonal matrix.
 
     This generalizes the
     :class:`~pyro.contrib.gp.kernels.dot_product.Linear` kernel to multiple
-    features. The typical use case is for modeling correlations among outputs
-    of a multi-output GP, where outputs are coded as distinct data points with
-    one-hot coded features denoting which output each datapoint represents.
+    features with a low-rank-plus-diagonal weight matrix. The typical use case
+    is for modeling correlations among outputs of a multi-output GP, where
+    outputs are coded as distinct data points with one-hot coded features
+    denoting which output each datapoint represents.
+
+    If only ``rank`` is specified, the kernel ``(C C^T + D)`` will be
+    randomly initialized to a matrix with expected value the identity matrix.
 
     References:
 
@@ -24,35 +30,66 @@ class Coregionalize(Kernel):
         Kernels for Vector-Valued Functions: a Review
 
     :param int input_dim: Number of feature dimensions of inputs.
+    :param int rank: Optional rank. This is only used if ``components`` is
+        unspecified. If neigher ``rank`` nor ``components`` is specified,
+        then ``rank`` defaults to ``input_dim``.
     :param torch.Tensor components: An optional ``(input_dim, rank)`` shaped
         matrix that maps features to ``rank``-many components. If unspecified,
         this will be randomly initialized.
-    :param int rank: Optional rank. This is only used if ``components`` is
-        unspecified. If unspecified, ``rank`` defaults to ``input_dim``.
+    :param torch.Tensor diagonal: An optional vector of length ``input_dim``.
+        If unspecified, this will be set to constant ``1 - rank / input_dim`` if
+        ``rank < input_dim`` otherwise zero.
     :param list active_dims: List of feature dimensions of the input which the
         kernel acts on.
     :param str name: Name of the kernel.
     """
 
-    def __init__(self, input_dim, components=None, rank=None, active_dims=None, name="coregionalize"):
+    def __init__(self, input_dim, rank=None, components=None, diagonal=None, active_dims=None, name="coregionalize"):
         super(Coregionalize, self).__init__(input_dim, active_dims, name)
+
+        # Add a low-rank kernel with expected value torch.eye(input_dim, input_dim) * rank / input_dim.
         if components is None:
-            if rank is None:
-                rank = input_dim
-            components = torch.randn(input_dim, rank) / rank ** 0.5
-        if components.dim() != 2 or components.shape[0] != input_dim:
-            raise ValueError("Expected region.shape == ({},rank), actual {}".format(input_dim, components.shape))
+            rank = input_dim if rank is None else rank
+            components = torch.randn(input_dim, rank) / input_dim ** 0.5
+        else:
+            rank = components.shape[-1]
+        if components.shape != (input_dim, rank):
+            raise ValueError("Expected components.shape == ({},rank), actual {}".format(input_dim, components.shape))
         self.components = Parameter(components)
+
+        # Add a diagonal component only if rank < input_dim.
+        # The expected value should be torch.eye(input_dim, input_dim) * (1 - rank / input_dim),
+        # such that the result has expected value the identity matrix.
+        if diagonal is None and rank < input_dim:
+            diagonal = components.new_ones(input_dim) * (1.0 - rank / input_dim)
+        if diagonal is None:
+            self.diagonal = None
+        else:
+            if diagonal.shape != (input_dim,):
+                raise ValueError("Expected diagonal.shape == ({},rank), actual {}".format(diagonal.shape))
+            self.diagonal = Parameter(diagonal)
+            self.set_constraint("diagonal", constraints.positive)
 
     def forward(self, X, Z=None, diag=False):
         components = self.get_param("components")
+        diagonal = None if self.diagonal is None else self.get_param("diagonal")
         X = self._slice_input(X)
         Xc = X.matmul(components)
+
         if diag:
-            return (Xc ** 2).sum(-1)
-        elif Z is None:
+            result = (Xc ** 2).sum(-1)
+            if diagonal is not None:
+                result = result + (X ** 2).mv(diagonal)
+            return result
+
+        if Z is None:
+            Z = X
             Zc = Xc
         else:
             Z = self._slice_input(Z)
             Zc = Z.matmul(components)
-        return Xc.matmul(Zc.t())
+
+        result = Xc.matmul(Zc.t())
+        if diagonal is not None:
+            result = result + (X * diagonal).matmul(Z.t())
+        return result

--- a/tests/contrib/gp/test_kernels.py
+++ b/tests/contrib/gp/test_kernels.py
@@ -115,6 +115,10 @@ def test_kernel_forward(kernel, X, Z, K_sum):
     if K_sum is not None:
         assert_equal(K.sum().item(), K_sum)
     assert_equal(kernel(X).diag(), kernel(X, diag=True))
+    if not isinstance(kernel, WhiteNoise):  # WhiteNoise avoids computing a delta function by assuming X != Z
+        assert_equal(kernel(X), kernel(X, X))
+    if Z is not None:
+        assert_equal(kernel(X, Z), kernel(Z, X).t())
 
 
 def test_combination():

--- a/tests/contrib/gp/test_kernels.py
+++ b/tests/contrib/gp/test_kernels.py
@@ -95,7 +95,14 @@ TEST_CASES = [
                         [0., 1., 0.]]),
         K_sum=None,  # kernel is randomly initialized
     ),
-
+    T(
+        Coregionalize(3, rank=2, diagonal=0.01 * torch.ones(3)),
+        X=torch.tensor([[1., 0., 0.],
+                        [0.5, 0., 0.5]]),
+        Z=torch.tensor([[1., 0., 0.],
+                        [0., 1., 0.]]),
+        K_sum=None,  # kernel is randomly initialized
+    ),
 ]
 
 TEST_IDS = [t[0].__class__.__name__ for t in TEST_CASES]


### PR DESCRIPTION
## Motivation

The idea is to change our `Coregionalization` kernel to allow "low-rank + diagonal" matrices, which anecdotally are easier to optimize than pure low-rank matrices.

## Design choices

The most common use case is to provide only the `rank` arg to `Coregionalization()`. In this case I've chosen to randomly initialize the `components` matrix and set `diagonal` to a constant, and scale both so that the expected value of the kernel is the identity matrix.

If `rank == num_inputs` I avoid the diagonal matrix entirely. This is sensible since `C C^T` is no longer sparse, and adding the `diagonal` component is redundant.