### PR TITLE
Add hide_fn parameter to poutine.block

### DIFF
--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -3,6 +3,62 @@ from __future__ import absolute_import, division, print_function
 from pyro.poutine.messenger import Messenger
 
 
+def _make_default_hide_fn(hide_all, expose_all, hide, expose, hide_types, expose_types):
+    # first, some sanity checks:
+    # hide_all and expose_all intersect?
+    assert (hide_all is False and expose_all is False) or \
+        (hide_all != expose_all), "cannot hide and expose a site"
+
+    # hide and expose intersect?
+    if hide is None:
+        hide = []
+    else:
+        hide_all = False
+
+    if expose is None:
+        expose = []
+    else:
+        hide_all = True
+
+    assert set(hide).isdisjoint(set(expose)), \
+        "cannot hide and expose a site"
+
+    # hide_types and expose_types intersect?
+    if hide_types is None:
+        hide_types = []
+    else:
+        hide_all = False
+
+    if expose_types is None:
+        expose_types = []
+    else:
+        hide_all = True
+
+    assert set(hide_types).isdisjoint(set(expose_types)), \
+        "cannot hide and expose a site type"
+
+    def _fn(msg):
+        # handle observes
+        if msg["type"] == "sample" and msg["is_observed"]:
+            msg_type = "observe"
+        else:
+            msg_type = msg["type"]
+
+        is_not_exposed = (msg["name"] not in expose) and \
+                         (msg_type not in expose_types)
+
+        # decision rule for hiding:
+        if (msg["name"] in hide) or \
+        (msg_type in hide_types) or \
+        (is_not_exposed and hide_all):  # noqa: E129
+
+            return True
+        # otherwise expose
+        else:
+            return False
+    return _fn
+
+
 class BlockMessenger(Messenger):
     """
     This Messenger selectively hides Pyro primitive sites from the outside world.
@@ -13,6 +69,7 @@ class BlockMessenger(Messenger):
 
     A site is hidden if at least one of the following holds:
 
+        0. hide_fn(msg) is True
         1. msg["name"] in hide
         2. msg["type"] in hide_types
         3. msg["name"] not in expose and msg["type"] not in expose_types
@@ -47,6 +104,8 @@ class BlockMessenger(Messenger):
 
     See the constructor for details.
 
+    :param: hide_fn: function that takes a site and returns True to hide the site
+      or False/None to expose it.  If specified, all other parameters are ignored.
     :param bool hide_all: hide all sites
     :param bool expose_all: expose all sites normally
     :param list hide: list of site names to hide, rest will be exposed normally
@@ -55,78 +114,18 @@ class BlockMessenger(Messenger):
     :param list expose_types: list of site types to expose normally, rest will be hidden
     """
 
-    def __init__(self,
+    def __init__(self, hide_fn=None,
                  hide_all=True, expose_all=False,
                  hide=None, expose=None,
                  hide_types=None, expose_types=None):
         super(BlockMessenger, self).__init__()
-        # first, some sanity checks:
-        # hide_all and expose_all intersect?
-        assert (hide_all is False and expose_all is False) or \
-               (hide_all != expose_all), "cannot hide and expose a site"
-
-        # hide and expose intersect?
-        if hide is None:
-            hide = []
+        if hide_fn is not None:
+            self.hide_fn = hide_fn
         else:
-            hide_all = False
-
-        if expose is None:
-            expose = []
-        else:
-            hide_all = True
-
-        assert set(hide).isdisjoint(set(expose)), \
-            "cannot hide and expose a site"
-
-        # hide_types and expose_types intersect?
-        if hide_types is None:
-            hide_types = []
-        else:
-            hide_all = False
-
-        if expose_types is None:
-            expose_types = []
-        else:
-            hide_all = True
-
-        assert set(hide_types).isdisjoint(set(expose_types)), \
-            "cannot hide and expose a site type"
-
-        # now set stuff
-        self.hide_all = hide_all
-        self.expose_all = expose_all
-        self.hide = hide
-        self.expose = expose
-        self.hide_types = hide_types
-        self.expose_types = expose_types
-
-    def _block_up(self, msg):
-        """
-        Uses rule described in main docstring to decide whether to block or expose.
-
-        :param msg: current message at a trace site, after all execution finished.
-        :returns: boolean decision to hide or expose site.
-        """
-        # handle observes
-        if msg["type"] == "sample" and msg["is_observed"]:
-            msg_type = "observe"
-        else:
-            msg_type = msg["type"]
-
-        is_not_exposed = (msg["name"] not in self.expose) and \
-                         (msg_type not in self.expose_types)
-
-        # decision rule for hiding:
-        if (msg["name"] in self.hide) or \
-           (msg_type in self.hide_types) or \
-           (is_not_exposed and self.hide_all):  # noqa: E129
-
-            return True
-        # otherwise expose
-        else:
-            return False
+            self.hide_fn = _make_default_hide_fn(hide_all, expose_all,
+                                                 hide, expose,
+                                                 hide_types, expose_types)
 
     def _process_message(self, msg):
-        msg["stop"] = self._block_up(msg)
+        msg["stop"] = self.hide_fn(msg)
         return None

--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -135,5 +135,5 @@ class BlockMessenger(Messenger):
                                                  hide_types, expose_types)
 
     def _process_message(self, msg):
-        msg["stop"] = self.hide_fn(msg)
+        msg["stop"] = bool(self.hide_fn(msg))
         return None

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -208,7 +208,7 @@ def block(fn=None, hide_fn=None, hide=None, expose=None, hide_types=None, expose
     :param expose_types: list of site types to be exposed while all others hidden
     :returns: stochastic function decorated with a :class:`~pyro.poutine.block_messenger.BlockMessenger`
     """
-    msngr = BlockMessenger(hide=hide, expose=expose,
+    msngr = BlockMessenger(hide_fn=hide_fn, hide=hide, expose=expose,
                            hide_types=hide_types, expose_types=expose_types)
     return msngr(fn) if fn is not None else msngr
 

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -166,13 +166,14 @@ def lift(fn=None, prior=None):
     return msngr(fn) if fn is not None else msngr
 
 
-def block(fn=None, hide=None, expose=None, hide_types=None, expose_types=None):
+def block(fn=None, hide_fn=None, hide=None, expose=None, hide_types=None, expose_types=None):
     """
     This handler selectively hides Pyro primitive sites from the outside world.
     Default behavior: block everything.
 
     A site is hidden if at least one of the following holds:
 
+        0. ``hide_fn(msg) is True``
         1. ``msg["name"] in hide``
         2. ``msg["type"] in hide_types``
         3. ``msg["name"] not in expose and msg["type"] not in expose_types``
@@ -199,6 +200,8 @@ def block(fn=None, hide=None, expose=None, hide_types=None, expose_types=None):
         True
 
     :param fn: a stochastic function (callable containing Pyro primitive calls)
+    :param: hide_fn: function that takes a site and returns True to hide the site
+      or False/None to expose it.  If specified, all other parameters are ignored.
     :param hide: list of site names to hide
     :param expose: list of site names to be exposed while all others hidden
     :param hide_types: list of site types to be hidden

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -166,14 +166,14 @@ def lift(fn=None, prior=None):
     return msngr(fn) if fn is not None else msngr
 
 
-def block(fn=None, hide_fn=None, hide=None, expose=None, hide_types=None, expose_types=None):
+def block(fn=None, hide_fn=None, expose_fn=None, hide=None, expose=None, hide_types=None, expose_types=None):
     """
     This handler selectively hides Pyro primitive sites from the outside world.
     Default behavior: block everything.
 
     A site is hidden if at least one of the following holds:
 
-        0. ``hide_fn(msg) is True``
+        0. ``hide_fn(msg) is True`` or ``(not expose_fn(msg)) is True``
         1. ``msg["name"] in hide``
         2. ``msg["type"] in hide_types``
         3. ``msg["name"] not in expose and msg["type"] not in expose_types``
@@ -202,13 +202,18 @@ def block(fn=None, hide_fn=None, hide=None, expose=None, hide_types=None, expose
     :param fn: a stochastic function (callable containing Pyro primitive calls)
     :param: hide_fn: function that takes a site and returns True to hide the site
       or False/None to expose it.  If specified, all other parameters are ignored.
+      Only specify one of hide_fn or expose_fn, not both.
+    :param: expose_fn: function that takes a site and returns True to expose the site
+      or False/None to hide it.  If specified, all other parameters are ignored.
+      Only specify one of hide_fn or expose_fn, not both.
     :param hide: list of site names to hide
     :param expose: list of site names to be exposed while all others hidden
     :param hide_types: list of site types to be hidden
     :param expose_types: list of site types to be exposed while all others hidden
     :returns: stochastic function decorated with a :class:`~pyro.poutine.block_messenger.BlockMessenger`
     """
-    msngr = BlockMessenger(hide_fn=hide_fn, hide=hide, expose=expose,
+    msngr = BlockMessenger(hide_fn=hide_fn, expose_fn=expose_fn,
+                           hide=hide, expose=expose,
                            hide_types=hide_types, expose_types=expose_types)
     return msngr(fn) if fn is not None else msngr
 

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -123,6 +123,16 @@ class BlockHandlerTests(NormalNormalNormalHandlerTestCase):
         assert "latent2" not in model_trace
         assert "obs" in model_trace
 
+    def test_block_expose_fn(self):
+        model_trace = poutine.trace(
+            poutine.block(self.model,
+                          expose_fn=lambda msg: "latent" in msg["name"],
+                          hide=["latent1"])
+        ).get_trace()
+        assert "latent1" in model_trace
+        assert "latent2" in model_trace
+        assert "obs" not in model_trace
+
     def test_block_full(self):
         model_trace = poutine.trace(poutine.block(self.model)).get_trace()
         guide_trace = poutine.trace(poutine.block(self.guide)).get_trace()

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -113,6 +113,16 @@ class ReplayHandlerTests(NormalNormalNormalHandlerTestCase):
 
 class BlockHandlerTests(NormalNormalNormalHandlerTestCase):
 
+    def test_block_hide_fn(self):
+        model_trace = poutine.trace(
+            poutine.block(self.model,
+                          hide_fn=lambda msg: "latent" in msg["name"],
+                          expose=["latent1"])
+        ).get_trace()
+        assert "latent1" not in model_trace
+        assert "latent2" not in model_trace
+        assert "obs" in model_trace
+
     def test_block_full(self):
         model_trace = poutine.trace(poutine.block(self.model)).get_trace()
         guide_trace = poutine.trace(poutine.block(self.guide)).get_trace()


### PR DESCRIPTION
Addresses #1160 

Example:
```python
def model():
    pyro.sample("x1", dist.Bernoulli(0.5))
    pyro.sample("x2", dist.Bernoulli(0.5))
    pyro.sample("y", dist.Bernoulli(0.5))

blocked = poutine.block(model, hide_fn=lambda msg: "x" in msg["name"])
assert "x1" not in poutine.trace(blocked).get_trace(...)
assert "y" in poutine.trace(blocked).get_trace(...)
```