### PR TITLE
Typo Fix in VAE Tutorial

### DIFF
--- a/tutorial/source/vae.ipynb
+++ b/tutorial/source/vae.ipynb
@@ -184,7 +184,7 @@
    "metadata": {},
    "source": [
     "Given a latent code $z$, the forward call of `Decoder`  returns the parameters for a Bernoulli distribution in image space. Since  each image is of size\n",
-    "$28\\times28=784$, `mu_img` is of size `batch_size` x 784.\n",
+    "$28\\times28=784$, `loc_img` is of size `batch_size` x 784.\n",
     "\n",
     "Next we define a PyTorch module that encapsulates our encoder network:"
    ]
@@ -263,7 +263,7 @@
     "- in case we're on GPU, we use `new_zeros` and `new_ones` to ensure that newly created tensors are on the same GPU device.\n",
     "\n",
     "Next we sample the latent `z` from the prior, making sure to give the random variable a unique Pyro name `'latent'`. \n",
-    "Then we pass `z` through the decoder network, which returns `mu_img`. We then score the observed images in the mini-batch `x` against the Bernoulli likelihood parametrized by `mu_img`.\n",
+    "Then we pass `z` through the decoder network, which returns `loc_img`. We then score the observed images in the mini-batch `x` against the Bernoulli likelihood parametrized by `loc_img`.\n",
     "Note that we flatten `x` so that all the pixels are in the rightmost dimension.\n",
     "\n",
     "That's all there is to it! Note how closely the flow of Pyro primitives in `model` follows the generative story of our model, e.g. as encapsulated by Figure 1. Now we move on to the guide:"
@@ -482,7 +482,7 @@
    "source": [
     "Basically the only change we need to make is that we call evaluate_loss instead of step. This function will compute an estimate of the ELBO but won't take any gradient steps.\n",
     "\n",
-    "The final piece of code we'd like to highlight is the helper method `reconstruct_img` in the VAE class: This is just the image reconstruction experiment we described in the introduction translated into code. We take an image and pass it through the encoder. Then we sample in latent space using the gaussian distribution provided by the encoder. Finally we decode the latent code into an image: we return the mean vector mu_img instead of sampling with it. Note that since the `sample()` statement is stochastic, we'll get different draws of z every time we run the reconstruct_img function. If we've learned a good model and guide—in particular if we've learned a good latent representation—this plurality of z samples will correspond to different styles of digit writing, and the reconstructed images should exhibit an interesting variety of different styles."
+    "The final piece of code we'd like to highlight is the helper method `reconstruct_img` in the VAE class: This is just the image reconstruction experiment we described in the introduction translated into code. We take an image and pass it through the encoder. Then we sample in latent space using the gaussian distribution provided by the encoder. Finally we decode the latent code into an image: we return the mean vector `loc_img` instead of sampling with it. Note that since the `sample()` statement is stochastic, we'll get different draws of z every time we run the reconstruct_img function. If we've learned a good model and guide—in particular if we've learned a good latent representation—this plurality of z samples will correspond to different styles of digit writing, and the reconstructed images should exhibit an interesting variety of different styles."
    ]
   },
   {


### PR DESCRIPTION
Make the change: `mu_img` => `loc_img` in the text. The code is not changed.