### PR TITLE
Improve default handling of logger messages

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-import logging
-
+from pyro.logger import log
 import pyro.poutine as poutine
 from pyro.poutine import condition, do
 from pyro.primitives import (clear_param_store, enable_validation, get_param_store, iarange, irange, module, param,
@@ -16,10 +15,6 @@ try:
 except ImportError:
     __version__ = version_prefix
 
-# Default logger to prevent 'No handler found' warning.
-logging.getLogger(__name__).addHandler(logging.NullHandler())
-
-
 __all__ = [
     "__version__",
     "clear_param_store",
@@ -29,6 +24,7 @@ __all__ = [
     "get_param_store",
     "iarange",
     "irange",
+    "log",
     "module",
     "param",
     "poutine",

--- a/pyro/logger.py
+++ b/pyro/logger.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import, division, print_function
+
+import logging
+
+
+default_format = '%(levelname)s \t %(message)s'
+log = logging.getLogger("pyro")
+log.setLevel(logging.INFO)
+
+
+if not logging.root.handlers:
+    default_handler = logging.StreamHandler()
+    default_handler.setLevel(logging.INFO)
+    default_handler.setFormatter(logging.Formatter(default_format))
+    log.addHandler(default_handler)
+    log.propagate = False

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import copy
-import logging
 import numbers
 import warnings
 from collections import OrderedDict
@@ -17,10 +16,6 @@ from pyro.distributions.distribution import Distribution
 from pyro.params import param_with_module_name
 from pyro.poutine.runtime import _DIM_ALLOCATOR, _MODULE_NAMESPACE_DIVIDER, _PYRO_PARAM_STORE, am_i_wrapped, apply_stack
 from pyro.util import deep_getattr, set_rng_seed  # noqa: F401
-
-
-# Default logger to prevent 'No handler found' warning.
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
 def get_param_store():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,13 +2,5 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
-logger = logging.getLogger(__name__)
-
 # create log handler for tests
-handler = logging.StreamHandler()
-formatter = logging.Formatter('%(levelname).1s %(name)s \t %(message)s')
-handler.setFormatter(formatter)
-
-# set default logging level for tests
-logger.addHandler(handler)
-logger.setLevel(logging.DEBUG)
+logging.basicConfig(format='%(levelname).1s \t %(message)s', level=logging.DEBUG)

--- a/tests/contrib/gp/test_models.py
+++ b/tests/contrib/gp/test_models.py
@@ -19,9 +19,7 @@ from pyro.infer.mcmc.mcmc import MCMC
 from pyro.params import param_with_module_name
 from tests.common import assert_equal
 
-logging.basicConfig(format='%(levelname)s %(message)s')
-logger = logging.getLogger('pyro')
-logger.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
 
 T = namedtuple("TestGPModel", ["model_class", "X", "y", "kernel", "likelihood"])
 

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -14,9 +14,7 @@ from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.mcmc import MCMC
 from tests.common import assert_equal
 
-logging.basicConfig(format='%(levelname)s %(message)s')
-logger = logging.getLogger('pyro')
-logger.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class GaussianChain(object):

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -1,5 +1,3 @@
-import logging
-
 import torch
 
 import pyro
@@ -9,10 +7,6 @@ from pyro.infer import EmpiricalMarginal
 from pyro.infer.mcmc.mcmc import MCMC
 from pyro.infer.mcmc.trace_kernel import TraceKernel
 from tests.common import assert_equal
-
-logging.basicConfig()
-# Change the logging level to DEBUG to see the output of the MCMC logger
-logging.getLogger().setLevel(logging.ERROR)
 
 
 class PriorKernel(TraceKernel):

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -15,9 +15,7 @@ from tests.common import assert_equal
 
 from .test_hmc import TEST_CASES, TEST_IDS, T, rmse
 
-logging.basicConfig(format='%(levelname)s %(message)s')
-logger = logging.getLogger('pyro')
-logger.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
 
 T2 = T(*TEST_CASES[2].values)._replace(num_samples=800, warmup_steps=200)
 TEST_CASES[2] = pytest.param(*T2, marks=pytest.mark.skipif(


### PR DESCRIPTION
We had our logging set up in a way that the default handler was a `NullHandler`, and the onus of setting up the logging was on the user. While this works great for most libraries used in production applications, most users do not use Pyro inside an application where the root logger is already configured. e.g. #1175, and many other forum postings where some issues with HMC/NUTS sampling were not apparent simply because the user did not configure a logger.

This is a minor change to enforce the following:
 - If no root logger is configured, the default handler will just output to stdout, as most users would expect (and not swallow `INFO`, `DEBUG` level messages).
 - If a root logger is already configured (say, via `logging.basicConfig(...)`) before "pyro" is imported, then all log messages will be directed to the root logger.  In such cases, the output should not be duplicated. e.g. in certain tests, the output from the logger was getting duplicated. 
    ```
    tests/infer/test_enum.py::test_gmm_iter_discrete_traces[gmm_model-dense-3] D 
    tests.infer.test_enum 	 M z_0 = 1
    DEBUG M z_0 = 1
    D tests.infer.test_enum 	 M z_0 = 1
    DEBUG M z_0 = 1 
    D tests.infer.test_enum 	 M   z_1 = 1
    ...
    ```
 - If a root logger is configured after "pyro" is imported, we will use the default handler to output messages from inside "pyro" and the application specific logging will go to the root logger. e.g. `baseball.py` uses a different format for its own output.

Partly addresses #1175; we need better warnings and diagnostics separately.
