### PR TITLE
Defer to .expand_by wherever possible in distribution.expand

### DIFF
--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -592,7 +592,7 @@ class AutoIAFNormal(AutoContinuous):
         iaf = dist.InverseAutoregressiveFlow(self.latent_dim, self.hidden_dim,
                                              sigmoid_bias=self.sigmoid_bias)
         pyro.module("{}_iaf".format(self.prefix), iaf.module)
-        self.iaf_dist = dist.TransformedDistribution(dist.Normal(0., 1.).expand(self.latent_dim), [iaf])
+        self.iaf_dist = dist.TransformedDistribution(dist.Normal(0., 1.).expand([self.latent_dim]), [iaf])
         return pyro.sample("_{}_latent".format(self.prefix), self.iaf_dist.independent(1),
                            infer={"is_auxiliary": True})
 

--- a/pyro/distributions/binomial.py
+++ b/pyro/distributions/binomial.py
@@ -6,6 +6,7 @@ import torch
 from torch.distributions import constraints
 from torch.distributions.utils import broadcast_all, lazy_property, logits_to_probs, probs_to_logits
 
+from pyro.distributions.util import ShapeMismatchError
 from pyro.distributions.torch_distribution import TorchDistributionMixin
 
 
@@ -121,11 +122,15 @@ class Binomial(torch.distributions.Distribution, TorchDistributionMixin):
         return values
 
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        total_count = self.total_count.expand(batch_shape)
-        if 'probs' in self.__dict__:
-            probs = self.probs.expand(batch_shape)
-            return Binomial(total_count, probs=probs, validate_args=validate_args)
-        else:
-            logits = self.logits.expand(batch_shape)
-            return Binomial(total_count, logits=logits, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            total_count = self.total_count.expand(batch_shape)
+            if 'probs' in self.__dict__:
+                probs = self.probs.expand(batch_shape)
+                return Binomial(total_count, probs=probs, validate_args=validate_args)
+            else:
+                logits = self.logits.expand(batch_shape)
+                return Binomial(total_count, logits=logits, validate_args=validate_args)

--- a/pyro/distributions/half_cauchy.py
+++ b/pyro/distributions/half_cauchy.py
@@ -6,6 +6,7 @@ from torch.distributions import constraints
 from torch.distributions.transforms import AbsTransform, AffineTransform
 from torch.distributions.utils import broadcast_all
 
+from pyro.distributions.util import ShapeMismatchError
 from pyro.distributions.torch import Cauchy, TransformedDistribution
 
 
@@ -49,6 +50,10 @@ class HalfCauchy(TransformedDistribution):
         return self.base_dist.entropy() - math.log(2)
 
     def expand(self, batch_shape):
-        loc = self.loc.expand(batch_shape)
-        scale = self.scale.expand(batch_shape)
-        return HalfCauchy(loc, scale)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            loc = self.loc.expand(batch_shape)
+            scale = self.scale.expand(batch_shape)
+            return HalfCauchy(loc, scale)

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -3,197 +3,304 @@ from __future__ import absolute_import, division, print_function
 import torch
 
 from pyro.distributions.torch_distribution import TorchDistributionMixin
+from pyro.distributions.util import ShapeMismatchError
 
 
 class Bernoulli(torch.distributions.Bernoulli, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        if 'probs' in self.__dict__:
-            probs = self.probs.expand(batch_shape)
-            return Bernoulli(probs=probs, validate_args=validate_args)
-        else:
-            logits = self.logits.expand(batch_shape)
-            return Bernoulli(logits=logits, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            if 'probs' in self.__dict__:
+                probs = self.probs.expand(batch_shape)
+                return Bernoulli(probs=probs, validate_args=validate_args)
+            else:
+                logits = self.logits.expand(batch_shape)
+                return Bernoulli(logits=logits, validate_args=validate_args)
 
 
 class Beta(torch.distributions.Beta, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        concentration1 = self.concentration1.expand(batch_shape)
-        concentration0 = self.concentration0.expand(batch_shape)
-        return Beta(concentration1, concentration0, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            concentration1 = self.concentration1.expand(batch_shape)
+            concentration0 = self.concentration0.expand(batch_shape)
+            beta = Beta(concentration1, concentration0, validate_args=validate_args)
+            beta.has_rsample = getattr(self, 'has_rsample')
+            return beta
 
 
 class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
     def expand(self, batch_shape):
-        batch_shape = torch.Size(batch_shape)
-        validate_args = self.__dict__.get('validate_args')
-        if 'probs' in self.__dict__:
-            probs = self.probs.expand(batch_shape + self.probs.shape[-1:])
-            return Categorical(probs=probs, validate_args=validate_args)
-        else:
-            logits = self.logits.expand(batch_shape + self.logits.shape[-1:])
-            return Categorical(logits=logits, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            batch_shape = torch.Size(batch_shape)
+            validate_args = self.__dict__.get('validate_args')
+            if 'probs' in self.__dict__:
+                probs = self.probs.expand(batch_shape + self.probs.shape[-1:])
+                return Categorical(probs=probs, validate_args=validate_args)
+            else:
+                logits = self.logits.expand(batch_shape + self.logits.shape[-1:])
+                return Categorical(logits=logits, validate_args=validate_args)
 
 
 class Cauchy(torch.distributions.Cauchy, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        loc = self.loc.expand(batch_shape)
-        scale = self.scale.expand(batch_shape)
-        return Cauchy(loc, scale, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            loc = self.loc.expand(batch_shape)
+            scale = self.scale.expand(batch_shape)
+            cauchy = Cauchy(loc, scale, validate_args=validate_args)
+            cauchy.has_rsample = getattr(self, 'has_rsample')
+            return cauchy
 
 
 class Chi2(torch.distributions.Chi2, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        df = self.df.expand(batch_shape)
-        return Chi2(df, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            df = self.df.expand(batch_shape)
+            chi2 = Chi2(df, validate_args=validate_args)
+            chi2.has_rsample = getattr(self, 'has_rsample')
+            return chi2
 
 
 class Dirichlet(torch.distributions.Dirichlet, TorchDistributionMixin):
     def expand(self, batch_shape):
-        batch_shape = torch.Size(batch_shape)
-        validate_args = self.__dict__.get('validate_args')
-        concentration = self.concentration.expand(batch_shape + self.event_shape)
-        return Dirichlet(concentration, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            batch_shape = torch.Size(batch_shape)
+            validate_args = self.__dict__.get('validate_args')
+            concentration = self.concentration.expand(batch_shape + self.event_shape)
+            dirichlet = Dirichlet(concentration, validate_args=validate_args)
+            dirichlet.has_rsample = getattr(self, 'has_rsample')
+            return dirichlet
 
 
 class Exponential(torch.distributions.Exponential, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        rate = self.rate.expand(batch_shape)
-        return Exponential(rate, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            rate = self.rate.expand(batch_shape)
+            exponential = Exponential(rate, validate_args=validate_args)
+            exponential.has_rsample = getattr(self, 'has_rsample')
+            return exponential
 
 
 class Gamma(torch.distributions.Gamma, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        concentration = self.concentration.expand(batch_shape)
-        rate = self.rate.expand(batch_shape)
-        return Gamma(concentration, rate, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            concentration = self.concentration.expand(batch_shape)
+            rate = self.rate.expand(batch_shape)
+            gamma = Gamma(concentration, rate, validate_args=validate_args)
+            gamma.has_rsample = getattr(self, 'has_rsample')
+            return gamma
 
 
 class Geometric(torch.distributions.Geometric, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        if 'probs' in self.__dict__:
-            probs = self.probs.expand(batch_shape)
-            return Geometric(probs=probs, validate_args=validate_args)
-        else:
-            logits = self.logits.expand(batch_shape)
-            return Geometric(logits=logits, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            if 'probs' in self.__dict__:
+                probs = self.probs.expand(batch_shape)
+                return Geometric(probs=probs, validate_args=validate_args)
+            else:
+                logits = self.logits.expand(batch_shape)
+                return Geometric(logits=logits, validate_args=validate_args)
 
 
 class Gumbel(torch.distributions.Gumbel, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        loc = self.loc.expand(batch_shape)
-        scale = self.scale.expand(batch_shape)
-        return Gumbel(loc, scale, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            loc = self.loc.expand(batch_shape)
+            scale = self.scale.expand(batch_shape)
+            return Gumbel(loc, scale, validate_args=validate_args)
 
 
 class Independent(torch.distributions.Independent, TorchDistributionMixin):
     def expand(self, batch_shape):
-        batch_shape = torch.Size(batch_shape)
-        validate_args = self.__dict__.get('validate_args')
-        extra_shape = self.base_dist.event_shape[:self.reinterpreted_batch_ndims]
-        base_dist = self.base_dist.expand(batch_shape + extra_shape)
-        return Independent(base_dist, self.reinterpreted_batch_ndims, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            batch_shape = torch.Size(batch_shape)
+            validate_args = self.__dict__.get('validate_args')
+            extra_shape = self.base_dist.event_shape[:self.reinterpreted_batch_ndims]
+            base_dist = self.base_dist.expand(batch_shape + extra_shape)
+            return Independent(base_dist, self.reinterpreted_batch_ndims, validate_args=validate_args)
 
 
 class Laplace(torch.distributions.Laplace, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        loc = self.loc.expand(batch_shape)
-        scale = self.scale.expand(batch_shape)
-        return Laplace(loc, scale, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            loc = self.loc.expand(batch_shape)
+            scale = self.scale.expand(batch_shape)
+            laplace = Laplace(loc, scale, validate_args=validate_args)
+            laplace.has_rsample = getattr(self, 'has_rsample')
+            return laplace
 
 
 class LogNormal(torch.distributions.LogNormal, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        loc = self.loc.expand(batch_shape)
-        scale = self.scale.expand(batch_shape)
-        return LogNormal(loc, scale, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            loc = self.loc.expand(batch_shape)
+            scale = self.scale.expand(batch_shape)
+            return LogNormal(loc, scale, validate_args=validate_args)
 
 
 class Multinomial(torch.distributions.Multinomial, TorchDistributionMixin):
     def expand(self, batch_shape):
-        batch_shape = torch.Size(batch_shape)
-        validate_args = self.__dict__.get('validate_args')
-        if 'probs' in self.__dict__:
-            probs = self.probs.expand(batch_shape + self.event_shape)
-            return Multinomial(self.total_count, probs=probs, validate_args=validate_args)
-        else:
-            logits = self.logits.expand(batch_shape + self.event_shape)
-            return Multinomial(self.total_count, logits=logits, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            batch_shape = torch.Size(batch_shape)
+            validate_args = self.__dict__.get('validate_args')
+            if 'probs' in self.__dict__:
+                probs = self.probs.expand(batch_shape + self.event_shape)
+                return Multinomial(self.total_count, probs=probs, validate_args=validate_args)
+            else:
+                logits = self.logits.expand(batch_shape + self.event_shape)
+                return Multinomial(self.total_count, logits=logits, validate_args=validate_args)
 
 
 class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributionMixin):
     def expand(self, batch_shape):
-        batch_shape = torch.Size(batch_shape)
-        validate_args = self.__dict__.get('validate_args')
-        loc = self.loc.expand(batch_shape + self.event_shape)
-        if 'scale_tril' in self.__dict__:
-            scale_tril = self.scale_tril.expand(batch_shape + self.event_shape + self.event_shape)
-            return MultivariateNormal(loc, scale_tril=scale_tril, validate_args=validate_args)
-        elif 'covariance_matrix' in self.__dict__:
-            covariance_matrix = self.covariance_matrix.expand(batch_shape + self.event_shape + self.event_shape)
-            return MultivariateNormal(loc, covariance_matrix=covariance_matrix, validate_args=validate_args)
-        else:
-            precision_matrix = self.precision_matrix.expand(batch_shape + self.event_shape + self.event_shape)
-            return MultivariateNormal(loc, precision_matrix=precision_matrix, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            batch_shape = torch.Size(batch_shape)
+            validate_args = self.__dict__.get('validate_args')
+            loc = self.loc.expand(batch_shape + self.event_shape)
+            if 'scale_tril' in self.__dict__:
+                scale_tril = self.scale_tril.expand(batch_shape + self.event_shape + self.event_shape)
+                mvn = MultivariateNormal(loc, scale_tril=scale_tril, validate_args=validate_args)
+            elif 'covariance_matrix' in self.__dict__:
+                covariance_matrix = self.covariance_matrix.expand(batch_shape + self.event_shape + self.event_shape)
+                mvn = MultivariateNormal(loc, covariance_matrix=covariance_matrix, validate_args=validate_args)
+            else:
+                precision_matrix = self.precision_matrix.expand(batch_shape + self.event_shape + self.event_shape)
+                mvn = MultivariateNormal(loc, precision_matrix=precision_matrix, validate_args=validate_args)
+            mvn.has_rsample = getattr(self, 'has_rsample')
+            return mvn
 
 
 class Normal(torch.distributions.Normal, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        loc = self.loc.expand(batch_shape)
-        scale = self.scale.expand(batch_shape)
-        return Normal(loc, scale, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            loc = self.loc.expand(batch_shape)
+            scale = self.scale.expand(batch_shape)
+            normal = Normal(loc, scale, validate_args=validate_args)
+            normal.has_rsample = getattr(self, 'has_rsample')
+            return normal
 
 
 class OneHotCategorical(torch.distributions.OneHotCategorical, TorchDistributionMixin):
     def expand(self, batch_shape):
-        batch_shape = torch.Size(batch_shape)
-        validate_args = self.__dict__.get('validate_args')
-        if 'probs' in self.__dict__:
-            probs = self.probs.expand(batch_shape + self.event_shape)
-            return OneHotCategorical(probs=probs, validate_args=validate_args)
-        else:
-            logits = self.logits.expand(batch_shape + self.event_shape)
-            return OneHotCategorical(logits=logits, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            batch_shape = torch.Size(batch_shape)
+            validate_args = self.__dict__.get('validate_args')
+            if 'probs' in self.__dict__:
+                probs = self.probs.expand(batch_shape + self.event_shape)
+                return OneHotCategorical(probs=probs, validate_args=validate_args)
+            else:
+                logits = self.logits.expand(batch_shape + self.event_shape)
+                return OneHotCategorical(logits=logits, validate_args=validate_args)
 
 
 class Poisson(torch.distributions.Poisson, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        rate = self.rate.expand(batch_shape)
-        return Poisson(rate, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            rate = self.rate.expand(batch_shape)
+            return Poisson(rate, validate_args=validate_args)
 
 
 class StudentT(torch.distributions.StudentT, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        df = self.df.expand(batch_shape)
-        loc = self.loc.expand(batch_shape)
-        scale = self.scale.expand(batch_shape)
-        return StudentT(df, loc, scale, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            df = self.df.expand(batch_shape)
+            loc = self.loc.expand(batch_shape)
+            scale = self.scale.expand(batch_shape)
+            student_t = StudentT(df, loc, scale, validate_args=validate_args)
+            student_t.has_rsample = getattr(self, 'has_rsample')
+            return student_t
 
 
 class TransformedDistribution(torch.distributions.TransformedDistribution, TorchDistributionMixin):
     def expand(self, batch_shape):
-        base_dist = self.base_dist.expand(batch_shape)
-        return TransformedDistribution(base_dist, self.transforms)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            base_dist = self.base_dist.expand(batch_shape)
+            return TransformedDistribution(base_dist, self.transforms)
 
 
 class Uniform(torch.distributions.Uniform, TorchDistributionMixin):
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
-        low = self.low.expand(batch_shape)
-        high = self.high.expand(batch_shape)
-        return Uniform(low, high, validate_args=validate_args)
+        try:
+            sample_shape = self._sample_shape(batch_shape)
+            return self.expand_by(sample_shape)
+        except ShapeMismatchError:
+            validate_args = self.__dict__.get('validate_args')
+            low = self.low.expand(batch_shape)
+            high = self.high.expand(batch_shape)
+            uniform = Uniform(low, high, validate_args=validate_args)
+            uniform.has_rsample = getattr(self, 'has_rsample')
+            return uniform
 
 
 # Programmatically load all distributions from PyTorch.

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -230,3 +230,7 @@ def validation_enabled(is_validate=True):
         yield
     finally:
         enable_validation(distribution_validation_status)
+
+
+class ShapeMismatchError(ValueError):
+    pass

--- a/tests/contrib/autoguide/test_advi.py
+++ b/tests/contrib/autoguide/test_advi.py
@@ -24,7 +24,7 @@ from tests.common import assert_equal
 def test_scores(auto_class):
     def model():
         if auto_class is AutoIAFNormal:
-            pyro.sample("z", dist.Normal(0.0, 1.0).expand(10))
+            pyro.sample("z", dist.Normal(0.0, 1.0).expand([10]))
         else:
             pyro.sample("z", dist.Normal(0.0, 1.0))
 
@@ -224,7 +224,7 @@ def test_discrete_parallel(continuous_class):
 def test_guide_list(auto_class):
 
     def model():
-        pyro.sample("x", dist.Normal(0., 1.).expand(2))
+        pyro.sample("x", dist.Normal(0., 1.).expand([2]))
         pyro.sample("y", dist.MultivariateNormal(torch.zeros(5), torch.eye(5, 5)))
 
     guide = AutoGuideList(model)

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -6,6 +6,7 @@ import torch
 
 import pyro
 import pyro.distributions as dist
+from pyro.distributions.torch_distribution import ReshapedDistribution
 from pyro.distributions.util import broadcast_shape
 from tests.common import assert_equal, xfail_if_not_implemented
 
@@ -99,7 +100,9 @@ def test_distribution_validate_args(dist_class, args, validate_args):
 
 
 def check_sample_shapes(small, large):
-    if isinstance(small, dist.LogNormal):
+    if isinstance(small, dist.LogNormal) or (
+            isinstance(small, ReshapedDistribution) and
+            isinstance(small.base_dist, dist.LogNormal)):
         # Ignore broadcasting bug in LogNormal:
         # https://github.com/pytorch/pytorch/pull/7269
         return
@@ -148,13 +151,32 @@ def test_expand_existing_dim(dist, shape_type):
             check_sample_shapes(small, large)
 
 
-def test_expand_twice(dist):
+@pytest.mark.parametrize("sample_shapes", [
+    [(2, 1), (2, 3)],
+    [(2, 1, 1), (2, 1, 3), (2, 5, 3)],
+])
+def test_subsequent_expands_ok(dist, sample_shapes):
+    for idx in range(dist.get_num_test_data()):
+        d = dist.pyro_dist(**dist.get_dist_params(idx))
+        original_batch_shape = d.batch_shape
+        for shape in sample_shapes:
+            proposed_batch_shape = torch.Size(shape) + original_batch_shape
+            with xfail_if_not_implemented():
+                n = d.expand(proposed_batch_shape)
+            assert n.batch_shape == proposed_batch_shape
+            check_sample_shapes(d, n)
+            d = n
+
+
+@pytest.mark.parametrize("initial_shape, proposed_shape", [
+    [(2, 1), (4, 3)],
+    [(2, 4), (2, 2, 1)],
+    [(1, 2, 1), (2, 1)],
+])
+def test_expand_error(dist, initial_shape, proposed_shape):
     for idx in range(dist.get_num_test_data()):
         small = dist.pyro_dist(**dist.get_dist_params(idx))
-        medium = small.expand(torch.Size((2, 1)) + small.batch_shape)
-        batch_shape = torch.Size((2, 3)) + small.batch_shape
-        with xfail_if_not_implemented():
-            large = medium.expand(batch_shape)
-        assert large.batch_shape == batch_shape
-        check_sample_shapes(small, large)
-        check_sample_shapes(medium, large)
+        medium = small.expand(torch.Size(initial_shape) + small.batch_shape)
+        proposed_batch_shape = torch.Size(proposed_shape) + small.batch_shape
+        with pytest.raises(ValueError):
+            medium.expand(proposed_batch_shape)

--- a/tests/infer/test_conjugate_gradients.py
+++ b/tests/infer/test_conjugate_gradients.py
@@ -16,7 +16,7 @@ class ConjugateChainGradientTests(GaussianChain):
         pyro.clear_param_store()
         self.setup_chain(N)
 
-        elbo = TraceGraph_ELBO(num_particles=10000, vectorize_particles=True, max_iarange_nesting=1)
+        elbo = TraceGraph_ELBO(num_particles=100000, vectorize_particles=True, max_iarange_nesting=1)
         elbo.loss_and_grads(self.model, self.guide, reparameterized=reparameterized)
 
         for i in range(1, N + 1):

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -71,7 +71,7 @@ def test_subsample_gradient(Elbo, reparameterized, subsample):
 def test_iarange(Elbo, reparameterized):
     pyro.clear_param_store()
     data = torch.tensor([-0.5, 2.0])
-    num_particles = 20000
+    num_particles = 100000
     precision = 0.06
     Normal = dist.Normal if reparameterized else fakes.NonreparameterizedNormal
 
@@ -119,7 +119,7 @@ def test_iarange(Elbo, reparameterized):
 def test_iarange_elbo_vectorized_particles(Elbo, reparameterized):
     pyro.clear_param_store()
     data = torch.tensor([-0.5, 2.0])
-    num_particles = 20000
+    num_particles = 100000
     precision = 0.06
     Normal = dist.Normal if reparameterized else fakes.NonreparameterizedNormal
 


### PR DESCRIPTION
Mostly addresses #1180, except for another perf issue (relatively minor) that I discovered and mentioned in #1180.

### Changes:
 - `.expand` calls `.expand_by` if we are merely appending batch dims to the left.
 - Implements `ReshapedDistribution.expand`. Multiple calls to this should be much faster especially if the base distribution has scalar parameters as this merely readjusts the sample shape. Without this implementation, multiple expands would otherwise call the more restrictive `TorchDistributionMixin.expand` and fail. e.g. 

    ```python
    d = dist.Normal(0., 1.)
    d.expand([2, 1, 1])  # Returns ReshapedDistribution
    d.expand([2, 1, 2])  # Calls TorchDistributionMixin.expand which 
                         # is more restrictive and fails.
     ```
 - Our non reparameterized distributions were accidentally getting their `has_rsample` attribute reset when expanded. This adds a fix for the issue, and increases the number of particles for the failing tests.

### Perf impact (pasted from #1180):
`test_enum.py::test_elbo_iarange_iarange` (set of 81 total tests) on my local mac notebook:

 - Without any fixes - 46 seconds.
 - Deferring to .expand - 35 seconds.
 - Using iarange as rightmost - 30 seconds.
