### PR TITLE
Implement TorchDistribution.expand()

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -29,6 +29,16 @@ Abstract Distribution
     :special-members: __call__
     :show-inheritance:
 
+TorchDistributionMixin
+----------------------
+
+.. autoclass:: pyro.distributions.torch_distribution.TorchDistributionMixin
+    :members:
+    :undoc-members:
+    :special-members: __call__
+    :show-inheritance:
+    :member-order: bysource
+
 TorchDistribution
 -----------------
 

--- a/pyro/distributions/binomial.py
+++ b/pyro/distributions/binomial.py
@@ -119,3 +119,13 @@ class Binomial(torch.distributions.Distribution, TorchDistributionMixin):
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         values = values.expand((-1,) + self._batch_shape)
         return values
+
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        total_count = self.total_count.expand(batch_shape)
+        if 'probs' in self.__dict__:
+            probs = self.probs.expand(batch_shape)
+            return Binomial(total_count, probs=probs, validate_args=validate_args)
+        else:
+            logits = self.logits.expand(batch_shape)
+            return Binomial(total_count, logits=logits, validate_args=validate_args)

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -42,6 +42,12 @@ class Delta(TorchDistribution):
         self.log_density = log_density
         super(Delta, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        v = self.v.expand(batch_shape + self.event_shape)
+        log_density = self.log_density.expand(batch_shape)
+        return Delta(v, log_density, self.event_dim, validate_args=validate_args)
+
     def rsample(self, sample_shape=torch.Size()):
         shape = sample_shape + self.v.shape
         return self.v.expand(shape)

--- a/pyro/distributions/half_cauchy.py
+++ b/pyro/distributions/half_cauchy.py
@@ -47,3 +47,8 @@ class HalfCauchy(TransformedDistribution):
 
     def entropy(self):
         return self.base_dist.entropy() - math.log(2)
+
+    def expand(self, batch_shape):
+        loc = self.loc.expand(batch_shape)
+        scale = self.scale.expand(batch_shape)
+        return HalfCauchy(loc, scale)

--- a/pyro/distributions/lowrank_mvn.py
+++ b/pyro/distributions/lowrank_mvn.py
@@ -107,8 +107,8 @@ class LowRankMultivariateNormal(TorchDistribution):
         elif y.dim() == 2:
             W_Dinv_y = W_Dinv.matmul(y.t())
         else:
-            raise ValueError("SparseMultivariateNormal distribution does not support "
-                             "computing log_prob for a tensor with more than 2 dimensionals.")
+            raise NotImplementedError("SparseMultivariateNormal distribution does not support "
+                                      "computing log_prob for a tensor with more than 2 dimensionals.")
         Linv_W_Dinv_y = matrix_triangular_solve_compat(W_Dinv_y, L, upper=False)
         if y.dim() == 2:
             Linv_W_Dinv_y = Linv_W_Dinv_y.t()

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -43,6 +43,13 @@ class Cauchy(torch.distributions.Cauchy, TorchDistributionMixin):
         return Cauchy(loc, scale, validate_args=validate_args)
 
 
+class Chi2(torch.distributions.Chi2, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        df = self.df.expand(batch_shape)
+        return Chi2(df, validate_args=validate_args)
+
+
 class Dirichlet(torch.distributions.Dirichlet, TorchDistributionMixin):
     def expand(self, batch_shape):
         validate_args = self.__dict__.get('validate_args')
@@ -57,6 +64,33 @@ class Exponential(torch.distributions.Exponential, TorchDistributionMixin):
         return Exponential(rate, validate_args=validate_args)
 
 
+class Gamma(torch.distributions.Gamma, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        concentration = self.concentration.expand(batch_shape)
+        rate = self.rate.expand(batch_shape)
+        return Gamma(concentration, rate, validate_args=validate_args)
+
+
+class Geometric(torch.distributions.Geometric, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        if 'probs' in self.__dict__:
+            probs = self.probs.expand(batch_shape)
+            return Geometric(probs=probs, validate_args=validate_args)
+        else:
+            logits = self.logits.expand(batch_shape)
+            return Geometric(logits=logits, validate_args=validate_args)
+
+
+class Gumbel(torch.distributions.Gumbel, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        loc = self.loc.expand(batch_shape)
+        scale = self.scale.expand(batch_shape)
+        return Gumbel(loc, scale, validate_args=validate_args)
+
+
 class Independent(torch.distributions.Independent, TorchDistributionMixin):
     def expand(self, batch_shape):
         validate_args = self.__dict__.get('validate_args')
@@ -65,12 +99,31 @@ class Independent(torch.distributions.Independent, TorchDistributionMixin):
         return Independent(base_dist, self.reinterpreted_batch_ndims, validate_args=validate_args)
 
 
+class Laplace(torch.distributions.Laplace, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        loc = self.loc.expand(batch_shape)
+        scale = self.scale.expand(batch_shape)
+        return Laplace(loc, scale, validate_args=validate_args)
+
+
 class LogNormal(torch.distributions.LogNormal, TorchDistributionMixin):
     def expand(self, batch_shape):
         validate_args = self.__dict__.get('validate_args')
         loc = self.loc.expand(batch_shape)
         scale = self.scale.expand(batch_shape)
         return LogNormal(loc, scale, validate_args=validate_args)
+
+
+class Multinomial(torch.distributions.Multinomial, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        if 'probs' in self.__dict__:
+            probs = self.probs.expand(batch_shape + self.event_shape)
+            return Multinomial(self.total_count, probs=probs, validate_args=validate_args)
+        else:
+            logits = self.logits.expand(batch_shape + self.event_shape)
+            return Multinomial(self.total_count, logits=logits, validate_args=validate_args)
 
 
 class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributionMixin):
@@ -113,6 +166,21 @@ class Poisson(torch.distributions.Poisson, TorchDistributionMixin):
         validate_args = self.__dict__.get('validate_args')
         rate = self.rate.expand(batch_shape)
         return Poisson(rate, validate_args=validate_args)
+
+
+class StudentT(torch.distributions.StudentT, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        df = self.df.expand(batch_shape)
+        loc = self.loc.expand(batch_shape)
+        scale = self.scale.expand(batch_shape)
+        return StudentT(df, loc, scale, validate_args=validate_args)
+
+
+class TransformedDistribution(torch.distributions.TransformedDistribution, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        base_dist = self.base_dist.expand(batch_shape)
+        return TransformedDistribution(base_dist, self.transforms)
 
 
 class Uniform(torch.distributions.Uniform, TorchDistributionMixin):

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -4,6 +4,125 @@ import torch
 
 from pyro.distributions.torch_distribution import TorchDistributionMixin
 
+
+class Bernoulli(torch.distributions.Bernoulli, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        if 'probs' in self.__dict__:
+            probs = self.probs.expand(batch_shape)
+            return Bernoulli(probs=probs, validate_args=validate_args)
+        else:
+            logits = self.logits.expand(batch_shape)
+            return Bernoulli(logits=logits, validate_args=validate_args)
+
+
+class Beta(torch.distributions.Beta, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        concentration1 = self.concentration1.expand(batch_shape)
+        concentration0 = self.concentration0.expand(batch_shape)
+        return Beta(concentration1, concentration0, validate_args=validate_args)
+
+
+class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        if 'probs' in self.__dict__:
+            probs = self.probs.expand(batch_shape + self.probs.shape[-1:])
+            return Categorical(probs=probs, validate_args=validate_args)
+        else:
+            logits = self.logits.expand(batch_shape + self.logits.shape[-1:])
+            return Categorical(logits=logits, validate_args=validate_args)
+
+
+class Cauchy(torch.distributions.Cauchy, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        loc = self.loc.expand(batch_shape)
+        scale = self.scale.expand(batch_shape)
+        return Cauchy(loc, scale, validate_args=validate_args)
+
+
+class Dirichlet(torch.distributions.Dirichlet, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        concentration = self.concentration.expand(batch_shape + self.event_shape)
+        return Dirichlet(concentration, validate_args=validate_args)
+
+
+class Exponential(torch.distributions.Exponential, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        rate = self.rate.expand(batch_shape)
+        return Exponential(rate, validate_args=validate_args)
+
+
+class Independent(torch.distributions.Independent, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        extra_shape = self.base_dist.event_shape[:self.reinterpreted_batch_ndims]
+        base_dist = self.base_dist.expand(batch_shape + extra_shape)
+        return Independent(base_dist, self.reinterpreted_batch_ndims, validate_args=validate_args)
+
+
+class LogNormal(torch.distributions.LogNormal, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        loc = self.loc.expand(batch_shape)
+        scale = self.scale.expand(batch_shape)
+        return LogNormal(loc, scale, validate_args=validate_args)
+
+
+class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        batch_shape = torch.Size(batch_shape)
+        validate_args = self.__dict__.get('validate_args')
+        loc = self.loc.expand(batch_shape + self.event_shape)
+        if 'scale_tril' in self.__dict__:
+            scale_tril = self.scale_tril.expand(batch_shape + self.event_shape + self.event_shape)
+            return MultivariateNormal(loc, scale_tril=scale_tril, validate_args=validate_args)
+        elif 'covariance_matrix' in self.__dict__:
+            covariance_matrix = self.covariance_matrix.expand(batch_shape + self.event_shape + self.event_shape)
+            return MultivariateNormal(loc, covariance_matrix=covariance_matrix, validate_args=validate_args)
+        else:
+            precision_matrix = self.precision_matrix.expand(batch_shape + self.event_shape + self.event_shape)
+            return MultivariateNormal(loc, precision_matrix=precision_matrix, validate_args=validate_args)
+
+
+class Normal(torch.distributions.Normal, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        loc = self.loc.expand(batch_shape)
+        scale = self.scale.expand(batch_shape)
+        return Normal(loc, scale, validate_args=validate_args)
+
+
+class OneHotCategorical(torch.distributions.OneHotCategorical, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        if 'probs' in self.__dict__:
+            probs = self.probs.expand(batch_shape + self.event_shape)
+            return OneHotCategorical(probs=probs, validate_args=validate_args)
+        else:
+            logits = self.logits.expand(batch_shape + self.event_shape)
+            return OneHotCategorical(logits=logits, validate_args=validate_args)
+
+
+class Poisson(torch.distributions.Poisson, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        rate = self.rate.expand(batch_shape)
+        return Poisson(rate, validate_args=validate_args)
+
+
+class Uniform(torch.distributions.Uniform, TorchDistributionMixin):
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        low = self.low.expand(batch_shape)
+        high = self.high.expand(batch_shape)
+        return Uniform(low, high, validate_args=validate_args)
+
+
 # Programmatically load all distributions from PyTorch.
 __all__ = []
 for _name, _Dist in torch.distributions.__dict__.items():

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -69,7 +69,16 @@ class TorchDistributionMixin(Distribution):
         Expands a distribution to a desired
         :attr:`~torch.distributions.distribution.Distribution.batch_shape`.
 
-        :param torch.Size batch_shape: The target ``batch_shape``.
+        Note that this is more general than :meth:`expand_by` because
+        ``d.expand_by(sample_shape)`` can be reduced to
+        ``d.expand(sample_shape + d.batch_shape)``.
+
+        :param torch.Size batch_shape: The target ``batch_shape``. This must
+            compatible with ``self.batch_shape`` similar to the requirements
+            of :func:`torch.Tensor.expand`: the target ``batch_shape`` must
+            be at least as long as ``self.batch_shape``, and for each
+            non-singleton dim of ``self.batch_shape``, ``batch_shape`` must
+            either agree or be set to ``-1``.
         :return: An expanded version of this distribution.
         :rtype: :class:`ReshapedDistribution`
         """
@@ -94,6 +103,9 @@ class TorchDistributionMixin(Distribution):
         """
         Expands a distribution by adding ``sample_shape`` to the left side of
         its :attr:`~torch.distributions.distribution.Distribution.batch_shape`.
+
+        To expand internal dims of ``self.batch_shape`` from 1 to something
+        larger, use :meth:`expand` instead.
 
         :param torch.Size sample_shape: The size of the iid batch to be drawn
             from the distribution.

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import numbers
+
 import torch
 from torch.distributions import constraints
 
@@ -62,6 +64,32 @@ class TorchDistributionMixin(Distribution):
         """
         return sample_shape + self.batch_shape + self.event_shape
 
+    def expand(self, batch_shape):
+        """
+        Expands a distribution to a desired
+        :attr:`~torch.distributions.distribution.Distribution.batch_shape`.
+
+        :param torch.Size batch_shape: The target ``batch_shape``.
+        :return: An expanded version of this distribution.
+        :rtype: :class:`ReshapedDistribution`
+        """
+        batch_shape = list(batch_shape)
+        if len(batch_shape) < len(self.batch_shape):
+            raise ValueError("Expected len(batch_shape) >= len(self.batch_shape), "
+                             "actual {} vs {}".format(len(batch_shape), len(self.batch_shape)))
+        # check sizes of existing dims
+        for dim in range(-1, -1 - len(self.batch_shape), -1):
+            if batch_shape[dim] == -1:
+                batch_shape[dim] = self.batch_shape[dim]
+            elif batch_shape[dim] != self.batch_shape[dim]:
+                if self.batch_shape[dim] != 1:
+                    raise ValueError("Cannot broadcast dim {} of size {} to size {}".format(
+                        dim, self.batch_shape[dim], batch_shape[dim]))
+                else:
+                    raise NotImplementedError("https://github.com/uber/pyro/issues/1119")
+        sample_shape = batch_shape[:len(batch_shape) - len(self.batch_shape)]
+        return self.expand_by(sample_shape)
+
     def expand_by(self, sample_shape):
         """
         Expands a distribution by adding ``sample_shape`` to the left side of
@@ -104,6 +132,7 @@ class TorchDistributionMixin(Distribution):
         """
         if reinterpreted_batch_ndims is None:
             reinterpreted_batch_ndims = len(self.batch_shape)
+        # TODO return pyro.distributions.torch.Independent(self, reinterpreted_batch_ndims)
         return ReshapedDistribution(self, reinterpreted_batch_ndims=reinterpreted_batch_ndims)
 
     def mask(self, mask):
@@ -242,13 +271,15 @@ class ReshapedDistribution(TorchDistribution):
         return self.base_dist.rsample(sample_shape + self.sample_shape)
 
     def log_prob(self, value):
-        return sum_rightmost(self.base_dist.log_prob(value), self.reinterpreted_batch_ndims)
+        return sum_rightmost(self.base_dist.log_prob(value), self.reinterpreted_batch_ndims).expand(self.batch_shape)
 
     def score_parts(self, value):
         log_prob, score_function, entropy_term = self.base_dist.score_parts(value)
-        log_prob = sum_rightmost(log_prob, self.reinterpreted_batch_ndims)
-        score_function = sum_rightmost(score_function, self.reinterpreted_batch_ndims)
-        entropy_term = sum_rightmost(entropy_term, self.reinterpreted_batch_ndims)
+        log_prob = sum_rightmost(log_prob, self.reinterpreted_batch_ndims).expand(self.batch_shape)
+        if not isinstance(score_function, numbers.Number):
+            score_function = sum_rightmost(score_function, self.reinterpreted_batch_ndims).expand(self.batch_shape)
+        if not isinstance(entropy_term, numbers.Number):
+            entropy_term = sum_rightmost(entropy_term, self.reinterpreted_batch_ndims).expand(self.batch_shape)
         return ScoreParts(log_prob, score_function, entropy_term)
 
     def enumerate_support(self):

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -63,3 +63,9 @@ class VonMises(TorchDistribution):
         log_prob = self.concentration * torch.cos(value - self.loc)
         log_prob = log_prob - math.log(2 * math.pi) - _log_modified_bessel_fn_0(self.concentration)
         return log_prob
+
+    def expand(self, batch_shape):
+        validate_args = self.__dict__.get('validate_args')
+        loc = self.loc.expand(batch_shape)
+        concentration = self.concentration.expand(batch_shape)
+        return VonMises(loc, concentration, validate_args=validate_args)

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -96,3 +96,62 @@ def test_distribution_validate_args(dist_class, args, validate_args):
         else:
             with pytest.raises(ValueError):
                 dist_class(**args)
+
+
+def check_sample_shapes(small, large):
+    if isinstance(small, dist.LogNormal):
+        # Ignore broadcasting bug in LogNormal:
+        # https://github.com/pytorch/pytorch/pull/7269
+        return
+    try:
+        x = small.sample()
+        assert_equal(small.log_prob(x).expand(large.batch_shape), large.log_prob(x))
+        x = large.sample()
+        assert_equal(small.log_prob(x), large.log_prob(x))
+    except NotImplementedError:
+        pass
+
+
+@pytest.mark.parametrize('sample_shape', [(), (2,), (2, 3)])
+def test_expand_by(dist, sample_shape):
+    for idx in range(dist.get_num_test_data()):
+        small = dist.pyro_dist(**dist.get_dist_params(idx))
+        large = small.expand(sample_shape + small.batch_shape)
+        assert large.batch_shape == sample_shape + small.batch_shape
+        check_sample_shapes(small, large)
+
+
+@pytest.mark.parametrize('sample_shape', [(), (2,), (2, 3)])
+def test_expand_new_dim(dist, sample_shape):
+    for idx in range(dist.get_num_test_data()):
+        small = dist.pyro_dist(**dist.get_dist_params(idx))
+        large = small.expand(sample_shape + small.batch_shape)
+        assert large.batch_shape == sample_shape + small.batch_shape
+        check_sample_shapes(small, large)
+
+
+def test_expand_existing_dim(dist):
+    for idx in range(dist.get_num_test_data()):
+        small = dist.pyro_dist(**dist.get_dist_params(idx))
+        for dim, size in enumerate(small.batch_shape):
+            if size != 1:
+                continue
+            batch_shape = list(small.batch_shape)
+            batch_shape[dim] = 5
+            batch_shape = torch.Size(batch_shape)
+            with xfail_if_not_implemented():
+                large = small.expand(batch_shape)
+            assert large.batch_shape == batch_shape
+            check_sample_shapes(small, large)
+
+
+def test_expand_twice(dist):
+    for idx in range(dist.get_num_test_data()):
+        small = dist.pyro_dist(**dist.get_dist_params(idx))
+        medium = small.expand(torch.Size((2, 1)) + small.batch_shape)
+        batch_shape = torch.Size((2, 3)) + small.batch_shape
+        with xfail_if_not_implemented():
+            large = medium.expand(batch_shape)
+        assert large.batch_shape == batch_shape
+        check_sample_shapes(small, large)
+        check_sample_shapes(medium, large)

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -116,7 +116,7 @@ def check_sample_shapes(small, large):
 def test_expand_by(dist, sample_shape):
     for idx in range(dist.get_num_test_data()):
         small = dist.pyro_dist(**dist.get_dist_params(idx))
-        large = small.expand(sample_shape + small.batch_shape)
+        large = small.expand_by(sample_shape)
         assert large.batch_shape == sample_shape + small.batch_shape
         check_sample_shapes(small, large)
 


### PR DESCRIPTION
Resolves #1119 

This PR combines a partial implementation of `TorchDistribution.expand()` with a number of custom implementations for most distribution classes. A general implementation would be tricky to implement and slow in practice, since permuting dimensions would make the resulting tensors non-contiguous.

## Tested

- added a number of new tests of `.expand()` and `.expand_by()`
- fixed some existing distributions (e.g. `ReshapedDistribution`) to pass new tests
- ignored errors due to https://github.com/pytorch/pytorch/pull/7269