### PR TITLE
Fix TraceEnum_ELBO to allow use of grad() in guide

### DIFF
--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -144,7 +144,7 @@ class TraceEnum_ELBO(ELBO):
 
             if trainable_params and elbo_particle.requires_grad:
                 loss_particle = -elbo_particle
-                (loss_particle / self.num_particles).backward()
+                (loss_particle / self.num_particles).backward(retain_graph=True)
 
         loss = -elbo
         if torch_isnan(loss):


### PR DESCRIPTION
This configures `.backward()` to use `requires_grad=True` in `TraceEnum_ELBO`. This is needed for guides that create autograd graphs internally so that the created graphs are retained after multiple `poutine.replay()`s. The motivating use case is guides that use `pyro.ops.newton.newton_step_2d`.

Note this is only needed in sequential enumeration; the usual `Trace_ELBO` and parallel `TraceEnum_ELBO` never perform repeated replay on a single partial guide trace.

## Tested

- added a simple regression test
- tested on an internal application