### PR TITLE
Support decorating methods with handlers

### DIFF
--- a/pyro/poutine/messenger.py
+++ b/pyro/poutine/messenger.py
@@ -25,6 +25,7 @@ class Messenger(object):
         def _wraps(*args, **kwargs):
             with self:
                 return fn(*args, **kwargs)
+        _wraps.msngr = self
         return _wraps
 
     def __enter__(self):

--- a/pyro/poutine/messenger.py
+++ b/pyro/poutine/messenger.py
@@ -123,37 +123,3 @@ class Messenger(object):
 
     def _pyro_param(self, msg):
         return None
-
-
-# class Handler(object):
-#     """
-#     Wrapper class created by ``Messenger.__call__``
-#     """
-# 
-#     def __init__(self, msngr, fn):
-#         """
-#         :param msngr: messenger to be used for inference
-#         :param fn: a stochastic function (callable containing Pyro primitive calls)
-#         """
-#         self.msngr = msngr
-#         self.fn = fn
-# 
-#     def __call__(self, *args, **kwargs):
-#         """
-#         Installs its messenger onto the global effect stack,
-#         then calls the stored stochastic function with the given varargs,
-#         then uninstalls its messenger from the stack and returns the above value.
-# 
-#         Guaranteed to have the same call signature (input/output type)
-#         as the stored function.
-#         """
-#         with self.msngr:
-#             return self.fn(*args, **kwargs)
-# 
-#     def _reset(self):
-#         """
-#         Resets the computation to the beginning, un-sampling all sample sites.
-# 
-#         By default, does nothing, but overridden in derived classes.
-#         """
-#         self.msngr._reset()

--- a/pyro/poutine/messenger.py
+++ b/pyro/poutine/messenger.py
@@ -22,7 +22,10 @@ class Messenger(object):
         pass
 
     def __call__(self, fn):
-        return Handler(self, fn)
+        def _wraps(*args, **kwargs):
+            with self:
+                return fn(*args, **kwargs)
+        return _wraps
 
     def __enter__(self):
         """
@@ -122,35 +125,35 @@ class Messenger(object):
         return None
 
 
-class Handler(object):
-    """
-    Wrapper class created by ``Messenger.__call__``
-    """
-
-    def __init__(self, msngr, fn):
-        """
-        :param msngr: messenger to be used for inference
-        :param fn: a stochastic function (callable containing Pyro primitive calls)
-        """
-        self.msngr = msngr
-        self.fn = fn
-
-    def __call__(self, *args, **kwargs):
-        """
-        Installs its messenger onto the global effect stack,
-        then calls the stored stochastic function with the given varargs,
-        then uninstalls its messenger from the stack and returns the above value.
-
-        Guaranteed to have the same call signature (input/output type)
-        as the stored function.
-        """
-        with self.msngr:
-            return self.fn(*args, **kwargs)
-
-    def _reset(self):
-        """
-        Resets the computation to the beginning, un-sampling all sample sites.
-
-        By default, does nothing, but overridden in derived classes.
-        """
-        self.msngr._reset()
+# class Handler(object):
+#     """
+#     Wrapper class created by ``Messenger.__call__``
+#     """
+# 
+#     def __init__(self, msngr, fn):
+#         """
+#         :param msngr: messenger to be used for inference
+#         :param fn: a stochastic function (callable containing Pyro primitive calls)
+#         """
+#         self.msngr = msngr
+#         self.fn = fn
+# 
+#     def __call__(self, *args, **kwargs):
+#         """
+#         Installs its messenger onto the global effect stack,
+#         then calls the stored stochastic function with the given varargs,
+#         then uninstalls its messenger from the stack and returns the above value.
+# 
+#         Guaranteed to have the same call signature (input/output type)
+#         as the stored function.
+#         """
+#         with self.msngr:
+#             return self.fn(*args, **kwargs)
+# 
+#     def _reset(self):
+#         """
+#         Resets the computation to the beginning, un-sampling all sample sites.
+# 
+#         By default, does nothing, but overridden in derived classes.
+#         """
+#         self.msngr._reset()

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .messenger import Handler, Messenger
+from .messenger import Messenger
 from .trace_struct import Trace
 from .util import site_is_subsample
 
@@ -152,7 +152,7 @@ class TraceMessenger(Messenger):
         return None
 
 
-class TraceHandler(Handler):
+class TraceHandler(object):
     """
     Execution trace poutine.
 
@@ -163,6 +163,10 @@ class TraceHandler(Handler):
 
     We can also use this for visualization.
     """
+    def __init__(self, msngr, fn):
+        self.fn = fn
+        self.msngr = msngr
+
     def __call__(self, *args, **kwargs):
         """
         Runs the stochastic function stored in this poutine,

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -753,3 +753,22 @@ def test_decorator_interface_do():
         else:
             assert name not in tr
             assert_equal(tr.nodes["_RETURN"]["value"][name], data[name])
+
+
+def test_method_decorator_interface_condition():
+
+    class cls_model(object):
+
+        @poutine.condition(data={"b": torch.tensor(1.)})
+        def model(self, p):
+            pyro.sample("a", Bernoulli(p))
+            pyro.sample("b", Bernoulli(torch.tensor([0.5])))
+
+        def _model(self, p):
+            pyro.sample("a", Bernoulli(p))
+            pyro.sample("b", Bernoulli(torch.tensor([0.5])))
+
+    tr = poutine.trace(cls_model().model).get_trace(0.5)
+    assert isinstance(tr, poutine.Trace)
+    assert tr.graph_type == "flat"
+    assert tr.nodes["b"]["is_observed"] and tr.nodes["b"]["value"].item() == 1.

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -761,8 +761,7 @@ def test_method_decorator_interface_condition():
 
         @poutine.condition(data={"b": torch.tensor(1.)})
         def model(self, p):
-            pyro.sample("a", Bernoulli(p))
-            pyro.sample("b", Bernoulli(torch.tensor([0.5])))
+            self._model(p)
 
         def _model(self, p):
             pyro.sample("a", Bernoulli(p))


### PR DESCRIPTION
Currently, decorating methods with handlers like `poutine.broadcast` fails because `Messenger.__call__` returns a callable `Handler` object, not a function.  This PR removes `Handler` objects in favor of returning a function to support that use case.

cc @martinjankowiak 