### PR TITLE
Implicitly broadcast sample sites using iarange dim and size information

### DIFF
--- a/docs/source/poutine.rst
+++ b/docs/source/poutine.rst
@@ -12,6 +12,8 @@ Handlers
 
 .. autofunction:: pyro.poutine.block
 
+.. autofunction:: pyro.poutine.broadcast
+
 .. autofunction:: pyro.poutine.condition
 
 .. autofunction:: pyro.poutine.do

--- a/docs/source/pyro.poutine.txt
+++ b/docs/source/pyro.poutine.txt
@@ -14,6 +14,14 @@ _______________
     :undoc-members:
     :show-inheritance:
 
+BroadcastMessenger
+__________________
+
+.. automodule:: pyro.poutine.broadcast_messenger
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ConditionMessenger
 ___________________
 

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
-from .handlers import block, condition, do, enum, escape, indep, infer_config, lift, replay, queue, scale, trace
+from .handlers import block, broadcast, condition, do, enum, escape, indep, infer_config, lift, \
+    replay, queue, scale, trace
 from .runtime import NonlocalExit
 from .trace_struct import Trace
 
 
 __all__ = [
     "block",
+    "broadcast",
     "condition",
     "do",
     "enum",

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -21,20 +21,19 @@ class BroadcastMessenger(Messenger):
         dist = msg["fn"]
         actual_batch_shape = getattr(dist, "batch_shape", None)
         if actual_batch_shape is not None:
-            target_batch_shape = []
+            target_batch_shape = [None if size == 1 else size for size in actual_batch_shape]
             for f in msg["cond_indep_stack"]:
-                if f.dim is not None:
-                    assert f.dim < 0
-                    target_batch_shape = [None] * (-f.dim - len(target_batch_shape)) + target_batch_shape
-                    if target_batch_shape[f.dim] is not None:
-                        raise ValueError('\n  '.join([
-                            'at site "{}" within iarange("", dim={}), dim collision'
-                            .format(msg["name"], f.name, f.dim),
-                            'Try setting dim arg in other iaranges.']))
-                    target_batch_shape[f.dim] = f.size
+                if f.dim is None:
+                    continue
+                assert f.dim < 0
+                target_batch_shape = [None] * (-f.dim - len(target_batch_shape)) + target_batch_shape
+                if target_batch_shape[f.dim] not in (None, f.size):
+                    raise ValueError("Shape mismatch inside iarange('{}') at site {} dim {}, {} vs {}".format(
+                        f.name, msg['name'], f.dim, f.size, target_batch_shape[f.dim]))
+                target_batch_shape[f.dim] = f.size
             # Starting from the right, if expected size is None at an index,
             # set it to the actual size if it exists, else 1.
             for i in range(-len(target_batch_shape) + 1, 1):
                 if target_batch_shape[i] is None:
-                    target_batch_shape[i] = actual_batch_shape[i] if len(actual_batch_shape) > -i else 1
+                    target_batch_shape[i] = actual_batch_shape[i] if len(actual_batch_shape) >= -i else 1
             msg["fn"] = msg["fn"].expand(target_batch_shape)

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -34,7 +34,7 @@ class BroadcastMessenger(Messenger):
                     target_batch_shape[f.dim] = f.size
             # Starting from the right, if expected size is None at an index,
             # set it to the actual size if it exists, else 1.
-            for i in range(-len(target_batch_shape)+1, 1):
+            for i in range(-len(target_batch_shape) + 1, 1):
                 if target_batch_shape[i] is None:
                     target_batch_shape[i] = actual_batch_shape[i] if len(actual_batch_shape) > -i else 1
             msg["fn"] = msg["fn"].expand(target_batch_shape)

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -32,8 +32,8 @@ class BroadcastMessenger(Messenger):
                             .format(msg["name"], f.name, f.dim),
                             'Try setting dim arg in other iaranges.']))
                     target_batch_shape[f.dim] = f.size
-            # If expected shape is None at an index, infer as either 1,
-            # or the actual shape starting from the right.
+            # Starting from the right, if expected size is None at an index,
+            # set it to the actual size if it exists, else 1.
             for i in range(-len(target_batch_shape)+1, 1):
                 if target_batch_shape[i] is None:
                     target_batch_shape[i] = actual_batch_shape[i] if len(actual_batch_shape) > -i else 1

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import, division, print_function
+
+from .messenger import Messenger
+
+
+class BroadcastMessenger(Messenger):
+    """
+    `BroadcastMessenger` automatically broadcasts the batch shape of
+    the stochastic function at a sample site when inside a single
+    or nested iarange context. The existing `batch_shape` must be
+    broadcastable with the size of the :class::`pyro.iarange`
+    contexts installed in the `cond_indep_stack`.
+    """
+    def _pyro_sample(self, msg):
+        """
+        :param msg: current message at a trace site.
+        """
+        if msg["done"] or msg["type"] != "sample":
+            return
+
+        dist = msg["fn"]
+        actual_batch_shape = getattr(dist, "batch_shape", None)
+        if actual_batch_shape is not None:
+            target_batch_shape = []
+            for f in msg["cond_indep_stack"]:
+                if f.dim is not None:
+                    assert f.dim < 0
+                    target_batch_shape = [None] * (-f.dim - len(target_batch_shape)) + target_batch_shape
+                    if target_batch_shape[f.dim] is not None:
+                        raise ValueError('\n  '.join([
+                            'at site "{}" within iarange("", dim={}), dim collision'
+                            .format(msg["name"], f.name, f.dim),
+                            'Try setting dim arg in other iaranges.']))
+                    target_batch_shape[f.dim] = f.size
+            # If expected shape is None at an index, infer as either 1,
+            # or the actual shape starting from the right.
+            for i in range(-len(target_batch_shape)+1, 1):
+                if target_batch_shape[i] is None:
+                    target_batch_shape[i] = actual_batch_shape[i] if len(actual_batch_shape) > -i else 1
+            msg["fn"] = msg["fn"].expand(target_batch_shape)

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -8,7 +8,7 @@ class BroadcastMessenger(Messenger):
     `BroadcastMessenger` automatically broadcasts the batch shape of
     the stochastic function at a sample site when inside a single
     or nested iarange context. The existing `batch_shape` must be
-    broadcastable with the size of the :class::`pyro.iarange`
+    broadcastable with the size of the :class:`~pyro.iarange`
     contexts installed in the `cond_indep_stack`.
     """
     def _pyro_sample(self, msg):

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -206,6 +206,43 @@ def block(fn=None, hide=None, expose=None, hide_types=None, expose_types=None):
     return msngr(fn) if fn is not None else msngr
 
 
+def broadcast(fn=None):
+    """
+    Automatically broadcasts the batch shape of the stochastic function
+    at a sample site when inside a single or nested iarange context.
+    The existing `batch_shape` must be broadcastable with the size
+    of the :class:`~pyro.iarange` contexts installed in the
+    `cond_indep_stack`.
+
+    Notice how `model_automatic_broadcast` below automates expanding of
+    distribution batch shapes. This makes it easy to modularize a
+    Pyro model as the sub-components are agnostic of the wrapping
+    :class:`~pyro.iarange` contexts.
+
+    >>> import pyro
+    >>> import pyro.distributions as dist
+    >>> import pyro.poutine as poutine
+    >>>
+    >>> def model_broadcast_by_hand():
+    ...     with pyro.iarange("batch", 100, dim=-2):
+    ...         with pyro.iarange("components", 3, dim=-1)
+    ...             sample = pyro.sample("sample", dist.Bernoulli(torch.ones(3) * 0.5)
+    ...                                                .expand_by(100))
+    ...             assert sample.shape == torch.Size((100, 3))
+    ...     return sample
+    >>>
+    >>> @poutine.brodcast
+    >>> def model_automatic_broadcast():
+    ...     with pyro.iarange("batch", 100, dim=-2):
+    ...         with pyro.iarange("components", 3, dim=-1)
+    ...             sample = pyro.sample("sample", dist.Bernoulli(torch.tensor(0.5)))
+    ...             assert sample.shape == torch.Size((100, 3))
+    ...     return sample
+    """
+    msngr = BroadcastMessenger()
+    return msngr(fn) if fn is not None else msngr
+
+
 def escape(fn=None, escape_fn=None):
     """
     Given a callable that contains Pyro primitive calls,
@@ -318,18 +355,6 @@ def enum(fn=None, first_available_dim=None):
         dimension and all dimensions left may be used internally by Pyro.
     """
     msngr = EnumerateMessenger(first_available_dim=first_available_dim)
-    return msngr(fn) if fn is not None else msngr
-
-
-def broadcast(fn=None):
-    """
-    Automatically broadcasts the batch shape of the stochastic function
-    at a sample site when inside a single or nested iarange context.
-    The existing `batch_shape` must be
-    broadcastable with the size of the :class::`pyro.iarange`
-    contexts installed in the `cond_indep_stack`.
-    """
-    msngr = BroadcastMessenger()
     return msngr(fn) if fn is not None else msngr
 
 

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -54,6 +54,7 @@ from six.moves import xrange
 
 from pyro.poutine import util
 
+from .broadcast_messenger import BroadcastMessenger
 from .block_messenger import BlockMessenger
 from .condition_messenger import ConditionMessenger
 from .enumerate_messenger import EnumerateMessenger
@@ -317,6 +318,18 @@ def enum(fn=None, first_available_dim=None):
         dimension and all dimensions left may be used internally by Pyro.
     """
     msngr = EnumerateMessenger(first_available_dim=first_available_dim)
+    return msngr(fn) if fn is not None else msngr
+
+
+def broadcast(fn=None):
+    """
+    Automatically broadcasts the batch shape of the stochastic function
+    at a sample site when inside a single or nested iarange context.
+    The existing `batch_shape` must be
+    broadcastable with the size of the :class::`pyro.iarange`
+    contexts installed in the `cond_indep_stack`.
+    """
+    msngr = BroadcastMessenger()
     return msngr(fn) if fn is not None else msngr
 
 

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -206,6 +206,7 @@ def check_site_shape(site, max_iarange_nesting):
                     'at site "{}" within iarange("", dim={}), dim collision'.format(site["name"], f.name, f.dim),
                     'Try setting dim arg in other iaranges.']))
             expected_shape[f.dim] = f.size
+    expected_shape = [-1 if e is None else e for e in expected_shape]
 
     # Check for iarange stack overflow.
     if len(expected_shape) > max_iarange_nesting:
@@ -217,11 +218,6 @@ def check_site_shape(site, max_iarange_nesting):
     if max_iarange_nesting < len(actual_shape):
         actual_shape = actual_shape[len(actual_shape) - max_iarange_nesting:]
 
-    # Starting from the right, if expected size is None at an index,
-    # set it to the actual size if it exists, else 1.
-    for i in range(-len(expected_shape) + 1, 1):
-        if expected_shape[i] is None:
-            expected_shape[i] = actual_shape[i] if len(expected_shape) > -i else 1
     # Check for incorrect iarange placement on the right of max_iarange_nesting.
     for actual_size, expected_size in zip_longest(reversed(actual_shape), reversed(expected_shape), fillvalue=1):
         if expected_size != -1 and expected_size != actual_size:

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -206,7 +206,6 @@ def check_site_shape(site, max_iarange_nesting):
                     'at site "{}" within iarange("", dim={}), dim collision'.format(site["name"], f.name, f.dim),
                     'Try setting dim arg in other iaranges.']))
             expected_shape[f.dim] = f.size
-    expected_shape = [1 if e is None else e for e in expected_shape]
 
     # Check for iarange stack overflow.
     if len(expected_shape) > max_iarange_nesting:
@@ -218,6 +217,11 @@ def check_site_shape(site, max_iarange_nesting):
     if max_iarange_nesting < len(actual_shape):
         actual_shape = actual_shape[len(actual_shape) - max_iarange_nesting:]
 
+    # If expected shape is None at an index, infer as either 1,
+    # or the actual shape starting from the right.
+    for i in range(-len(expected_shape) + 1, 1):
+        if expected_shape[i] is None:
+            expected_shape[i] = actual_shape[i] if len(expected_shape) > -i else 1
     # Check for incorrect iarange placement on the right of max_iarange_nesting.
     for actual_size, expected_size in zip_longest(reversed(actual_shape), reversed(expected_shape), fillvalue=1):
         if expected_size != -1 and expected_size != actual_size:

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -217,8 +217,8 @@ def check_site_shape(site, max_iarange_nesting):
     if max_iarange_nesting < len(actual_shape):
         actual_shape = actual_shape[len(actual_shape) - max_iarange_nesting:]
 
-    # If expected shape is None at an index, infer as either 1,
-    # or the actual shape starting from the right.
+    # Starting from the right, if expected size is None at an index,
+    # set it to the actual size if it exists, else 1.
     for i in range(-len(expected_shape) + 1, 1):
         if expected_shape[i] is None:
             expected_shape[i] = actual_shape[i] if len(expected_shape) > -i else 1

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -13,6 +13,7 @@ from pyro.distributions.testing import fakes
 from pyro.infer import (SVI, JitTrace_ELBO, JitTraceEnum_ELBO, JitTraceGraph_ELBO, Trace_ELBO, TraceEnum_ELBO,
                         TraceGraph_ELBO)
 from pyro.optim import Adam
+import pyro.poutine as poutine
 from tests.common import assert_equal, xfail_param
 
 logger = logging.getLogger(__name__)
@@ -73,31 +74,30 @@ def test_iarange(Elbo, reparameterized):
     Normal = dist.Normal if reparameterized else fakes.NonreparameterizedNormal
 
     def model():
-        x = data.unsqueeze(-1).expand(-1, num_particles)
-        data_iarange = pyro.iarange("data", len(data), dim=-2)
-        particles_iarange = pyro.iarange("particles", num_particles, dim=-1)
+        particles_iarange = pyro.iarange("particles", num_particles, dim=-2)
+        data_iarange = pyro.iarange("data", len(data), dim=-1)
 
         pyro.sample("nuisance_a", Normal(0, 1))
         with particles_iarange, data_iarange:
-            z = pyro.sample("z", Normal(0, 1).expand_by(x.shape))
+            z = pyro.sample("z", Normal(0, 1))
         pyro.sample("nuisance_b", Normal(2, 3))
         with data_iarange, particles_iarange:
-            pyro.sample("x", Normal(z, 1), obs=x)
+            pyro.sample("x", Normal(z, 1), obs=data)
         pyro.sample("nuisance_c", Normal(4, 5))
 
     def guide():
-        loc = pyro.param("loc", lambda: torch.zeros(len(data), requires_grad=True))
-        scale = pyro.param("scale", lambda: torch.tensor([1.0], requires_grad=True))
-        mus = loc.unsqueeze(-1).expand(-1, num_particles)
+        loc = pyro.param("loc", torch.zeros(len(data)))
+        scale = pyro.param("scale", torch.tensor([1.]))
 
         pyro.sample("nuisance_c", Normal(4, 5))
-        with pyro.iarange("particles", num_particles):
-            with pyro.iarange("data", len(data)):
-                pyro.sample("z", Normal(mus, scale))
+        with pyro.iarange("particles", num_particles, dim=-2):
+            with pyro.iarange("data", len(data), dim=-1):
+                pyro.sample("z", Normal(loc, scale))
         pyro.sample("nuisance_b", Normal(2, 3))
         pyro.sample("nuisance_a", Normal(0, 1))
 
     optim = Adam({"lr": 0.1})
+    model, guide = poutine.broadcast(model), poutine.broadcast(guide)
     inference = SVI(model, guide, optim, loss=Elbo(strict_enumeration_warning=False))
     inference.loss_and_grads(model, guide)
     params = dict(pyro.get_param_store().named_parameters())

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -829,7 +829,8 @@ def test_enum_discrete_non_enumerated_iarange_ok(enumerate_):
         assert_ok(model, model, TraceEnum_ELBO(max_iarange_nesting=1))
 
 
-def test_iarange_shape_broadcasting():
+@pytest.mark.parametrize("times", [1, 2], ids=["applied_once", "applied_twice"])
+def test_iarange_shape_broadcasting(times):
     data = torch.ones(1000, 2)
 
     def model():
@@ -846,7 +847,8 @@ def test_iarange_shape_broadcasting():
                 pyro.sample("p", dist.Beta(torch.tensor(1.1), torch.tensor(1.1)))
 
     pyro.clear_param_store()
-    model, guide = poutine.broadcast(model), poutine.broadcast(guide)
+    for _ in range(times):
+        model, guide = poutine.broadcast(model), poutine.broadcast(guide)
     assert_ok(model, guide, Trace_ELBO())
 
 

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -855,6 +855,8 @@ def test_iarange_shape_broadcasting(times):
 @pytest.mark.parametrize('enumerate_', [None, "sequential", "parallel"])
 def test_enum_discrete_iarange_shape_broadcasting_ok(enumerate_):
 
+    @poutine.broadcast
+    @config_enumerate(default=enumerate_)
     def model():
         x_iarange = pyro.iarange("x_iarange", 10, 5, dim=-1)
         y_iarange = pyro.iarange("y_iarange", 11, 6, dim=-2)
@@ -875,6 +877,5 @@ def test_enum_discrete_iarange_shape_broadcasting_ok(enumerate_):
                 else:
                     assert d.shape == torch.Size((50, 6, 5))
 
-    model = config_enumerate(poutine.broadcast(model), default=enumerate_)
     assert_ok(model, model, TraceEnum_ELBO(max_iarange_nesting=3,
                                            strict_enumeration_warning=(enumerate_ == "parallel")))


### PR DESCRIPTION
This makes a small change to use the `expand` logic from #1119 to implement implicit broadcasting via a `broadcast` poutine.

This should be safe to merge as this logic will not be exercised until the user wraps their model/guides inside `poutine.broadcast`. We could later decide to reuse this to do the broadcasting behind the scenes for parallelizing over `num_particles`, for instance. Or use our learnings to build more composable broadcasting effects as @eb8680 mentioned in #1115. 

e.g. Using @fritzo's example from #1119
```py
X, Y = 320, 200
x_axis = pyro.iarange("x_axis", X, dim=-2)
y_axis = pyro.iarange("y_axis", Y, dim=-1)
with x_axis:
    x_noise = pyro.sample("x", dist.Normal(0, 1).expand_by([X, 1])) # .expand_by() suffices
with y_axis:
    y_noise = pyro.sample("y", dist.Normal(0, 1).expand_by([Y]))    # .expand_by() suffices
with x_axis, y_axis:
    yx = pyro.sample("yx", dist.Normal(y_noise, 1).expand_by([X])) # .expand_by() suffices
    xy = pyro.sample("xy", dist.Normal(x_noise, 1).expand([X, Y])) # .expand() is needed
    ...
```

we do not need to `expand` or `expand_by` if the model is wrapped inside `poutine.broadcast`:

```py
x_axis = pyro.iarange("x_axis", X, dim=-2)
y_axis = pyro.iarange("y_axis", Y, dim=-1)
with x_axis:
    x_noise = pyro.sample("x", dist.Normal(0, 1))
    assert x_noise.shape == torch.Size((320, 1))
with y_axis:
    y_noise = pyro.sample("y", dist.Normal(0, 1))
    assert y_noise.shape == torch.Size((200,))
with x_axis, y_axis:
    yx = pyro.sample("yx", dist.Normal(y_noise, 1))
    assert yx.shape == torch.Size((320, 200))
    xy = pyro.sample("xy", dist.Normal(x_noise, 1))
    assert xy.shape == torch.Size((320, 200))
```

 - Note that this requires the user to line up the different `iarange`s correctly via the `dim` arg.
 - **Tests**: Added a couple of tests to `test_valid_models`. Also modified one of the gradient tests to use the broadcasting logic.
