### PR TITLE
fix broken links on pyro.ai

### DIFF
--- a/tutorial/source/tensor_shapes.ipynb
+++ b/tutorial/source/tensor_shapes.ipynb
@@ -22,14 +22,14 @@
     "  - use ellipsis notation like `pixel = image[..., i, j]`\n",
     "  \n",
     "#### Table of Contents\n",
-    "- [Distribution shapes](#dist-shapes)\n",
-    "  - [Examples](#dist-examples)\n",
-    "  - [Reshaping distributions](#dist-reshape)\n",
-    "  - [It is always safe to assume dependence](#assume-dependence)\n",
-    "- [Declaring independence with iarange](#iarange)\n",
-    "- [Subsampling inside iarange](#subsampling)\n",
-    "- [Broadcasting to allow Parallel Enumeration](#subsampling)\n",
-    "  - [Writing parallelizable code](#parallelizable)"
+    "- [Distribution shapes](#Distributions-shapes:-batch_shape-and-event_shape)\n",
+    "  - [Examples](#Examples)\n",
+    "  - [Reshaping distributions](#Reshaping-distributions)\n",
+    "  - [It is always safe to assume dependence](#It-is-always-safe-to-assume-dependence)\n",
+    "- [Declaring independence with iarange](#Declaring-independent-dims-with-iarange)\n",
+    "- [Subsampling inside iarange](#Subsampling-tensors-inside-an-iarange)\n",
+    "- [Broadcasting to allow Parallel Enumeration](#Broadcasting-to-allow-parallel-enumeration)\n",
+    "  - [Writing parallelizable code](#Writing-parallelizable-code)"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Distributions shapes: `batch_shape` and `event_shape` <a class=\"anchor\" id=\"dist-shapes\"></a>\n",
+    "## Distributions shapes: `batch_shape` and `event_shape` <a class=\"anchor\" id=\"Distributions-shapes:-batch_shape-and-event_shape\"></a>\n",
     "\n",
     "PyTorch `Tensor`s have a single `.shape` attribute, but `Distribution`s have two shape attributions with special meaning: `.batch_shape` and `.event_shape`. These two combine to define the total shape of a sample\n",
     "```py\n",
@@ -83,7 +83,7 @@
     "```\n",
     "For example univariate distributions have empty event shape (because each number is an independent event). Distributions over vectors like `MultivariateNormal` have `len(event_shape) == 1`. Distributions over matrices like `InverseWishart` have `len(event_shape) == 2`.\n",
     "\n",
-    "### Examples <a class=\"anchor\" id=\"dist-examples\"></a>\n",
+    "### Examples <a class=\"anchor\" id=\"Examples\"></a>\n",
     "\n",
     "The simplest distribution shape is a single univariate distribution."
    ]
@@ -170,7 +170,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Reshaping distributions <a class=\"anchor\" id=\"dist-reshape\"></a>\n",
+    "### Reshaping distributions <a class=\"anchor\" id=\"Reshaping-distributions\"></a>\n",
     "\n",
     "In Pyro you can treat a univariate distribution as multivariate by calling the `.independent(_)` property."
    ]
@@ -195,7 +195,7 @@
    "source": [
     "While you work with Pyro programs, keep in mind that samples have shape `batch_shape + event_shape`, whereas `.log_prob(x)` values have shape `batch_shape`. You'll need to ensure that `batch_shape` is carefully controlled by either trimming it down with `.independent(n)` or by declaring dimensions as independent via `pyro.iarange`.\n",
     "\n",
-    "### It is always safe to assume dependence <a class=\"anchor\" id=\"assume-dependence\"></a>\n",
+    "### It is always safe to assume dependence <a class=\"anchor\" id=\"It-is-always-safe-to-assume-dependence\"></a>\n",
     "\n",
     "Often in Pyro we'll declare some dimensions as dependent even though they are in fact independent, e.g.\n",
     "```py\n",
@@ -213,7 +213,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Declaring independent dims with `iarange` <a class=\"anchor\" id=\"iarange\"></a>\n",
+    "## Declaring independent dims with `iarange` <a class=\"anchor\" id=\"Declaring-independent-dims-with-iarange\"></a>\n",
     "\n",
     "Pyro models can use the context manager [pyro.iarange](http://docs.pyro.ai/en/dev/primitives.html#pyro.iarange) to declare that certain batch dimensions are independent. Inference algorithms can then take advantage of this independence to e.g. construct lower variance gradient estimators or to enumerate in linear space rather than exponential space. An example of an independent dimension is the index over data in a minibatch: each datum should be independent of all others.\n",
     "\n",
@@ -320,7 +320,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Subsampling tensors inside an `iarange` <a class=\"anchor\" id=\"subsampling\"></a>\n",
+    "## Subsampling tensors inside an `iarange` <a class=\"anchor\" id=\"Subsampling-tensors-inside-an-iarange\"></a>\n",
     "\n",
     "One of the main uses of [iarange](http://docs.pyro.ai/en/dev/primitives.html#pyro.iarange) is to subsample data. This is possible within an `iarange` because data are independent, so the expected value of the loss on, say, half the data should be half the expected loss on the full data.\n",
     "\n",
@@ -352,7 +352,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Broadcasting to allow parallel enumeration <a class=\"anchor\" id=\"enumerate\"></a>\n",
+    "## Broadcasting to allow parallel enumeration <a class=\"anchor\" id=\"Broadcasting-to-allow-parallel-enumeration\"></a>\n",
     "\n",
     "Pyro 0.2 introduces the ability to enumerate discrete latent variables in parallel. This can significantly reduce the variance of gradient estimators when learning a posterior via [SVI](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.svi.SVI).\n",
     "\n",
@@ -451,7 +451,7 @@
     "            |   |                             .independent(1))\n",
     "```\n",
     "\n",
-    "### Writing parallelizable code <a class=\"anchor\" id=\"parallelizable\"></a>\n",
+    "### Writing parallelizable code <a class=\"anchor\" id=\"Writing-parallelizable-code\"></a>\n",
     "\n",
     "It can be tricky to write Pyro models that correctly handle parallelized sample sites. Two tricks help: [broadcasting](http://pytorch.org/docs/master/notes/broadcasting.html) and [ellipsis slicing](http://python-reference.readthedocs.io/en/latest/docs/brackets/ellipsis.html). Let's look at a contrived model to see how these work in practice. Our aim is to write a model that works both with and without enumeration."
    ]


### PR DESCRIPTION
anchor names have to match the header title in order for the html to work correctly. didnt catch this one earlier, but [it works now](http://pyro.ai/examples/tensor_shapes.html)