### PR TITLE
Accept callables to AutoGuideList.add(-)

### DIFF
--- a/docs/source/contrib.autoguide.rst
+++ b/docs/source/contrib.autoguide.rst
@@ -19,6 +19,14 @@ AutoGuideList
     :special-members: __call__
     :show-inheritance:
 
+AutoCallable
+------------
+.. autoclass:: pyro.contrib.autoguide.AutoCallable
+    :members:
+    :undoc-members:
+    :special-members: __call__
+    :show-inheritance:
+
 AutoDelta
 ---------
 .. autoclass:: pyro.contrib.autoguide.AutoDelta

--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -34,6 +34,7 @@ except ImportError:
     from contextlib2 import ExitStack  # python 2
 
 __all__ = [
+    'AutoCallable',
     'AutoContinuous',
     'AutoDelta',
     'AutoDiagonalNormal',
@@ -157,7 +158,8 @@ class AutoGuideList(AutoGuide):
         have been created by blocking the model to restrict to a subset of
         sample sites. No two parts should operate on any one sample site.
 
-        :param AutoGuide part: a partial guide to add
+        :param part: a partial guide to add
+        :type part: AutoGuide or callable
         """
         if not isinstance(part, AutoGuide):
             part = AutoCallable(self.model, part)


### PR DESCRIPTION
Resolves #1168 

This creates a simple wrapper `AutoCallable` to allow callables to be `.add()`ed to an `AutoGuideList`.

## Tested

- smoke test with no return value
- smoke test with dict return value
- value test with optional `median` callable