### PR TITLE
Allocate rightmost available dim in iaranges by default

### DIFF
--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -16,7 +16,6 @@ class _DimAllocator(object):
     """
     def __init__(self):
         self._stack = []  # in reverse orientation of log_prob.shape
-        self._default_stack_idx = 0  # default stack index for allocation
 
     def allocate(self, name, dim):
         """
@@ -28,8 +27,9 @@ class _DimAllocator(object):
             raise ValueError('duplicate iarange "{}"'.format(name))
         if dim is None:
             # Automatically designate the rightmost available dim for allocation.
-            dim = -(self._default_stack_idx + 1)
-            self._default_stack_idx += 1
+            dim = -1
+            while -dim <= len(self._stack) and self._stack[-1 - dim] is not None:
+                dim -= 1
         elif dim >= 0:
             raise ValueError('Expected dim < 0 to index from the right, actual {}'.format(dim))
 
@@ -50,7 +50,6 @@ class _DimAllocator(object):
         free_idx = -1 - dim  # stack index to free
         assert self._stack[free_idx] == name
         self._stack[free_idx] = None
-        self._default_stack_idx = min(self._default_stack_idx, free_idx)
         while self._stack and self._stack[-1] is None:
             self._stack.pop()
 

--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -16,6 +16,7 @@ class _DimAllocator(object):
     """
     def __init__(self):
         self._stack = []  # in reverse orientation of log_prob.shape
+        self._default_stack_idx = 0  # default stack index for allocation
 
     def allocate(self, name, dim):
         """
@@ -26,28 +27,30 @@ class _DimAllocator(object):
         if name in self._stack:
             raise ValueError('duplicate iarange "{}"'.format(name))
         if dim is None:
-            # Automatically allocate the rightmost dimension to the left of all existing dims.
-            self._stack.append(name)
-            dim = -len(self._stack)
+            # Automatically designate the rightmost available dim for allocation.
+            dim = -(self._default_stack_idx + 1)
+            self._default_stack_idx += 1
         elif dim >= 0:
             raise ValueError('Expected dim < 0 to index from the right, actual {}'.format(dim))
-        else:
-            # Allocate the requested dimension.
-            while dim < -len(self._stack):
-                self._stack.append(None)
-            if self._stack[-1 - dim] is not None:
-                raise ValueError('\n'.join([
-                    'at iaranges "{}" and "{}", collide at dim={}'.format(name, self._stack[-1 - dim], dim),
-                    '\nTry moving the dim of one iarange to the left, e.g. dim={}'.format(dim - 1)]))
-            self._stack[-1 - dim] = name
+
+        # Allocate the requested dimension.
+        while dim < -len(self._stack):
+            self._stack.append(None)
+        if self._stack[-1 - dim] is not None:
+            raise ValueError('\n'.join([
+                'at iaranges "{}" and "{}", collide at dim={}'.format(name, self._stack[-1 - dim], dim),
+                '\nTry moving the dim of one iarange to the left, e.g. dim={}'.format(dim - 1)]))
+        self._stack[-1 - dim] = name
         return dim
 
     def free(self, name, dim):
         """
         Free a dimension.
         """
-        assert self._stack[-1 - dim] == name
-        self._stack[-1 - dim] = None
+        free_idx = -1 - dim  # stack index to free
+        assert self._stack[free_idx] == name
+        self._stack[free_idx] = None
+        self._default_stack_idx = min(self._default_stack_idx, free_idx)
         while self._stack and self._stack[-1] is None:
             self._stack.pop()
 


### PR DESCRIPTION
The current dim allocation behavior for `iarange` is to allocate the dim to the left of the last allocated dim (and start with the right-most dim). By default, this allocation looks like `-1, -2, -3, etc.`. If the user manually allocates a dim, the next allocated dim is to the left of this. So for instance, if the outermost dim starts at `-3`, the dim allocation scheme will be `-3, -4, -5` where the first two dims will continue to remain empty.

This proposes a minor change to our default dim allocation scheme so that we allocate the rightmost *available* dims by default instead of to the left of the last allocated one. So for the previous example, the dim allocation will be `-3, -1, -2`. As such, default allocation is from the rightmost available and manual placement can be used to deviate from this.

```python
with pyro.iarange("outer", 100, dim=-3):    # dim allocated: earlier = -3, now = -3
    with pyro.iarange("inner", 10):         # dim allocated: earlier = -4, now = -1
        with pyro.iarange("innermost", 5):  # dim allocated: earlier = -5, now = -2
        ...
```

This will make it easier to wrap existing models inside an outermost `num_particles` iarange in an automatic way, for instance, without the user having to manually specify dim placement. 

### Impact:

This will only impact models where the users were relying on this behavior of default allocation to the left of the last assigned dim, i.e. have an outer iarange with a `dim` arg, but not specifying the `dim` arg in the inner iaranges, as in the code above. In almost all such cases, we have been using the `dim` arg in the inner iaranges as well so as not to have empty iarange dims, so this seems like a low impact change, even if it deviates from our existing behavior.

The following examples would work before this PR but would fail after:
```py
@poutine.broadcast
def model_1():
    with pyro.iarange("foo", 2, dim=-2):
        with pyro.iarange("bar", 3):
            x = pyro.sample("x", dist.Normal(0., 1.))
            assert x.shape == (3,2,1)  # after this PR, shape == (2,3)

def model_2():
    foo = pyro.iarange("foo", 2, dim=-2)
    bar = pyro.iarange("bar", 3)
    baz = pyro.iarange("baz", 4, dim=-1)  # errors after this PR
    assert bar.dim == -3  # after this PR, bar.dim == -1
```