### PR TITLE
Implement AutoDelta and AutoLowRankMultivariateNormal

### DIFF
--- a/docs/source/contrib.autoguide.rst
+++ b/docs/source/contrib.autoguide.rst
@@ -19,6 +19,14 @@ AutoGuideList
     :special-members: __call__
     :show-inheritance:
 
+AutoDelta
+---------
+.. autoclass:: pyro.contrib.autoguide.AutoDelta
+    :members:
+    :undoc-members:
+    :special-members: __call__
+    :show-inheritance:
+
 AutoContinuous
 --------------
 .. autoclass:: pyro.contrib.autoguide.AutoContinuous
@@ -38,6 +46,14 @@ AutoMultivariateNormal
 AutoDiagonalNormal
 ------------------
 .. autoclass:: pyro.contrib.autoguide.AutoDiagonalNormal
+    :members:
+    :undoc-members:
+    :special-members: __call__
+    :show-inheritance:
+
+AutoLowRankMultivariateNormal
+-----------------------------
+.. autoclass:: pyro.contrib.autoguide.AutoLowRankMultivariateNormal
     :members:
     :undoc-members:
     :special-members: __call__

--- a/tests/contrib/autoguide/test_advi.py
+++ b/tests/contrib/autoguide/test_advi.py
@@ -7,13 +7,18 @@ import torch
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-from pyro.contrib.autoguide import AutoDiagonalNormal, AutoDiscreteParallel, AutoGuideList, AutoMultivariateNormal
+from pyro.contrib.autoguide import (AutoDelta, AutoDiagonalNormal, AutoDiscreteParallel, AutoGuideList,
+                                    AutoLowRankMultivariateNormal, AutoMultivariateNormal)
 from pyro.infer import SVI, Trace_ELBO, TraceEnum_ELBO, TraceGraph_ELBO
 from pyro.optim import Adam
 from tests.common import assert_equal
 
 
-@pytest.mark.parametrize("auto_class", [AutoMultivariateNormal, AutoDiagonalNormal])
+@pytest.mark.parametrize("auto_class", [
+    AutoDiagonalNormal,
+    AutoMultivariateNormal,
+    AutoLowRankMultivariateNormal,
+])
 def test_scores(auto_class):
     def model():
         pyro.sample("z", dist.Normal(0.0, 1.0))
@@ -32,7 +37,12 @@ def test_scores(auto_class):
 
 
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
-@pytest.mark.parametrize("auto_class", [AutoMultivariateNormal, AutoDiagonalNormal])
+@pytest.mark.parametrize("auto_class", [
+    AutoDelta,
+    AutoDiagonalNormal,
+    AutoMultivariateNormal,
+    AutoLowRankMultivariateNormal,
+])
 def test_shapes(auto_class, Elbo):
 
     def model():
@@ -48,7 +58,12 @@ def test_shapes(auto_class, Elbo):
 
 
 @pytest.mark.xfail(reason="irange is not yet supported")
-@pytest.mark.parametrize('auto_class', [AutoDiagonalNormal, AutoMultivariateNormal])
+@pytest.mark.parametrize('auto_class', [
+    AutoDelta,
+    AutoDiagonalNormal,
+    AutoMultivariateNormal,
+    AutoLowRankMultivariateNormal,
+])
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO])
 def test_irange_smoke(auto_class, Elbo):
 
@@ -70,7 +85,12 @@ def test_irange_smoke(auto_class, Elbo):
     infer.step()
 
 
-@pytest.mark.parametrize("auto_class", [AutoMultivariateNormal, AutoDiagonalNormal])
+@pytest.mark.parametrize("auto_class", [
+    AutoDelta,
+    AutoDiagonalNormal,
+    AutoMultivariateNormal,
+    AutoLowRankMultivariateNormal,
+])
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
 def test_median(auto_class, Elbo):
 
@@ -80,17 +100,20 @@ def test_median(auto_class, Elbo):
         pyro.sample("z", dist.Beta(2.0, 2.0))
 
     guide = auto_class(model)
-    infer = SVI(model, guide, Adam({'lr': 0.01}), Elbo(strict_enumeration_warning=False))
+    infer = SVI(model, guide, Adam({'lr': 0.05}), Elbo(strict_enumeration_warning=False))
     for _ in range(100):
         infer.step()
 
     median = guide.median()
     assert_equal(median["x"], torch.tensor(0.0), prec=0.1)
-    assert_equal(median["y"], torch.tensor(1.0), prec=0.1)
+    if auto_class is AutoDelta:
+        assert_equal(median["y"], torch.tensor(-1.0).exp(), prec=0.1)
+    else:
+        assert_equal(median["y"], torch.tensor(1.0), prec=0.1)
     assert_equal(median["z"], torch.tensor(0.5), prec=0.1)
 
 
-@pytest.mark.parametrize("auto_class", [AutoMultivariateNormal, AutoDiagonalNormal])
+@pytest.mark.parametrize("auto_class", [AutoDiagonalNormal, AutoMultivariateNormal, AutoLowRankMultivariateNormal])
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
 def test_quantiles(auto_class, Elbo):
 
@@ -126,7 +149,12 @@ def test_quantiles(auto_class, Elbo):
     assert quantiles["z"][2] < 0.99
 
 
-@pytest.mark.parametrize("continuous_class", [AutoMultivariateNormal, AutoDiagonalNormal])
+@pytest.mark.parametrize("continuous_class", [
+    AutoDelta,
+    AutoDiagonalNormal,
+    AutoMultivariateNormal,
+    AutoLowRankMultivariateNormal,
+])
 def test_discrete_parallel(continuous_class):
     K = 2
     data = torch.tensor([0., 1., 10., 11., 12.])


### PR DESCRIPTION
Resolves #570 

This implements two new automatic guides.

## `AutoDelta` for MAP inference

This is especially convenient for e.g. combining MAP estimation of global parameters with `Auto*Normal` estimation of local parameters.

## `AutoLowRankMultivariateNormal`

`AutoLowRankMultivariateNormal` has mid-range capacity, between `AutoDiagonalNormal` and `AutoMultivariateNormal`. As a design choice, I've initialized `D` and `W` similarly to the initialization of the `Coregionalize` kernel. This allows us to closely compare two types of models: Hierarchical generative models with ADVI guides -versus- GP models with Coregionalize kernels. I'm attempting to compare these two model classes on multiple-time-series forecasting.

## Tested

- added both classes to existing parametrized tests