### PR TITLE
Increase test iterations for CUDA testing

### DIFF
--- a/tests/contrib/autoguide/test_advi.py
+++ b/tests/contrib/autoguide/test_advi.py
@@ -126,7 +126,7 @@ def test_median(auto_class, Elbo):
 
     guide = auto_class(model)
     infer = SVI(model, guide, Adam({'lr': 0.02}), Elbo(strict_enumeration_warning=False))
-    for _ in range(250):
+    for _ in range(1000):
         infer.step()
 
     median = guide.median()

--- a/tests/contrib/autoguide/test_advi.py
+++ b/tests/contrib/autoguide/test_advi.py
@@ -126,7 +126,7 @@ def test_median(auto_class, Elbo):
 
     guide = auto_class(model)
     infer = SVI(model, guide, Adam({'lr': 0.02}), Elbo(strict_enumeration_warning=False))
-    for _ in range(200):
+    for _ in range(250):
         infer.step()
 
     median = guide.median()


### PR DESCRIPTION
The `test_advi.py::test_median` test seems to require significantly more (3x-5x) iterations to converge to the expected results on CUDA, with `auto_guide_callable` needing the most number of iterations. I am not sure why that is the case.

 @fritzo - I am just increasing the number of iterations for now, but let me know if this needs to be further investigated.