### PR TITLE
Replace deprecated pytest get_marker invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
         - PYTHONPATH=$PWD:$PYTHONPATH
 
 install:
+    - pip install -U pip
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
           pip install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp27-cp27mu-linux_x86_64.whl;
       else

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         'extras': EXTRAS_REQUIRE,
         'test': EXTRAS_REQUIRE + [
             'nbval',
-            'pytest',
+            'pytest>=3.5',
             'pytest-cov',
             'scipy>=0.19.0',
         ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,11 @@ def pytest_configure(config):
 
 def pytest_runtest_setup(item):
     pyro.clear_param_store()
-    if item.get_marker("disable_validation"):
+    if item.get_closest_marker("disable_validation"):
         pyro.enable_validation(False)
     else:
         pyro.enable_validation(True)
-    test_initialize_marker = item.get_marker("init")
+    test_initialize_marker = item.get_closest_marker("init")
     if test_initialize_marker:
         rng_seed = test_initialize_marker.kwargs["rng_seed"]
         pyro.set_rng_seed(rng_seed)
@@ -64,7 +64,7 @@ def pytest_collection_modifyitems(config, items):
     selected_items = []
     deselected_items = []
     for item in items:
-        stage_marker = item.get_marker("stage")
+        stage_marker = item.get_closest_marker("stage")
         if not stage_marker:
             selected_items.append(item)
             warnings.warn("No stage associated with the test {}. Will run on each stage invocation.".format(item.name))


### PR DESCRIPTION
pytest version 4 will deprecate the `item.get_marker` method which is used in `conftest.py`. This throws a warning in the latest version. Using `item.get_closest_marker` instead, as recommended by this [note](https://docs.pytest.org/en/latest/mark.html#updating-code) in the pytest docs.