### PR TITLE
Relax check for gp kernel active_dims to allow overlap

### DIFF
--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -175,16 +175,7 @@ class Combination(Kernel):
 
         active_dims = set(kern0.active_dims)
         if isinstance(kern1, Kernel):
-            active_dims1 = set(kern1.active_dims)
-            if active_dims == active_dims1:  # on the same active_dims
-                pass
-            elif len(active_dims & active_dims1) == 0:  # on disjoint active_dims
-                active_dims = active_dims | active_dims1
-            else:
-                raise ValueError("Sub-kernels must act on the same active dimensions "
-                                 "or disjoint active dimensions (to create direct sum "
-                                 "or tensor product of kernels).")
-
+            active_dims  |= set(kern1.active_dims)
         active_dims = sorted(active_dims)
         input_dim = len(active_dims)
         super(Combination, self).__init__(input_dim, active_dims, name)

--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -175,7 +175,7 @@ class Combination(Kernel):
 
         active_dims = set(kern0.active_dims)
         if isinstance(kern1, Kernel):
-            active_dims  |= set(kern1.active_dims)
+            active_dims |= set(kern1.active_dims)
         active_dims = sorted(active_dims)
         input_dim = len(active_dims)
         super(Combination, self).__init__(input_dim, active_dims, name)

--- a/tests/contrib/gp/test_kernels.py
+++ b/tests/contrib/gp/test_kernels.py
@@ -127,11 +127,10 @@ def test_combination():
     assert k.get_subkernel(k5.name) is k5
 
 
-def test_active_dims_overlap_error():
+def test_active_dims_overlap_ok():
     k1 = Matern52(2, variance, lengthscale[0], active_dims=[0, 1])
     k2 = Matern32(2, variance, lengthscale[0], active_dims=[1, 2])
-    with pytest.raises(ValueError):
-        Sum(k1, k2)
+    Sum(k1, k2)
 
 
 def test_active_dims_disjoint_ok():


### PR DESCRIPTION
This removes the check that, when combining kernels `k1` and `k2`, their `.active_dims` are either identical or disjoint. After this PR, arbitrary overlapping is allowed.

I'm unsure of the original intent of this check. The check appears to be no longer needed since all `._slice_input()` calls are made at the leaf kernels of `Combination` kernels and hence leaf kernels can safely grab their components.

Why do I want overlapping kernels? One example is in a dataset with three groups of features, say X0, X1, X2. I want to use X0 to modulate X1 and X2 via
```py
modulated1 = Coregionalize(active_dims=X0, ...).mul(RBF(active_dims=X1, ...))
modulated2 = Coregionalize(active_dims=X0, ...).mul(RBF(active_dims=X2, ...))
kernel = modulated1.add(modulated2)  # <---- error here
```
Of course I could work around this by combining with a `Constant`ly zero kernel
```py
workaround1 = Constant(input_dim=len(X2), active_dims=X2, variance=torch.zeros(1),
                       name="workaround1")
workaround1.fix_param("variance")
modulated1 = modulated1.add(workaround1)

workaround2 = Constant(input_dim=len(X1), active_dims=X1, variance=torch.zeros(1),
                       name="workaround2")
workaround2.fix_param("variance")
modulated2 = modulated2.add(workaround2)
```
but that feels very kludgey.

@fehiepsi Does this seem reasonable?