### PR TITLE
Add AutoGuideList.median() method

### DIFF
--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -113,6 +113,15 @@ class AutoGuide(object):
                 else:
                     raise NotImplementedError("AutoGuideList does not support pyro.irange")
 
+    def median(self, *args, **kwargs):
+        """
+        Returns the posterior median value of each latent variable.
+
+        :return: A dict mapping sample site name to median tensor.
+        :rtype: dict
+        """
+        raise NotImplementedError
+
 
 class AutoGuideList(AutoGuide):
     """
@@ -174,6 +183,18 @@ class AutoGuideList(AutoGuide):
         result = {}
         for part in self.parts:
             result.update(part(*args, **kwargs))
+        return result
+
+    def median(self, *args, **kwargs):
+        """
+        Returns the posterior median value of each latent variable.
+
+        :return: A dict mapping sample site name to median tensor.
+        :rtype: dict
+        """
+        result = {}
+        for part in self.parts:
+            result.update(part.median(*args, **kwargs))
         return result
 
 

--- a/tests/contrib/autoguide/test_advi.py
+++ b/tests/contrib/autoguide/test_advi.py
@@ -85,11 +85,19 @@ def test_irange_smoke(auto_class, Elbo):
     infer.step()
 
 
+def auto_guide_list_x(model):
+    guide = AutoGuideList(model)
+    guide.add(AutoDelta(poutine.block(model, expose=["x"])))
+    guide.add(AutoDiagonalNormal(poutine.block(model, hide=["x"])))
+    return guide
+
+
 @pytest.mark.parametrize("auto_class", [
     AutoDelta,
     AutoDiagonalNormal,
     AutoMultivariateNormal,
     AutoLowRankMultivariateNormal,
+    auto_guide_list_x,
 ])
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
 def test_median(auto_class, Elbo):
@@ -100,7 +108,7 @@ def test_median(auto_class, Elbo):
         pyro.sample("z", dist.Beta(2.0, 2.0))
 
     guide = auto_class(model)
-    infer = SVI(model, guide, Adam({'lr': 0.05}), Elbo(strict_enumeration_warning=False))
+    infer = SVI(model, guide, Adam({'lr': 0.02}), Elbo(strict_enumeration_warning=False))
     for _ in range(100):
         infer.step()
 


### PR DESCRIPTION
This adds a `.median()` method to `AutoGuideList`, simply aggregating the `.median()`s of the components, e.g. `AutoDelta.median()` and `AutoDiagonalNormal.median()`. This makes it much easier to experiment by swapping in an `AutoGuideList` for an `AutoDiagonalNormal` while keeping the same code for latent variable inspection.

## Tested

- added an example to test_median
- tested in an internal application