### PR TITLE
Implement interface for higher-order optimizers

### DIFF
--- a/docs/source/pyro.optim.txt
+++ b/docs/source/pyro.optim.txt
@@ -4,7 +4,9 @@ Pyro Optimizers
 .. automodule:: pyro.optim.optim
     :members:
     :undoc-members:
+    :special-members: __call__
     :show-inheritance:
+    :member-order: bysource
 
 PyTorch Optimizers
 ------------------
@@ -12,4 +14,16 @@ PyTorch Optimizers
 .. automodule:: pyro.optim.pytorch_optimizers
     :members:
     :undoc-members:
+    :special-members: __call__
     :show-inheritance:
+    :member-order: bysource
+
+Higher-Order Optimizers
+-----------------------
+
+.. automodule:: pyro.optim.multi
+    :members:
+    :undoc-members:
+    :special-members: __call__
+    :show-inheritance:
+    :member-order: bysource

--- a/pyro/optim/multi.py
+++ b/pyro/optim/multi.py
@@ -73,11 +73,7 @@ class PyroMultiOptimizer(MultiOptimizer):
         self.optim = optim
 
     def step(self, loss, params):
-        names = []
-        values = []
-        for name, value in params.items():
-            names.append(name)
-            values.append(value)
+        values = params.values()
         grads = torch.autograd.grad(loss, values, create_graph=True)
         for x, g in zip(values, grads):
             x.grad = g

--- a/pyro/optim/multi.py
+++ b/pyro/optim/multi.py
@@ -1,0 +1,114 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+
+from pyro.ops.newton import newton_step_2d
+from pyro.optim.optim import PyroOptim
+
+
+class MultiOptimizer(object):
+    """
+    Base class of optimizers that make use of higher-order derivatives.
+
+    Higher-order optimizers generally use :func:`torch.autograd.grad` rather
+    than :meth:`torch.Tensor.backward`, and therefore require a different
+    interface from usual Pyro and PyTorch optimizers. In this interface,
+    the :meth:`step` method inputs a ``loss`` tensor to be differentiated,
+    and backpropagation is triggered one or more times inside the optimizer.
+
+    Derived classes must implement :meth:`step` to compute derivatives and
+    update parameters in-place.
+
+    Example::
+
+        tr = poutine.trace(model).get_trace(*args, **kwargs)
+        loss = -tr.log_prob()
+        params = {name: pyro.param(name).unconstrained()
+                  for name in pyro.get_param_store().get_all_param_names()}
+        optim.step(loss, params)
+    """
+    def step(self, loss, params):
+        """
+        Performs an optimization step on parameters given a differentiable
+        ``loss`` tensor.
+
+        :param torch.Tensor loss: A differentiable tensor to be minimized.
+            Some optimizers require this to be differentiable multiple
+            times.
+        :param dict params: A dictionary mapping param name to unconstrained
+            value as stored in the param store.
+        """
+        raise NotImplementedError
+
+
+class PyroMultiOptimizer(MultiOptimizer):
+    """
+    Facade to wrap :class:`~pyro.optim.optim.PyroOptim` objects
+    in a :class:`MultiOptimizer` interface.
+    """
+    def __init__(self, optim):
+        self.optim = optim
+
+    def step(self, loss, params):
+        names = []
+        values = []
+        for name, value in params.items():
+            names.append(name)
+            values.append(value)
+        grads = torch.autograd.grad(loss, values, create_graph=True)
+        for x, g in zip(values, grads):
+            x.grad = g
+        self.optim(values)
+
+
+class TorchMultiOptimizer(PyroMultiOptimizer):
+    """
+    Facade to wrap :class:`~torch.optim.Optimizer` objects
+    in a :class:`MultiOptimizer` interface.
+    """
+    def __init__(self, optim_constructor, optim_args):
+        optim = PyroOptim(optim_constructor, optim_args)
+        super(TorchMultiOptimizer, self).__init__(optim)
+
+
+class MixedMultiOptimizer(MultiOptimizer):
+    """
+    Container class to combine different :class:`MultiOptimizer` instances for
+    different parameters.
+
+    :param list parts: A list of ``(names, optim)`` pairs, where each
+        ``names`` is a list of parameter names, and each ``optim`` is a
+        :class:`MultiOptimizer` object to be used for the named parameters.
+        Together the ``names`` should partition up all desired parameters to
+        optimize.
+    """
+    def __init__(self, parts):
+        self.parts = list(parts)
+
+    def step(self, loss, params):
+        for names_part, optim in self.parts:
+            optim.step(loss, {name: params[name] for name in names_part})
+
+
+class Newton2d(MultiOptimizer):
+    """
+    Implementation of :class:`MultiOptimizer` that performs a Newton update
+    on batched 2d variables, optionally regularizing via a per-parameter
+    ``trust_radius``. See :func:`~pyro.ops.newton.newton_step_2d` for details.
+
+    :param dict trust_radii: a dict mapping parameter name to radius of trust
+        region. Missing names will use unregularized Newton update, equivalent
+        to infinite trust radius.
+    """
+    def __init__(self, trust_radii={}):
+        self.trust_radii = trust_radii
+
+    def step(self, loss, params):
+        updated_values = {}
+        for name, value in params.items():
+            trust_radius = self.trust_radii.get(name)
+            updated_value, cov = newton_step_2d(loss, value, trust_radius)
+            updated_values[name] = updated_value.detach()
+        for name, value in params.items():
+            with torch.no_grad():
+                value[...] = updated_values[name]

--- a/tests/optim/test_multi.py
+++ b/tests/optim/test_multi.py
@@ -1,0 +1,49 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+import torch
+from torch.distributions import constraints
+
+import pyro
+import pyro.distributions as dist
+import pyro.optim
+import pyro.poutine as poutine
+from pyro.optim.multi import MixedMultiOptimizer, Newton2d, PyroMultiOptimizer, TorchMultiOptimizer
+from tests.common import assert_equal
+
+FACTORIES = [
+    lambda: PyroMultiOptimizer(pyro.optim.Adam({'lr': 0.05})),
+    lambda: TorchMultiOptimizer(torch.optim.Adam, {'lr': 0.05}),
+    lambda: Newton2d(trust_radii={'z': 0.2}),
+    lambda: MixedMultiOptimizer([(['y'], PyroMultiOptimizer(pyro.optim.Adam({'lr': 0.05}))),
+                                 (['x', 'z'], Newton2d())]),
+]
+
+
+@pytest.mark.parametrize('factory', FACTORIES)
+def test_optimizers(factory):
+    optim = factory()
+
+    def model(loc, cov):
+        x = pyro.param("x", torch.randn(2))
+        y = pyro.param("y", torch.randn(3, 2))
+        z = pyro.param("z", torch.randn(4, 2).abs(), constraint=constraints.greater_than(-1))
+        pyro.sample("obs_x", dist.MultivariateNormal(loc, cov), obs=x)
+        with pyro.iarange("y_iarange", 3):
+            pyro.sample("obs_y", dist.MultivariateNormal(loc, cov), obs=y)
+        with pyro.iarange("z_iarange", 4):
+            pyro.sample("obs_z", dist.MultivariateNormal(loc, cov), obs=z)
+
+    loc = torch.tensor([-0.5, 0.5])
+    cov = torch.tensor([[1.0, 0.09], [0.09, 0.1]])
+    for step in range(100):
+        tr = poutine.trace(model).get_trace(loc, cov)
+        loss = -tr.log_prob_sum()
+        params = {name: pyro.param(name).unconstrained() for name in ["x", "y", "z"]}
+        optim.step(loss, params)
+
+    for name in ["x", "y", "z"]:
+        actual = pyro.param(name)
+        expected = loc.expand(actual.shape)
+        assert_equal(actual, expected, prec=1e-2,
+                     msg='{} in correct: {} vs {}'.format(name, actual, expected))


### PR DESCRIPTION
This implements an interface compatible with higher-order optimizers, those that use not only gradient information but also some number of Hessian-vector products. The motivating optimizer is `Newton2d`. Additionally we've implemented wrappers for Pyro optimizers and PyTorch optimizers, and added a container class to apply different optimizers to different parameters.

Docs: http://fritzo.org/temp/pyro/html/optimization.html#module-pyro.optim.multi

## Remaining work

- [x] support differentiation through the optimization process
- [ ] expose `cov` return value from `newton_step_2d()`

## Tested

- added convergence tests for all new classes. tests run in under 2 seconds.

Pair coded with @eb8680 