### PR TITLE
Use momentum of the same size as the unconstrained sample site in HMC

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -189,8 +189,8 @@ class HMC(TraceKernel):
             if node["fn"].support is not constraints.real and self._automatic_transform_enabled:
                 self.transforms[name] = biject_to(node["fn"].support).inv
                 site_value = self.transforms[name](node["value"])
-            r_loc = torch.zeros_like(site_value)
-            r_scale = torch.ones_like(site_value)
+            r_loc = site_value.new_zeros(site_value.shape)
+            r_scale = site_value.new_ones(site_value.shape)
             self._r_dist[name] = dist.Normal(loc=r_loc, scale=r_scale)
         self._validate_trace(trace)
 

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -185,11 +185,13 @@ class HMC(TraceKernel):
         if self._automatic_transform_enabled:
             self.transforms = {}
         for name, node in sorted(trace.iter_stochastic_nodes(), key=lambda x: x[0]):
-            r_loc = torch.zeros_like(node["value"])
-            r_scale = torch.ones_like(node["value"])
-            self._r_dist[name] = dist.Normal(loc=r_loc, scale=r_scale)
+            site_value = node["value"]
             if node["fn"].support is not constraints.real and self._automatic_transform_enabled:
                 self.transforms[name] = biject_to(node["fn"].support).inv
+                site_value = self.transforms[name](node["value"])
+            r_loc = torch.zeros_like(site_value)
+            r_scale = torch.ones_like(site_value)
+            self._r_dist[name] = dist.Normal(loc=r_loc, scale=r_scale)
         self._validate_trace(trace)
 
         if self.adapt_step_size:

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -205,7 +205,6 @@ def test_normal_gamma():
     assert_equal(posterior.mean, true_std, prec=0.05)
 
 
-@pytest.mark.xfail(reason='log_abs_det_jacobian not implemented for StickBreakingTransform')
 def test_categorical_dirichlet():
     def model(data):
         concentration = torch.tensor([1.0, 1.0, 1.0])


### PR DESCRIPTION
Fixes #1121. 

HMC makes an assumption that the momentum shape will match the shape of the sample site. This is a bug when we have constraints present - because in that case the momentum shape should match the shape of the *unconstrained* sample site. While this won't commonly be triggered because most constraints do not affect the input shapes, this assumption is violated by the `StickBreakingTransform`, where the shapes of the momentum and the unconstrained sites will be off by 1 currently.