### PR TITLE
Adding doctest for testing Pyro docstring code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
           script:
               - pip install -r docs/requirements.txt
               - make docs
+              - make doctest
         - stage: perf
           python: 2.7
           env: STAGE=perf

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ scrub: FORCE
 	find tutorial -name "*.ipynb" | xargs python -m nbstripout --keep-output --keep-count
 	find tutorial -name "*.ipynb" | xargs python tutorial/source/cleannb.py
 
+doctest: FORCE
+	python -m pytest --doctest-modules -p tests.doctest_fixtures -p no:warnings pyro
+
 format: FORCE
 	isort --recursive *.py pyro/ examples/ tests/ profiler/*.py docs/source/conf.py
 
@@ -32,7 +35,7 @@ profile: ref=dev
 profile: FORCE
 	bash scripts/profile_model.sh ${ref} ${models}
 
-test: lint docs FORCE
+test: lint docs doctest FORCE
 	pytest -vx -n auto --stage unit
 
 test-examples: lint FORCE

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,7 @@ extensions = [
     'sphinx.ext.viewcode',  #
     'sphinx.ext.githubpages',  #
     'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -306,9 +306,6 @@ class Warping(Transforming):
     We can take advantage of :math:`f` to combine a Gaussian Process kernel with a deep
     learning architecture. For example:
 
-        >>> import torch
-        >>> import pyro.contrib.gp as gp
-
         >>> linear = torch.nn.Linear(10, 3)
         >>> # register its parameters to Pyro's ParamStore and wrap it by lambda
         >>> # to call the primitive pyro.module each time we use the linear function

--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -306,9 +306,12 @@ class Warping(Transforming):
     We can take advantage of :math:`f` to combine a Gaussian Process kernel with a deep
     learning architecture. For example:
 
+        >>> import torch
+        >>> import pyro.contrib.gp as gp
+
         >>> linear = torch.nn.Linear(10, 3)
-        # register its parameters to Pyro's ParamStore and wrap it by lambda
-        # to call the primitive pyro.module each time we use the linear function
+        >>> # register its parameters to Pyro's ParamStore and wrap it by lambda
+        >>> # to call the primitive pyro.module each time we use the linear function
         >>> pyro_linear_fn = lambda x: pyro.module("linear", linear)(x)
         >>> kernel = gp.kernels.Matern52(input_dim=3, lengthscale=torch.ones(3))
         >>> warped_kernel = gp.kernels.Warping(kernel, pyro_linear_fn)

--- a/pyro/contrib/gp/models/gplvm.py
+++ b/pyro/contrib/gp/models/gplvm.py
@@ -27,19 +27,29 @@ class GPLVM(Parameterized):
     its posterior by a multivariate normal distribution with two variational
     parameters: ``X_loc`` and ``X_scale_tril``.
 
-    For example, we can do dimensional reduction on Iris dataset as follows::
+    For example, we can do dimensional reduction on Iris dataset as follows:
 
-        # With y is the 2D Iris data of shape 150x4 and we want to reduce its dimension
-        # to a tensor X of shape 150x2, we will use GPLVM.
-        # First, define the initial values for X_loc parameter:
+        >>> # With y as the 2D Iris data of shape 150x4 and we want to reduce its dimension
+        >>> # to a tensor X of shape 150x2, we will use GPLVM.
+
+        .. doctest::
+           :hide:
+
+            >>> # Simulating iris data.
+            >>> y = torch.stack([dist.Normal(4.8, 0.1).sample((150,)),
+            ...                 dist.Normal(3.2, 0.3).sample((150,)),
+            ...                 dist.Normal(1.5, 0.4).sample((150,)),
+            ...                 dist.Exponential(0.5).sample((150,))])
+
+        >>> # First, define the initial values for X_loc parameter:
         >>> X_loc = torch.zeros(150, 2)
-        # Then, define a Gaussian Process model with input X_loc and output y:
+        >>> # Then, define a Gaussian Process model with input X_loc and output y:
         >>> kernel = gp.kernels.RBF(input_dim=2, lengthscale=torch.ones(2))
         >>> Xu = torch.zeros(20, 2)  # initial inducing inputs of sparse model
         >>> gpmodel = gp.models.SparseGPRegression(X_loc, y, kernel, Xu)
-        # Finally, wrap gpmodel by GPLVM, optimize, and get the "learned" mean of X:
+        >>> # Finally, wrap gpmodel by GPLVM, optimize, and get the "learned" mean of X:
         >>> gplvm = gp.models.GPLVM(gpmodel)
-        >>> gplvm.optimize()
+        >>> gplvm.optimize()  # doctest: +SKIP
         >>> X = gplvm.get_param("X_loc")
 
     Reference:

--- a/pyro/contrib/gp/models/model.py
+++ b/pyro/contrib/gp/models/model.py
@@ -136,17 +136,17 @@ class GPModel(Parameterized):
 
         Some examples to utilize this method are:
 
+        .. doctest::
+           :hide:
+
+            >>> X = torch.tensor([[1., 5, 3], [4, 3, 7]])
+            >>> y = torch.tensor([2., 1])
+            >>> kernel = gp.kernels.RBF(input_dim=3)
+            >>> kernel.set_prior("variance", dist.Uniform(torch.tensor(0.5), torch.tensor(1.5)))
+            >>> kernel.set_prior("lengthscale", dist.Uniform(torch.tensor(1.0), torch.tensor(3.0)))
+            >>> optimizer = pyro.optim.Adam({"lr": 0.01})
+
         + Batch training on a sparse variational model:
-
-            .. doctest::
-               :hide:
-
-                >>> X = torch.tensor([[1., 5, 3], [4, 3, 7]])
-                >>> y = torch.tensor([2., 1])
-                >>> kernel = gp.kernels.RBF(input_dim=3)
-                >>> kernel.set_prior("variance", dist.Uniform(torch.tensor(0.5), torch.tensor(1.5)))
-                >>> kernel.set_prior("lengthscale", dist.Uniform(torch.tensor(1.0), torch.tensor(3.0)))
-                >>> optimizer = pyro.optim.Adam({"lr": 0.01})
 
             >>> Xu = torch.tensor([[1., 0, 2]])  # inducing input
             >>> likelihood = gp.likelihoods.Gaussian()
@@ -157,7 +157,8 @@ class GPModel(Parameterized):
             ...     vsgp.set_data(Xi, yi)
             ...     svi.step()  # doctest: +SKIP
 
-        + Making a two-layer Gaussian Process stochastic function::
+        + Making a two-layer Gaussian Process stochastic function:
+
 
             >>> gpr1 = gp.models.GPRegression(X, None, kernel, name="GPR1")
             >>> Z, _ = gpr1.model()

--- a/pyro/contrib/gp/models/model.py
+++ b/pyro/contrib/gp/models/model.py
@@ -39,6 +39,8 @@ class GPModel(Parameterized):
         >>> X = torch.tensor([[1., 5, 3], [4, 3, 7]])
         >>> y = torch.tensor([2., 1])
         >>> kernel = gp.kernels.RBF(input_dim=3)
+        >>> kernel.set_prior("variance", dist.Uniform(torch.tensor(0.5), torch.tensor(1.5)))
+        >>> kernel.set_prior("lengthscale", dist.Uniform(torch.tensor(1.0), torch.tensor(3.0)))
         >>> gpr = gp.models.GPRegression(X, y, kernel)
 
     There are two ways to train a Gaussian Process model:
@@ -60,7 +62,7 @@ class GPModel(Parameterized):
         >>> optimizer = pyro.optim.Adam({"lr": 0.01})
         >>> svi = SVI(gpr.model, gpr.guide, optimizer, loss=Trace_ELBO())
         >>> for i in range(1000):
-        ...     svi.step()
+        ...     svi.step()  # doctest: +SKIP
 
     To give a prediction on new dataset, simply use :meth:`forward` like any PyTorch
     :class:`torch.nn.Module`:
@@ -136,20 +138,30 @@ class GPModel(Parameterized):
 
         + Batch training on a sparse variational model:
 
+            .. doctest::
+               :hide:
+
+                >>> X = torch.tensor([[1., 5, 3], [4, 3, 7]])
+                >>> y = torch.tensor([2., 1])
+                >>> kernel = gp.kernels.RBF(input_dim=3)
+                >>> kernel.set_prior("variance", dist.Uniform(torch.tensor(0.5), torch.tensor(1.5)))
+                >>> kernel.set_prior("lengthscale", dist.Uniform(torch.tensor(1.0), torch.tensor(3.0)))
+                >>> optimizer = pyro.optim.Adam({"lr": 0.01})
+
             >>> Xu = torch.tensor([[1., 0, 2]])  # inducing input
             >>> likelihood = gp.likelihoods.Gaussian()
-            >>> vsgp = gp.models.SparseVariationalGP(X, y, kernel, Xu, likelihood)
+            >>> vsgp = gp.models.VariationalSparseGP(X, y, kernel, Xu, likelihood)
             >>> svi = SVI(vsgp.model, vsgp.guide, optimizer, Trace_ELBO())
             >>> batched_X, batched_y = X.split(split_size=10), y.split(split_size=10)
             >>> for Xi, yi in zip(batched_X, batched_y):
             ...     vsgp.set_data(Xi, yi)
-            ...     svi.step()
+            ...     svi.step()  # doctest: +SKIP
 
-        + Making a two-layer Gaussian Process stochastic function:
+        + Making a two-layer Gaussian Process stochastic function::
 
-            >>> gpr1 = gp.models.GPRegression(X, None, kernel1, name="GPR1")
-            >>> Z, _ = gp_layer1.model()
-            >>> gpr2 = gp.models.GPRegression(Z, y, kernel2, name="GPR2")
+            >>> gpr1 = gp.models.GPRegression(X, None, kernel, name="GPR1")
+            >>> Z, _ = gpr1.model()
+            >>> gpr2 = gp.models.GPRegression(Z, y, kernel, name="GPR2")
             >>> def two_layer_model():
             ...     Z, _ = gpr1.model()
             ...     gpr2.set_data(Z, y)

--- a/pyro/contrib/named.py
+++ b/pyro/contrib/named.py
@@ -38,8 +38,8 @@ alias Pyro statements. For example::
     >>> state = named.Object("state")
     >>> loc = state.loc.param_(torch.zeros(1, requires_grad=True))
     >>> scale = state.scale.param_(torch.ones(1, requires_grad=True))
-    >>> z = state.z.sample_(dist.normal, loc, scale)
-    >>> state.x.observe_(dist.normal, z, loc, scale)
+    >>> z = state.z.sample_(dist.Normal(loc, scale))
+    >>> obs = state.x.sample_(dist.Normal(loc, scale), obs=z)
 
 For deeper examples of how these can be used in model code, see the
 `Tree Data <https://github.com/uber/pyro/blob/dev/examples/contrib/named/tree_data.py>`_

--- a/pyro/distributions/binomial.py
+++ b/pyro/distributions/binomial.py
@@ -22,7 +22,7 @@ class Binomial(torch.distributions.Distribution, TorchDistributionMixin):
     Example::
 
         >>> m = Binomial(100, torch.Tensor([0 , .2, .8, 1]))
-        >>> x = m.sample()
+        >>> m.sample()  # doctest: +SKIP
          0
          22
          71
@@ -30,7 +30,7 @@ class Binomial(torch.distributions.Distribution, TorchDistributionMixin):
         [torch.FloatTensor of size 4]]
 
         >>> m = Binomial(torch.Tensor([[5.], [10.]]), torch.Tensor([0.5, 0.8]))
-        >>> x = m.sample()
+        >>> m.sample()  # doctest: +SKIP
          4  5
          7  6
         [torch.FloatTensor of size (2,2)]

--- a/pyro/distributions/iaf.py
+++ b/pyro/distributions/iaf.py
@@ -14,7 +14,7 @@ class InverseAutoregressiveFlow(Transform):
     An implementation of an Inverse Autoregressive Flow. Together with the `TransformedDistribution` this
     provides a way to create richer variational approximations.
 
-    Example usage::
+    Example usage:
 
     >>> base_dist = dist.Normal(torch.zeros(10), torch.ones(10))
     >>> iaf = InverseAutoregressiveFlow(10, 40)

--- a/pyro/distributions/iaf.py
+++ b/pyro/distributions/iaf.py
@@ -16,10 +16,10 @@ class InverseAutoregressiveFlow(Transform):
 
     Example usage::
 
-    >>> base_dist = Normal(...)
-    >>> iaf = InverseAutoregressiveFlow(...)
-    >>> pyro.module("my_iaf", iaf.module)
-    >>> iaf_dist = TransformedDistribution(base_dist, [iaf])
+    >>> base_dist = dist.Normal(torch.zeros(10), torch.ones(10))
+    >>> iaf = InverseAutoregressiveFlow(10, 40)
+    >>> iaf_module = pyro.module("my_iaf", iaf.module)
+    >>> iaf_dist = dist.TransformedDistribution(base_dist, [iaf])
 
     Note that this implementation is only meant to be used in settings where the inverse of the Bijector
     is never explicitly computed (rather the result is cached from the forward call). In the context of

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -126,16 +126,24 @@ class TorchDistributionMixin(Distribution):
         as event dims, adding them to the left side of
         :attr:`~torch.distributions.distribution.Distribution.event_shape`.
 
-        Example::
+        Example:
+
+            .. doctest::
+               :hide:
+
+               >>> d0 = dist.Normal(torch.zeros(2, 3, 4, 5), torch.ones(2, 3, 4, 5))
+               >>> [d0.batch_shape, d0.event_shape]
+               [torch.Size([2, 3, 4, 5]), torch.Size([])]
+               >>> d1 = d0.independent(2)
 
             >>> [d1.batch_shape, d1.event_shape]
-            [torch.Size((2, 3)), torch.Size((4, 5))]
+            [torch.Size([2, 3]), torch.Size([4, 5])]
             >>> d2 = d1.independent(1)
             >>> [d2.batch_shape, d2.event_shape]
-            [torch.Size((2,)), torch.Size((3, 4, 5))]
+            [torch.Size([2]), torch.Size([3, 4, 5])]
             >>> d3 = d1.independent(2)
             >>> [d3.batch_shape, d3.event_shape]
-            [torch.Size(()), torch.Size((2, 3, 4, 5))]
+            [torch.Size([]), torch.Size([2, 3, 4, 5])]
 
         :param int reinterpreted_batch_ndims: The number of batch dimensions
             to reinterpret as event dimensions.

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -45,23 +45,24 @@ class HMC(TraceKernel):
         automatic transformations will be applied, as specified in
         :mod:`torch.distributions.constraint_registry`.
 
-    Example::
+    Example:
 
-        true_coefs = torch.tensor([1., 2., 3.])
-        data = torch.randn(2000, 3)
-        dim = 3
-        labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
+        >>> true_coefs = torch.tensor([1., 2., 3.])
+        >>> data = torch.randn(2000, 3)
+        >>> dim = 3
+        >>> labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
 
-        def model(data):
-            coefs_mean = torch.zeros(dim)
-            coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(3)))
-            y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
-            return y
+        >>> def model(data):
+        ...     coefs_mean = torch.zeros(dim)
+        ...     coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(3)))
+        ...     y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
+        ...     return y
 
-        hmc_kernel = HMC(model, step_size=0.0855, num_steps=4)
-        mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
-        posterior = EmpiricalMarginal(mcmc_run, 'beta')
-        print(posterior.mean)
+        >>> hmc_kernel = HMC(model, step_size=0.0855, num_steps=4)
+        >>> mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
+        >>> posterior = EmpiricalMarginal(mcmc_run, 'beta')
+        >>> posterior.mean  # doctest: +SKIP
+        tensor([ 0.9819,  1.9258,  2.9737])
     """
 
     def __init__(self, model, step_size=None, trajectory_length=None,

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -51,13 +51,13 @@ class HMC(TraceKernel):
         >>> data = torch.randn(2000, 3)
         >>> dim = 3
         >>> labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
-
+        >>>
         >>> def model(data):
         ...     coefs_mean = torch.zeros(dim)
         ...     coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(3)))
         ...     y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
         ...     return y
-
+        >>>
         >>> hmc_kernel = HMC(model, step_size=0.0855, num_steps=4)
         >>> mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
         >>> posterior = EmpiricalMarginal(mcmc_run, 'beta')

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -9,7 +9,7 @@ import pyro.distributions as dist
 from pyro.ops.integrator import single_step_velocity_verlet
 from pyro.util import torch_isnan
 
-from .hmc import HMC
+from pyro.infer.mcmc.hmc import HMC
 
 # sum_accept_probs and num_proposals are used to calculate
 # the statistic accept_prob for Dual Averaging scheme;
@@ -52,23 +52,24 @@ class NUTS(HMC):
         automatic transformations will be applied, as specified in
         :mod:`torch.distributions.constraint_registry`.
 
-    Example::
+    Example:
 
-        true_coefs = torch.tensor([1., 2., 3.])
-        data = torch.randn(2000, 3)
-        dim = 3
-        labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
+        >>> true_coefs = torch.tensor([1., 2., 3.])
+        >>> data = torch.randn(2000, 3)
+        >>> dim = 3
+        >>> labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
 
-        def model(data):
-            coefs_mean = torch.zeros(dim)
-            coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(3)))
-            y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
-            return y
+        >>> def model(data):
+        ...     coefs_mean = torch.zeros(dim)
+        ...     coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(3)))
+        ...     y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
+        ...     return y
 
-        nuts_kernel = NUTS(model, adapt_step_size=True)
-        mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=300).run(data)
-        posterior = EmpiricalMarginal(mcmc_run, 'beta')
-        print(posterior.mean)
+        >>> nuts_kernel = NUTS(model, adapt_step_size=True)
+        >>> mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=300).run(data)
+        >>> posterior = EmpiricalMarginal(mcmc_run, 'beta')
+        >>> posterior.mean  # doctest: +SKIP
+        tensor([ 0.9221,  1.9464,  2.9228])
     """
 
     def __init__(self, model, step_size=None, adapt_step_size=False, transforms=None):

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -58,13 +58,13 @@ class NUTS(HMC):
         >>> data = torch.randn(2000, 3)
         >>> dim = 3
         >>> labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
-
+        >>>
         >>> def model(data):
         ...     coefs_mean = torch.zeros(dim)
         ...     coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(3)))
         ...     y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
         ...     return y
-
+        >>>
         >>> nuts_kernel = NUTS(model, adapt_step_size=True)
         >>> mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=300).run(data)
         >>> posterior = EmpiricalMarginal(mcmc_run, 'beta')

--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .messenger import Messenger
+from pyro.poutine.messenger import Messenger
 
 
 class BlockMessenger(Messenger):
@@ -22,6 +22,15 @@ class BlockMessenger(Messenger):
     For example, suppose the stochastic function fn has two sample sites "a" and "b".
     Then any poutine outside of BlockMessenger(fn, hide=["a"])
     will not be applied to site "a" and will only see site "b":
+
+    .. doctest::
+       :hide:
+
+       >>> from pyro.poutine.trace_messenger import TraceMessenger
+
+    >>> def fn():
+    ...     a = pyro.sample("a", dist.Normal(0., 1.))
+    ...     return pyro.sample("b", dist.Normal(a, 1.))
 
     >>> fn_inner = TraceMessenger()(fn)
     >>> fn_outer = TraceMessenger()(BlockMessenger(hide=["a"])(TraceMessenger()(fn)))

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -67,12 +67,12 @@ class Trace(object):
     ``trace.nodes`` contains a ``collections.OrderedDict``
     of site names and metadata corresponding to ``x``, ``s``, ``z``, and the return value:
 
-        >>> print(list(name for name in trace.nodes.keys()))
+        >>> list(name for name in trace.nodes.keys())  # doctest: +SKIP
         ["_INPUT", "s", "z", "_RETURN"]
 
     As in :class:`networkx.DiGraph`, values of ``trace.nodes`` are dictionaries of node metadata:
 
-        >>> print(trace.nodes["z"])
+        >>> trace.nodes["z"]  # doctest: +SKIP
         {'type': 'sample', 'name': 'z', 'is_observed': False,
          'fn': Normal(), 'value': tensor(0.6480), 'args': (), 'kwargs': {},
          'infer': {}, 'scale': 1.0, 'cond_indep_stack': (),

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -289,7 +289,7 @@ class irange(object):
            >>> loc, scale = torch.tensor(0.), torch.tensor(1.)
            >>> data = torch.randn(100)
            >>> z = dist.Bernoulli(0.5).sample((100,))
-           
+
         >>> for i in irange('data', 100, subsample_size=10):
         ...     if z[i]:  # Prevents vectorization.
         ...         obs = sample('obs_{}'.format(i), dist.Normal(loc, scale), obs=data[i])

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -203,30 +203,36 @@ class iarange(object):
     :return: A reusabe context manager yielding a single 1-dimensional
         :class:`torch.Tensor` of indices.
 
-    Examples::
+    Examples:
 
-        # This version simply declares independence:
+        .. doctest::
+           :hide:
+
+           >>> loc, scale = torch.tensor(0.), torch.tensor(1.)
+           >>> data = torch.randn(100)
+
+        >>> # This version simply declares independence:
         >>> with iarange('data'):
-                sample('obs', Normal(loc, scale), obs=data)
+        ...     obs = sample('obs', dist.Normal(loc, scale), obs=data)
 
-        # This version subsamples data in vectorized way:
+        >>> # This version subsamples data in vectorized way:
         >>> with iarange('data', 100, subsample_size=10) as ind:
-                sample('obs', Normal(loc, scale), obs=data[ind])
+        ...     obs = sample('obs', dist.Normal(loc, scale), obs=data[ind])
 
-        # This wraps a user-defined subsampling method for use in pyro:
-        >>> ind = my_custom_subsample
+        >>> # This wraps a user-defined subsampling method for use in pyro:
+        >>> ind = torch.randint(0, 100, (10,)).long() # custom subsample
         >>> with iarange('data', 100, subsample=ind):
-                sample('obs', Normal(loc, scale), obs=data[ind])
+        ...     obs = sample('obs', dist.Normal(loc, scale), obs=data[ind])
 
-        # This reuses two different independence contexts.
+        >>> # This reuses two different independence contexts.
         >>> x_axis = iarange('outer', 320, dim=-1)
         >>> y_axis = iarange('inner', 200, dim=-2)
         >>> with x_axis:
-                x_noise = sample("x_noise", Normal(loc, scale).expand_by([320]))
+        ...     x_noise = sample("x_noise", dist.Normal(loc, scale).expand_by([320]))
         >>> with y_axis:
-                y_noise = sample("y_noise", Normal(loc, scale).expand_by([200, 1]))
+        ...     y_noise = sample("y_noise", dist.Normal(loc, scale).expand_by([200, 1]))
         >>> with x_axis, y_axis:
-                xy_noise = sample("xy_noise", Normal(loc, scale).expand_by([200, 320]))
+        ...     xy_noise = sample("xy_noise", dist.Normal(loc, scale).expand_by([200, 320]))
 
     See `SVI Part II <http://pyro.ai/examples/svi_part_ii.html>`_ for an
     extended discussion.
@@ -275,11 +281,18 @@ class irange(object):
         ``torch.Tensor.is_cuda``.
     :return: A reusable iterator yielding a sequence of integers.
 
-    Examples::
+    Examples:
 
+        .. doctest::
+           :hide:
+
+           >>> loc, scale = torch.tensor(0.), torch.tensor(1.)
+           >>> data = torch.randn(100)
+           >>> z = dist.Bernoulli(0.5).sample((100,))
+           
         >>> for i in irange('data', 100, subsample_size=10):
-                if z[i]:  # Prevents vectorization.
-                    observe('obs_{}'.format(i), normal, data[i], loc, scale)
+        ...     if z[i]:  # Prevents vectorization.
+        ...         obs = sample('obs_{}'.format(i), dist.Normal(loc, scale), obs=data[i])
 
     See `SVI Part II <http://pyro.ai/examples/svi_part_ii.html>`_ for an extended discussion.
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,8 @@ filterwarnings = error
     ignore::DeprecationWarning
     once::DeprecationWarning
 
+doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
+
 [yapf]
 based_on_style = google
 column_limit = 120

--- a/tests/doctest_fixtures.py
+++ b/tests/doctest_fixtures.py
@@ -1,0 +1,28 @@
+import numpy
+import pytest
+import torch
+
+import pyro
+import pyro.contrib.gp as gp
+import pyro.contrib.named as named
+import pyro.distributions as dist
+import pyro.poutine as poutine
+from pyro.infer import EmpiricalMarginal
+from pyro.infer.mcmc import HMC, MCMC, NUTS
+from pyro.params import param_with_module_name
+
+
+@pytest.fixture(autouse=True)
+def add_imports(doctest_namespace):
+    doctest_namespace['dist'] = dist
+    doctest_namespace['gp'] = gp
+    doctest_namespace['named'] = named
+    doctest_namespace['np'] = numpy
+    doctest_namespace['param_with_module_name'] = param_with_module_name
+    doctest_namespace['poutine'] = poutine
+    doctest_namespace['pyro'] = pyro
+    doctest_namespace['torch'] = torch
+    doctest_namespace['EmpiricalMarginal'] = EmpiricalMarginal
+    doctest_namespace['HMC'] = HMC
+    doctest_namespace['MCMC'] = MCMC
+    doctest_namespace['NUTS'] = NUTS


### PR DESCRIPTION
This resurrects #1142, with the following changes:

 - Moves all imports to a separate `doctest_namespace` which is imported by pytest before running doctest.
 - Hides all data / setting up code in a `doctest :hide:` directive, so that this is only used by doctest and does not appear in the sphinx generated documentation.

I was initially planning to only do this for a couple of docstrings, but given that we can hide all setup code, I didn't feel that any of the changes introduced are compromising readability. Let me know if we should remove doctest from any of these, and I'll just move them to a literal block instead.