### PR TITLE
Enable doctests to test code snippets in docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ raw
 logs
 *.log
 
+# Data
+*.data
+
 # Runtime data
 pids
 *.pid

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
           script:
               - pip install -r docs/requirements.txt
               - make docs
+              - make doctest
         - stage: perf
           if: type = cron
           python: 2.7

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ scrub: FORCE
 	find tutorial -name "*.ipynb" | xargs python tutorial/source/cleannb.py
 
 doctest: FORCE
-    pytest --doctest-modules -p no:warnings pyro
+	pytest --doctest-modules -p no:warnings pyro
 
 format: FORCE
 	isort --recursive *.py pyro/ examples/ tests/ profiler/*.py docs/source/conf.py

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ scrub: FORCE
 	find tutorial -name "*.ipynb" | xargs python -m nbstripout --keep-output --keep-count
 	find tutorial -name "*.ipynb" | xargs python tutorial/source/cleannb.py
 
+doctest: FORCE
+    pytest --doctest-modules -p no:warnings pyro
+
 format: FORCE
 	isort --recursive *.py pyro/ examples/ tests/ profiler/*.py docs/source/conf.py
 
@@ -32,7 +35,7 @@ profile: ref=dev
 profile: FORCE
 	bash scripts/profile_model.sh ${ref} ${models}
 
-test: lint docs FORCE
+test: lint docs doctest FORCE
 	pytest -vx -n auto --stage unit
 
 test-examples: lint FORCE

--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -306,9 +306,12 @@ class Warping(Transforming):
     We can take advantage of :math:`f` to combine a Gaussian Process kernel with a deep
     learning architecture. For example:
 
+        >>> import torch
+        >>> import pyro.contrib.gp as gp
+
         >>> linear = torch.nn.Linear(10, 3)
-        # register its parameters to Pyro's ParamStore and wrap it by lambda
-        # to call the primitive pyro.module each time we use the linear function
+        >>> # register its parameters to Pyro's ParamStore and wrap it by lambda
+        >>> # to call the primitive pyro.module each time we use the linear function
         >>> pyro_linear_fn = lambda x: pyro.module("linear", linear)(x)
         >>> kernel = gp.kernels.Matern52(input_dim=3, lengthscale=torch.ones(3))
         >>> warped_kernel = gp.kernels.Warping(kernel, pyro_linear_fn)

--- a/pyro/contrib/gp/models/gplvm.py
+++ b/pyro/contrib/gp/models/gplvm.py
@@ -33,12 +33,13 @@ class GPLVM(Parameterized):
         # to a tensor X of shape 150x2, we will use GPLVM.
         # First, define the initial values for X_loc parameter:
         >>> import pyro.contrib.gp as gp
-        >>> import observations
 
         >>> X_loc = torch.zeros(150, 2)
-        >>> y, _, _ = observations.iris('.')
-        >>> y = torch.from_numpy(y).float().t()
-
+        >>> # Simulate iris data.
+        >>> y = torch.stack([dist.Normal(4.8, 0.1).sample((150,)),
+        ...                 dist.Normal(3.2, 0.3).sample((150,)),
+        ...                 dist.Normal(1.5, 0.4).sample((150,)),
+        ...                 dist.Exponential(0.5).sample((150,))])
         >>> # Then, define a Gaussian Process model with input X_loc and output y:
         >>> kernel = gp.kernels.RBF(input_dim=2, lengthscale=torch.ones(2))
         >>> Xu = torch.zeros(20, 2)  # initial inducing inputs of sparse model

--- a/pyro/contrib/gp/models/gplvm.py
+++ b/pyro/contrib/gp/models/gplvm.py
@@ -32,15 +32,21 @@ class GPLVM(Parameterized):
         # With y is the 2D Iris data of shape 150x4 and we want to reduce its dimension
         # to a tensor X of shape 150x2, we will use GPLVM.
         # First, define the initial values for X_loc parameter:
+        >>> import pyro.contrib.gp as gp
+        >>> import observations
+
         >>> X_loc = torch.zeros(150, 2)
-        # Then, define a Gaussian Process model with input X_loc and output y:
+        >>> y, _, _ = observations.iris('.')
+        >>> y = torch.from_numpy(y).float().t()
+
+        >>> # Then, define a Gaussian Process model with input X_loc and output y:
         >>> kernel = gp.kernels.RBF(input_dim=2, lengthscale=torch.ones(2))
         >>> Xu = torch.zeros(20, 2)  # initial inducing inputs of sparse model
         >>> gpmodel = gp.models.SparseGPRegression(X_loc, y, kernel, Xu)
-        # Finally, wrap gpmodel by GPLVM, optimize, and get the "learned" mean of X:
+        >>> # Finally, wrap gpmodel by GPLVM, optimize, and get the "learned" mean of X:
         >>> gplvm = gp.models.GPLVM(gpmodel)
-        >>> gplvm.optimize()
-        >>> X = gplvm.get_param("X_loc")
+        >>> gplvm.optimize()  # doctest: +SKIP
+        >>> X = gplvm.get_param("X_loc")  # doctest: +SKIP
 
     Reference:
 

--- a/pyro/contrib/gp/models/model.py
+++ b/pyro/contrib/gp/models/model.py
@@ -41,6 +41,7 @@ class GPModel(Parameterized):
         >>> from pyro.infer.mcmc import HMC, MCMC
         >>> import pyro.distributions as dist
         >>> from pyro.params import param_with_module_name
+        >>> import torch
 
         >>> X = torch.tensor([[1., 5, 3], [4, 3, 7]])
         >>> y = torch.tensor([2., 1])
@@ -147,6 +148,7 @@ class GPModel(Parameterized):
             >>> import pyro
             >>> import pyro.contrib.gp as gp
             >>> import pyro.distributions as dist
+            >>> import torch
 
             >>> X = torch.tensor([[1., 5, 3], [4, 3, 7]])
             >>> y = torch.tensor([2., 1])

--- a/pyro/contrib/named.py
+++ b/pyro/contrib/named.py
@@ -12,6 +12,7 @@ This module provides three container data structures ``named.Object``,
 nested in each other. Together they track the address of each piece of data
 in each data structure, so that this address can be used as a Pyro site. For
 example::
+
     >>> import pyro.contrib.named as named
     >>> import pyro.distributions as dist
     >>> import torch

--- a/pyro/contrib/named.py
+++ b/pyro/contrib/named.py
@@ -12,6 +12,9 @@ This module provides three container data structures ``named.Object``,
 nested in each other. Together they track the address of each piece of data
 in each data structure, so that this address can be used as a Pyro site. For
 example::
+    >>> import pyro.contrib.named as named
+    >>> import pyro.distributions as dist
+    >>> import torch
 
     >>> state = named.Object("state")
     >>> print(str(state))
@@ -38,8 +41,8 @@ alias Pyro statements. For example::
     >>> state = named.Object("state")
     >>> loc = state.loc.param_(torch.zeros(1, requires_grad=True))
     >>> scale = state.scale.param_(torch.ones(1, requires_grad=True))
-    >>> z = state.z.sample_(dist.normal, loc, scale)
-    >>> state.x.observe_(dist.normal, z, loc, scale)
+    >>> z = state.z.sample_(dist.Normal(loc, scale))
+    >>> obs = state.x.sample_(dist.Normal(loc, scale), obs=z)
 
 For deeper examples of how these can be used in model code, see the
 `Tree Data <https://github.com/uber/pyro/blob/dev/examples/contrib/named/tree_data.py>`_

--- a/pyro/distributions/binomial.py
+++ b/pyro/distributions/binomial.py
@@ -23,6 +23,7 @@ class Binomial(torch.distributions.Distribution, TorchDistributionMixin):
 
         >>> m = Binomial(100, torch.Tensor([0 , .2, .8, 1]))
         >>> x = m.sample()
+        >>> print(x)  # doctest: +SKIP
          0
          22
          71
@@ -31,6 +32,7 @@ class Binomial(torch.distributions.Distribution, TorchDistributionMixin):
 
         >>> m = Binomial(torch.Tensor([[5.], [10.]]), torch.Tensor([0.5, 0.8]))
         >>> x = m.sample()
+        >>> print(x)  # doctest: +SKIP
          4  5
          7  6
         [torch.FloatTensor of size (2,2)]

--- a/pyro/distributions/iaf.py
+++ b/pyro/distributions/iaf.py
@@ -16,9 +16,12 @@ class InverseAutoregressiveFlow(Transform):
 
     Example usage::
 
-    >>> base_dist = Normal(...)
-    >>> iaf = InverseAutoregressiveFlow(...)
-    >>> pyro.module("my_iaf", iaf.module)
+    >>> import pyro
+    >>> from pyro.distributions import Normal, TransformedDistribution
+
+    >>> base_dist = Normal(torch.zeros(10), torch.ones(10))
+    >>> iaf = InverseAutoregressiveFlow(10, 40)
+    >>> iaf_module = pyro.module("my_iaf", iaf.module)
     >>> iaf_dist = TransformedDistribution(base_dist, [iaf])
 
     Note that this implementation is only meant to be used in settings where the inverse of the Bijector

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -127,15 +127,20 @@ class TorchDistributionMixin(Distribution):
         :attr:`~torch.distributions.distribution.Distribution.event_shape`.
 
         Example::
+            >>> from pyro.distributions import Normal
 
+            >>> d0 = Normal(torch.zeros(2, 3, 4, 5), torch.ones(2, 3, 4, 5))
+            >>> [d0.batch_shape, d0.event_shape]
+            [torch.Size([2, 3, 4, 5]), torch.Size([])]
+            >>> d1 = d0.independent(2)
             >>> [d1.batch_shape, d1.event_shape]
-            [torch.Size((2, 3)), torch.Size((4, 5))]
+            [torch.Size([2, 3]), torch.Size([4, 5])]
             >>> d2 = d1.independent(1)
             >>> [d2.batch_shape, d2.event_shape]
-            [torch.Size((2,)), torch.Size((3, 4, 5))]
+            [torch.Size([2]), torch.Size([3, 4, 5])]
             >>> d3 = d1.independent(2)
             >>> [d3.batch_shape, d3.event_shape]
-            [torch.Size(()), torch.Size((2, 3, 4, 5))]
+            [torch.Size([]), torch.Size([2, 3, 4, 5])]
 
         :param int reinterpreted_batch_ndims: The number of batch dimensions
             to reinterpret as event dimensions.

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -46,22 +46,25 @@ class HMC(TraceKernel):
         :mod:`torch.distributions.constraint_registry`.
 
     Example::
+        >>> from pyro.infer import EmpiricalMarginal
+        >>> from pyro.infer.mcmc import MCMC
 
-        true_coefs = torch.tensor([1., 2., 3.])
-        data = torch.randn(2000, 3)
-        dim = 3
-        labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
+        >>> true_coefs = torch.tensor([1., 2., 3.])
+        >>> data = torch.randn(2000, 3)
+        >>> dim = 3
+        >>> labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
 
-        def model(data):
-            coefs_mean = torch.zeros(dim)
-            coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(3)))
-            y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
-            return y
+        >>> def model(data):
+        ...     coefs_mean = torch.zeros(dim)
+        ...     coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(3)))
+        ...     y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
+        ...     return y
 
-        hmc_kernel = HMC(model, step_size=0.0855, num_steps=4)
-        mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
-        posterior = EmpiricalMarginal(mcmc_run, 'beta')
-        print(posterior.mean)
+        >>> hmc_kernel = HMC(model, step_size=0.0855, num_steps=4)
+        >>> mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
+        >>> posterior = EmpiricalMarginal(mcmc_run, 'beta')  # doctest: +SKIP
+        >>> print(posterior.mean)  # doctest: +SKIP
+        tensor([ 0.9819,  1.9258,  2.9737])
     """
 
     def __init__(self, model, step_size=None, trajectory_length=None,

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -9,7 +9,7 @@ import pyro.distributions as dist
 from pyro.ops.integrator import single_step_velocity_verlet
 from pyro.util import torch_isnan
 
-from .hmc import HMC
+from pyro.infer.mcmc.hmc import HMC
 
 # sum_accept_probs and num_proposals are used to calculate
 # the statistic accept_prob for Dual Averaging scheme;
@@ -53,22 +53,25 @@ class NUTS(HMC):
         :mod:`torch.distributions.constraint_registry`.
 
     Example::
+        >>> from pyro.infer import EmpiricalMarginal
+        >>> from pyro.infer.mcmc import MCMC
 
-        true_coefs = torch.tensor([1., 2., 3.])
-        data = torch.randn(2000, 3)
-        dim = 3
-        labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
+        >>> true_coefs = torch.tensor([1., 2., 3.])
+        >>> data = torch.randn(2000, 3)
+        >>> dim = 3
+        >>> labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
 
-        def model(data):
-            coefs_mean = torch.zeros(dim)
-            coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(3)))
-            y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
-            return y
+        >>> def model(data):
+        ...     coefs_mean = torch.zeros(dim)
+        ...     coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(3)))
+        ...     y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
+        ...     return y
 
-        nuts_kernel = NUTS(model, adapt_step_size=True)
-        mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=300).run(data)
-        posterior = EmpiricalMarginal(mcmc_run, 'beta')
-        print(posterior.mean)
+        >>> nuts_kernel = NUTS(model, adapt_step_size=True)
+        >>> mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=300).run(data)
+        >>> posterior = EmpiricalMarginal(mcmc_run, 'beta')  # doctest: +SKIP
+        >>> print(posterior.mean)  # doctest: +SKIP
+        tensor([ 0.9221,  1.9464,  2.9228])
     """
 
     def __init__(self, model, step_size=None, adapt_step_size=False, transforms=None):

--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .messenger import Messenger
+from pyro.poutine.messenger import Messenger
 
 
 class BlockMessenger(Messenger):
@@ -22,6 +22,14 @@ class BlockMessenger(Messenger):
     For example, suppose the stochastic function fn has two sample sites "a" and "b".
     Then any poutine outside of BlockMessenger(fn, hide=["a"])
     will not be applied to site "a" and will only see site "b":
+
+    >>> import pyro
+    >>> import pyro.distributions as dist
+    >>> from pyro.poutine.trace_messenger import TraceMessenger
+
+    >>> def fn():
+    ...     a = pyro.sample("a", dist.Normal(0., 1.))
+    ...     return pyro.sample("b", dist.Normal(a, 1.))
 
     >>> fn_inner = TraceMessenger()(fn)
     >>> fn_outer = TraceMessenger()(BlockMessenger(hide=["a"])(TraceMessenger()(fn)))

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -50,6 +50,10 @@ class Trace(object):
 
     Consider the following Pyro program:
 
+        >>> import pyro
+        >>> import pyro.distributions as dist
+        >>>
+        >>> pyro.set_rng_seed(0)
         >>> def model(x):
         ...     s = pyro.param("s", torch.tensor(0.5))
         ...     z = pyro.sample("z", dist.Normal(x, s))
@@ -67,12 +71,12 @@ class Trace(object):
     ``trace.nodes`` contains a ``collections.OrderedDict``
     of site names and metadata corresponding to ``x``, ``s``, ``z``, and the return value:
 
-        >>> print(list(name for name in trace.nodes.keys()))
+        >>> print(list(name for name in trace.nodes.keys()))  # doctest: +SKIP
         ["_INPUT", "s", "z", "_RETURN"]
 
     As in :class:`networkx.DiGraph`, values of ``trace.nodes`` are dictionaries of node metadata:
 
-        >>> print(trace.nodes["z"])
+        >>> print(trace.nodes["z"])  # doctest: +SKIP
         {'type': 'sample', 'name': 'z', 'is_observed': False,
          'fn': Normal(), 'value': tensor(0.6480), 'args': (), 'kwargs': {},
          'infer': {}, 'scale': 1.0, 'cond_indep_stack': (),

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -205,28 +205,32 @@ class iarange(object):
 
     Examples::
 
-        # This version simply declares independence:
+        >>> from pyro.distributions import Normal
+        >>> loc, scale = torch.tensor(0.), torch.tensor(1.)
+        >>> data = torch.randn(100)
+
+        >>> # This version simply declares independence:
         >>> with iarange('data'):
-                sample('obs', Normal(loc, scale), obs=data)
+        ...     obs = sample('obs', Normal(loc, scale), obs=data)
 
-        # This version subsamples data in vectorized way:
+        >>> # This version subsamples data in vectorized way:
         >>> with iarange('data', 100, subsample_size=10) as ind:
-                sample('obs', Normal(loc, scale), obs=data[ind])
+        ...     obs = sample('obs', Normal(loc, scale), obs=data[ind])
 
-        # This wraps a user-defined subsampling method for use in pyro:
-        >>> ind = my_custom_subsample
+        >>> # This wraps a user-defined subsampling method for use in pyro:
+        >>> ind = torch.randint(0, 100, (10,)).long() # custom subsample
         >>> with iarange('data', 100, subsample=ind):
-                sample('obs', Normal(loc, scale), obs=data[ind])
+        ...     obs = sample('obs', Normal(loc, scale), obs=data[ind])
 
-        # This reuses two different independence contexts.
+        >>> # This reuses two different independence contexts.
         >>> x_axis = iarange('outer', 320, dim=-1)
         >>> y_axis = iarange('inner', 200, dim=-2)
         >>> with x_axis:
-                x_noise = sample("x_noise", Normal(loc, scale).expand_by([320]))
+        ...     x_noise = sample("x_noise", Normal(loc, scale).expand_by([320]))
         >>> with y_axis:
-                y_noise = sample("y_noise", Normal(loc, scale).expand_by([200, 1]))
+        ...     y_noise = sample("y_noise", Normal(loc, scale).expand_by([200, 1]))
         >>> with x_axis, y_axis:
-                xy_noise = sample("xy_noise", Normal(loc, scale).expand_by([200, 320]))
+        ...     xy_noise = sample("xy_noise", Normal(loc, scale).expand_by([200, 320]))
 
     See `SVI Part II <http://pyro.ai/examples/svi_part_ii.html>`_ for an
     extended discussion.
@@ -276,10 +280,14 @@ class irange(object):
     :return: A reusable iterator yielding a sequence of integers.
 
     Examples::
+        >>> from pyro.distributions import Bernoulli, Normal
+        >>> loc, scale = torch.tensor(0.), torch.tensor(1.)
+        >>> data = torch.randn(100)
 
+        >>> z = Bernoulli(0.5).sample((100,))
         >>> for i in irange('data', 100, subsample_size=10):
-                if z[i]:  # Prevents vectorization.
-                    observe('obs_{}'.format(i), normal, data[i], loc, scale)
+        ...     if z[i]:  # Prevents vectorization.
+        ...         obs = sample('obs_{}'.format(i), Normal(loc, scale), obs=data[i])
 
     See `SVI Part II <http://pyro.ai/examples/svi_part_ii.html>`_ for an extended discussion.
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,8 @@ filterwarnings = error
     ignore::DeprecationWarning
     once::DeprecationWarning
 
+doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
+
 [yapf]
 based_on_style = google
 column_limit = 120


### PR DESCRIPTION
Fixes #1130.
 - fixes a number of outdated/buggy code in the docstrings.
 - refactors some code snippets to be independently runnable.
 - `+SKIPS` output of stochastic functions, or certain snippets that are hard to test.

There are a few design considerations with regard to handling imports. 
 1. Import the modules required by the docstrings in the file itself, to avoid imports (often repetitive) within each of the docstrings. 
    - Pros: Relatively straightforward, prevents repetitive imports within the same file. 
    - Cons: Unnecessary imports that may not be needed by the functions themselves - as such these will need to be specially marked as `#noqa` and could lead to circular import issues.
 2. Use [extraglobs](https://docs.python.org/3/library/doctest.html#basic-api), or as suggested by @fehiepsi, the doctest namespace fixture by pytest. 
     - Pros - Cleaner than the previous approach. 
     - Cons - Will be coupled to pytest and won't run via a simple doctest invocation that is supported by most IDEs.
 3. Explicitly define all imports for each code snippet. 
     - Pros - Each code snippet can be copy pasted and is guaranteed to run without figuring out where the global dictionary is defined. It will also be decoupled from pytest and be runnable by different IDEs.
     - Cons - Repetitive import invocations, often within the same file.

We have (3) currently, and I am leaning towards (2) to at least put the most common imports in a global namespace like torch, pyro, pyro.distributions. Let me know your thoughts.