### PR TITLE
[Do not merge] Infer local names of non-anonymous sample statements

### DIFF
--- a/LICENSE.Apache-2.txt
+++ b/LICENSE.Apache-2.txt
@@ -1,0 +1,182 @@
+Applies to pyro/contrib/autoname/compilation.py, which is modified from 
+https://github.com/google/tangent/blob/master/tangent/compile.py and
+https://github.com/google/tangent/blob/master/tangent/quoting.py.
+
+-------------------------------------------------------------------------
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/pyro/contrib/autoname/__init__.py
+++ b/pyro/contrib/autoname/__init__.py
@@ -5,8 +5,10 @@ generating unique, semantically meaningful names for sample sites.
 from __future__ import absolute_import, division, print_function
 
 from pyro.contrib.autoname import named
+from pyro.contrib.autoname.glom_named import glom_name
 
 
 __all__ = [
+    "glom_name",
     "named",
 ]

--- a/pyro/contrib/autoname/compilation.py
+++ b/pyro/contrib/autoname/compilation.py
@@ -1,0 +1,180 @@
+# This code is MODIFIED from the version in Tangent (github.com/google/tangent)
+# found at https://github.com/google/tangent/blob/master/tangent/compile.py
+# and at https://github.com/google/tangent/blob/master/tangent/quoting.py
+#
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#      Unless required by applicable law or agreed to in writing, software
+#      distributed under the License is distributed on an "AS IS" BASIS,
+#      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#      See the License for the specific language governing permissions and
+#      limitations under the License.
+"""Going from AST or source code to executable code."""
+from __future__ import absolute_import
+
+from uuid import uuid4
+
+import os
+import tempfile
+
+import inspect
+import textwrap
+
+import astor
+import gast
+import six
+if six.PY3:
+    from importlib import util
+else:
+    import imp
+
+from .quoting import to_source  # noqa: E402
+
+
+def compile_file(source, globals_=None):
+    """
+    Compile by saving to file and importing that.
+
+    Compiling the AST/source code this way ensures that the source code is
+    readable by e.g. `pdb` or `inspect`.
+
+    Args:
+      source: The code to compile, either as a string or as an AST.
+      globals_: A dictionary of variables that should be available as globals in
+          the compiled module. They will be monkey patched after importing the
+          module.
+
+    Returns:
+      A module object containing the compiled source code.
+    """
+    if isinstance(source, gast.AST):
+        source = to_source(source)
+
+    # Write source to temporary file
+    tempdir = tempfile.mkdtemp()
+    uuid = str(uuid4().hex[:4])
+    tmpname = os.path.join(tempdir, 'pyro_autoname_%s.py' % uuid)
+    with open(tmpname, 'w') as f:
+        f.write(source)
+
+    # Load the temporary file as a module
+    module_name = 'pyro_autoname_%s' % uuid
+    if six.PY3:
+        spec = util.spec_from_file_location(module_name, tmpname)
+        m = util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+    else:
+        m = imp.load_source(module_name, tmpname)
+
+    # Update the modules namespace
+    if globals_:
+        m.__dict__.update(globals_)
+    return m
+
+
+def compile_function(node, globals_=None):
+    """
+    Convert an AST or string into a function with inspectable source.
+
+    This function uses `compile_file` internally, but instead of returning the
+    entire module it will return the function only.
+
+    Args:
+      node: A `FunctionDef` node or a `Module` node which contains at least one
+          `FunctionDef` node. If a module contains multiple functions, a handle
+          to the first one will be returned.
+      globals_: See `compile_file`
+
+    Returns:
+      A handle to the compiled function.
+
+    Raises:
+      TypeError: If the input is not a string or AST.
+      ValueError: If no function can be found.
+    """
+    if not isinstance(node, gast.AST):
+        if not isinstance(node, six.string_types):
+            raise TypeError
+        node = gast.parse(node)
+    if isinstance(node, gast.Module):
+        for succ in node.body:
+            if isinstance(succ, gast.FunctionDef):
+                name = succ.name
+                break
+        else:
+            raise ValueError('no function found')
+    elif isinstance(node, gast.FunctionDef):
+        name = node.name
+    else:
+        raise TypeError
+    module = compile_file(node, globals_)
+    return getattr(module, name)
+
+
+def to_source(node, indentation=' ' * 4):
+    """
+    Return source code of a given AST.
+    """
+    if isinstance(node, gast.AST):
+        node = gast.gast_to_ast(node)
+    generator = astor.code_gen.SourceGenerator(indentation, False,
+                                               astor.string_repr.pretty_string)
+    generator.visit(node)
+    generator.result.append('\n')
+    return astor.source_repr.pretty_source(generator.result).lstrip()
+
+
+def parse_function(fn):
+    """
+    Get the source of a function and return its AST.
+    """
+    try:
+        return parse_string(inspect.getsource(fn))
+    except (IOError, OSError) as e:
+        raise ValueError('Cannot parse function: %s' % e)
+
+
+def parse_string(src):
+    """
+    Parse a string into an AST.
+    """
+    return gast.parse(textwrap.dedent(src))
+
+
+def quote(src_string, return_expr=False):
+    """
+    Go from source code to AST nodes.
+
+    This function returns a tree without enclosing `Module` or `Expr` nodes.
+
+    Args:
+      src_string: The source code to parse.
+      return_expr: Whether or not to return a containing expression. This can be
+          set to `True` if the result is to be part of a series of statements.
+
+    Returns:
+      An AST of the given source code.
+    """
+    node = parse_string(src_string)
+    body = node.body
+    if len(body) == 1:
+        if isinstance(body[0], gast.Expr) and not return_expr:
+            out = body[0].value
+        else:
+            out = body[0]
+    else:
+        out = node
+    return out
+
+
+def unquote(node):
+    """
+    Go from an AST to source code.
+    """
+    return to_source(node).strip()

--- a/pyro/contrib/autoname/compilation.py
+++ b/pyro/contrib/autoname/compilation.py
@@ -34,8 +34,6 @@ if six.PY3:
 else:
     import imp
 
-from .quoting import to_source  # noqa: E402
-
 
 def compile_file(source, globals_=None):
     """
@@ -59,12 +57,12 @@ def compile_file(source, globals_=None):
     # Write source to temporary file
     tempdir = tempfile.mkdtemp()
     uuid = str(uuid4().hex[:4])
-    tmpname = os.path.join(tempdir, 'pyro_autoname_%s.py' % uuid)
+    tmpname = os.path.join(tempdir, 'autoname_%s.py' % uuid)
     with open(tmpname, 'w') as f:
         f.write(source)
 
     # Load the temporary file as a module
-    module_name = 'pyro_autoname_%s' % uuid
+    module_name = 'autoname_%s' % uuid
     if six.PY3:
         spec = util.spec_from_file_location(module_name, tmpname)
         m = util.module_from_spec(spec)

--- a/pyro/contrib/autoname/glom_named.py
+++ b/pyro/contrib/autoname/glom_named.py
@@ -1,0 +1,47 @@
+import copy
+import glom
+import gast
+from .compilation import quote, unquote, compile_function, parse_function
+
+
+class PrimitiveDetector(gast.NodeVisitor):
+
+    def __init__(self):
+        self._ret = False
+
+    def visit_Call(self, node):
+        self.generic_visit(node)
+        if isinstance(node.func, gast.Attribute):
+            self._ret = self._ret or \
+                        isinstance(node.func.value, gast.Name) and \
+                        node.func.value.id == "pyro" and \
+                        node.func.attr in ("sample", "param")
+
+    def visit(self, node):
+        super(PrimitiveDetector, self).visit(node)
+        return self._ret
+
+
+class NameRewriter(gast.NodeTransformer):
+
+    def _make_glom(self, node):
+        new_node = copy.copy(node)
+        new_node.ctx = gast.Load()
+        return quote("str(glom.T." + unquote(new_node) + ")[6:]")
+
+    def visit_Assign(self, node):
+        if isinstance(node.value, gast.Call) and \
+           PrimitiveDetector().visit(node.value) and \
+           len(node.targets) == 1:
+            new_name_node = self._make_glom(node.targets[0])
+            if isinstance(node.value.args[0], gast.Str):
+                node.value.args[0] = new_name_node
+            else:
+                node.value.args.insert(0, new_name_node)
+        return node
+
+
+def name(fn):
+    node = NameRewriter().visit(parse_function(fn))
+    g = {"glom": glom}.update(fn.__globals__)
+    return compile_function(node, g)

--- a/tests/contrib/autoname/test_glom_named.py
+++ b/tests/contrib/autoname/test_glom_named.py
@@ -1,0 +1,41 @@
+import pytest
+
+import pyro
+import pyro.distributions as dist
+import pyro.poutine as poutine
+
+from pyro.contrib.autoname.glom_named import sample, dynamic_scope
+
+
+def test_dynamic_simple():
+
+    def submodel():
+        y = sample(dist.Bernoulli(0.5))
+        return y
+
+    class B(object):
+        def __init__(self):
+            b = 3
+
+    @dynamic_scope
+    def model():
+        x = sample(dist.Bernoulli(0.5))
+        y = sample(dist.Bernoulli(0.5))
+        # xx = submodel()
+        z = [x, y, None, None]
+        i = 3
+        z[i] = sample(dist.Bernoulli(0.5))
+        zz = {}
+        zz["a"] = sample(dist.Bernoulli(0.5))
+        ab = B()
+        ab.b = sample(dist.Bernoulli(0.5))
+        # yy = submodel()
+        # xyz = [sample(dist.Bernoulli(0.5)) for i in range(3)]
+        # z[-1] = submodel()
+        # for i in range(3):
+        #     zi = sample(dist.Bernoulli(0.5))
+        #     z.append(zi)
+        return z
+
+    tr = poutine.trace(model).get_trace()
+    print(tr.nodes)


### PR DESCRIPTION
This PR is experimenting with using [glom](http://glom.readthedocs.io/en/latest/api.html#object-oriented-access-and-method-calls-with-t) and AST rewriting to infer semantically meaningful names automatically for `pyro.sample` and `pyro.param` calls that appear on the right-hand side of an assignment statement.  I'm currently using some boilerplate AST parsing/compilation code adapted from Tangent (hence the license in the PR), but would probably remove it before actually merging this to `contrib.autoname`.

`glom` is a library for querying nested data structures.  `glom.T` is sort of like a souped-up version of the data structures in `contrib.autoname.named`.  As in `contrib.autoname.named`, I've just used the string representations of those data structures for a proof of concept, but it's possible that in the future we could replace the string-based query language for sample sites with `glom` or something like it.

Mostly posted for @fritzo to look at the test in `tests/contrib/autoname/test_glom_named.py`.