### PR TITLE
Minor updates to perf tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,11 @@ jobs:
               - pip install -r docs/requirements.txt
               - make docs
         - stage: perf
-          if: type = cron
           python: 2.7
           env: STAGE=perf
           script:
               - pip install -e .[profile]
-              - make perf-test
+              - pytest -vs --benchmark-disable tests/perf/test_benchmark.py
         - python: 3.5
           if: type = cron
           env: STAGE=perf

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -51,7 +51,7 @@ def poisson_gamma_model(reparameterized, Elbo):
     n_data = len(data)
     data_sum = data.sum(0)
     alpha_n = alpha0 + data_sum  # posterior alpha
-    beta_n = beta0 + torch.tensor(n_data)  # posterior beta
+    beta_n = beta0 + torch.tensor(float(n_data))  # posterior beta
     log_alpha_n = torch.log(alpha_n)
     log_beta_n = torch.log(beta_n)
 
@@ -119,14 +119,14 @@ def svgp_multiclass(num_steps, whiten):
     likelihood = gp.likelihoods.MultiClass(num_classes=3)
     Xu = X[::5].clone()
 
-    gpmodel = gp.models.SparseVariationalGP(X, y, kernel, Xu, likelihood,
+    gpmodel = gp.models.VariationalSparseGP(X, y, kernel, Xu, likelihood,
                                             latent_shape=torch.Size([3]),
                                             whiten=whiten)
 
     gpmodel.fix_param("Xu")
     gpmodel.kernel.get_subkernel("WhiteNoise").fix_param("variance")
 
-    gpmodel.optimize(optim.Adam({"lr": 0.0001}), num_steps)
+    gpmodel.optimize(optim.Adam({"lr": 0.0001}), num_steps=num_steps)
 
 
 @pytest.mark.parametrize('model, model_args, id', TEST_MODELS, ids=MODEL_IDS)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,6 +8,9 @@ import pytest
 
 from tests.common import EXAMPLES_DIR, requires_cuda
 
+pytestmark = pytest.mark.stage('test_examples')
+
+
 CPU_EXAMPLES = [
     ['air/main.py', '--num-steps=1'],
     ['baseball.py', '--num-samples=200', '--warmup-steps=100'],
@@ -65,7 +68,6 @@ def test_coverage():
                     pytest.fail('Example: {} not covered by CUDA_TESTS.'.format(example))
 
 
-@pytest.mark.stage("test_examples")
 @pytest.mark.parametrize('example,args', CPU_EXAMPLES, ids=make_ids(CPU_EXAMPLES))
 def test_cpu(example, args):
     example = os.path.join(EXAMPLES_DIR, example)
@@ -73,7 +75,6 @@ def test_cpu(example, args):
 
 
 @requires_cuda
-@pytest.mark.stage("test_examples")
 @pytest.mark.parametrize('example,args', CUDA_EXAMPLES, ids=make_ids(CUDA_EXAMPLES))
 def test_cuda(example, args):
     example = os.path.join(EXAMPLES_DIR, example)


### PR DESCRIPTION
Our test cron on travis is currently disabled, due to the high amount of noise and failed builds that we were getting. I am in the process of setting up test crons (#1146), and noticed that our perf tests were outdated. 

This includes some minor fixes, and also runs the suite on PRs by disabling the benchmark so that the tests are not replicated, and should be quite fast. This is to prevent the perf test suite from getting outdated.