### PR TITLE
Implement flat assignment solvers (exact, bp, sparse)

### DIFF
--- a/pyro/contrib/tracking/assignment.py
+++ b/pyro/contrib/tracking/assignment.py
@@ -30,6 +30,109 @@ def _exp(value):
     return value.exp()
 
 
+class MarginalAssignment(object):
+    """
+    Computes marginal data associations between objects and detections.
+
+    This assumes that each detection corresponds to zero or one object,
+    and each object corresponds to zero or more detections. Specifically
+    this does not assume detections have been partitioned into frames of
+    mutual exclusion as is common in 2-D assignment problems.
+
+    :param torch.Tensor exists_logits: a tensor of shape ``[num_objects]``
+        representing per-object factors for existence of each potential object.
+    :param torch.Tensor assign_logits: a tensor of shape
+        ``[num_detections, num_objects]`` representing per-edge factors of
+        assignment probability, where each edge denotes that a given detection
+        associates with a single object.
+    :param int bp_iters: optional number of belief propagation iterations. If
+        unspecified or ``None`` an expensive exact algorithm will be used.
+
+    :ivar int num_detections: the number of detections
+    :ivar int num_objects: the number of (potentially existing) objects
+    :ivar pyro.distributions.Bernoulli exists_dist: a mean field posterior
+        distribution over object existence.
+    :ivar pyro.distributions.Categorical assign_dist: a mean field posterior
+        distribution over the object (or None) to which each detection
+        associates.  This has ``.event_shape == (num_objects + 1,)`` where the
+        final element denotes spurious detection, and
+        ``.batch_shape == (num_frames, num_detections)``.
+    """
+    def __init__(self, exists_logits, assign_logits, bp_iters=None):
+        assert exists_logits.dim() == 1, exists_logits.shape
+        assert assign_logits.dim() == 2, assign_logits.shape
+        assert assign_logits.shape[-1] == exists_logits.shape[-1]
+        self.num_detections, self.num_objects = assign_logits.shape
+
+        # Clamp to avoid NANs.
+        exists_logits = exists_logits.clamp(min=-40, max=40)
+        assign_logits = assign_logits.clamp(min=-40, max=40)
+
+        # This does all the work.
+        if bp_iters is None:
+            exists, assign = compute_marginals(exists_logits, assign_logits)
+        else:
+            exists, assign = compute_marginals_bp(exists_logits, assign_logits, bp_iters)
+
+        # Wrap the results in Distribution objects.
+        # This adds a final logit=0 element denoting spurious detection.
+        padded_assign = torch.nn.functional.pad(assign, (0, 1), "constant", 0.0)
+        self.assign_dist = dist.Categorical(logits=padded_assign)
+        self.exists_dist = dist.Bernoulli(logits=exists)
+
+
+class MarginalAssignmentSparse(object):
+    """
+    A cheap sparse version of :class:`MarginalAssignment`.
+
+    :param int num_detections: the number of detections
+    :param int num_objects: the number of (potentially existing) objects
+    :param torch.LongTensor edges: a ``[2, num_edges]``-shaped tensor of
+        (detection, object) index pairs specifying feasible associations.
+    :param torch.Tensor exists_logits: a tensor of shape ``[num_objects]``
+        representing per-object factors for existence of each potential object.
+    :param torch.Tensor assign_logits: a tensor of shape ``[num_edges]``
+        representing per-edge factors of assignment probability, where each
+        edge denotes that a given detection associates with a single object.
+    :param int bp_iters: optional number of belief propagation iterations. If
+        unspecified or ``None`` an expensive exact algorithm will be used.
+
+    :ivar int num_detections: the number of detections
+    :ivar int num_objects: the number of (potentially existing) objects
+    :ivar pyro.distributions.Bernoulli exists_dist: a mean field posterior
+        distribution over object existence.
+    :ivar pyro.distributions.Categorical assign_dist: a mean field posterior
+        distribution over the object (or None) to which each detection
+        associates.  This has ``.event_shape == (num_objects + 1,)`` where the
+        final element denotes spurious detection, and
+        ``.batch_shape == (num_frames, num_detections)``.
+    """
+    def __init__(self, num_objects, num_detections, edges, exists_logits, assign_logits, bp_iters):
+        assert edges.dim() == 2, edges.shape
+        assert edges.shape[0] == 2, edges.shape
+        assert exists_logits.shape == (num_objects,), exists_logits.shape
+        assert assign_logits.shape == edges.shape[1:], assign_logits.shape
+        self.num_objects = num_objects
+        self.num_detections = num_detections
+        self.edges = edges
+
+        # Clamp to avoid NANs.
+        exists_logits = exists_logits.clamp(min=-40, max=40)
+        assign_logits = assign_logits.clamp(min=-40, max=40)
+
+        # This does all the work.
+        exists, assign = compute_marginals_sparse_bp(
+            num_objects, num_detections, edges, exists_logits, assign_logits, bp_iters)
+
+        # Wrap the results in Distribution objects.
+        # This adds a final logit=0 element denoting spurious detection.
+        padded_assign = assign.new_empty(num_detections, num_objects + 1).fill_(-float('inf'))
+        padded_assign[:, -1] = 0
+        padded_assign[edges[0], edges[1]] = assign
+        self.assign_dist = dist.Categorical(logits=padded_assign)
+        self.exists_dist = dist.Bernoulli(logits=exists)
+
+
 class MarginalAssignmentPersistent(object):
     """
     This computes marginal distributions of a multi-frame multi-object
@@ -45,23 +148,24 @@ class MarginalAssignmentPersistent(object):
     variable number of detections, simply set corresponding elements of
     ``assign_logits`` to ``-float('inf')``.
 
-    :param torch.Tensor exists_logits: a tensor of shape `[num_objects]`
+    :param torch.Tensor exists_logits: a tensor of shape ``[num_objects]``
         representing per-object factors for existence of each potential object.
     :param torch.Tensor assign_logits: a tensor of shape
-        `[num_frames, num_detections, num_objects]` representing per-edge
+        ``[num_frames, num_detections, num_objects]`` representing per-edge
         factors of assignment probability, where each edge denotes that at a
         given time frame a given detection associates with a single object.
     :param int bp_iters: optional number of belief propagation iterations. If
         unspecified or ``None`` an expensive exact algorithm will be used.
+
     :ivar int num_frames: the number of time frames
     :ivar int num_detections: the (maximum) number of detections per frame
     :ivar int num_objects: the number of (potentially existing) objects
-    :ivar pyro.distributions.Bernoulli exists_dist: a mean field distribution
-        over object existence.
-    :ivar pyro.distributions.Categorical assign_dist: a mean field distribution
-        over the object (or None) to which each detection associates.
-        This has ``.event_shape == (num_objects + 1,)`` where the final element
-        denotes spurious detection, and
+    :ivar pyro.distributions.Bernoulli exists_dist: a mean field posterior
+        distribution over object existence.
+    :ivar pyro.distributions.Categorical assign_dist: a mean field posterior
+        distribution over the object (or None) to which each detection
+        associates.  This has ``.event_shape == (num_objects + 1,)`` where the
+        final element denotes spurious detection, and
         ``.batch_shape == (num_frames, num_detections)``.
     """
     def __init__(self, exists_logits, assign_logits, bp_iters=None):
@@ -89,10 +193,110 @@ class MarginalAssignmentPersistent(object):
         assert self.exists_dist.batch_shape == (self.num_objects,)
 
 
+def compute_marginals(exists_logits, assign_logits):
+    """
+    This implements exact inference of pairwise marginals via
+    enumeration. This is very expensive and is only useful for testing.
+
+    See :class:`MarginalAssignment` for args and problem description.
+    """
+    num_detections, num_objects = assign_logits.shape
+    assert exists_logits.shape == (num_objects,)
+
+    exists_probs = exists_logits.new_zeros(2, num_objects)  # [not exist, exist]
+    assign_probs = assign_logits.new_zeros(num_detections, num_objects + 1)
+    for assign in itertools.product(range(num_objects + 1), repeat=num_detections):
+        assign_part = sum(assign_logits[j, i] for j, i in enumerate(assign) if i < num_objects)
+        for exists in itertools.product(*[[1] if i in assign else [0, 1] for i in range(num_objects)]):
+            exists_part = sum(exists_logits[i] for i, e in enumerate(exists) if e)
+            prob = _exp(exists_part + assign_part)
+            for i, e in enumerate(exists):
+                exists_probs[e, i] += prob
+            for j, i in enumerate(assign):
+                assign_probs[j, i] += prob
+
+    # Convert from probs to logits.
+    exists = exists_probs.log()
+    assign = assign_probs.log()
+    exists = exists[1] - exists[0]
+    assign = assign[:, :-1] - assign[:, -1:]
+    return exists, assign
+
+
+def compute_marginals_bp(exists_logits, assign_logits, bp_iters):
+    """
+    This implements approximate inference of pairwise marginals via
+    loopy belief propagation, adapting the approach of [1].
+
+    See :class:`MarginalAssignment` for args and problem description.
+
+    [1] Jason L. Williams, Roslyn A. Lau (2014)
+        Approximate evaluation of marginal association probabilities with
+        belief propagation
+        https://arxiv.org/abs/1209.6299
+    """
+    message_e_to_a = exists_logits.new_zeros(assign_logits.shape)
+    message_a_to_e = exists_logits.new_zeros(assign_logits.shape)
+    for i in range(bp_iters):
+        message_e_to_a = -(message_a_to_e - message_a_to_e.sum(0, True) - exists_logits).exp().log1p()
+        joint = (assign_logits + message_e_to_a).exp()
+        message_a_to_e = (assign_logits - torch.log1p(joint.sum(1, True) - joint)).exp().log1p()
+        _warn_if_nan(message_e_to_a, 'message_e_to_a iter {}'.format(i))
+        _warn_if_nan(message_a_to_e, 'message_a_to_e iter {}'.format(i))
+
+    # Convert from probs to logits.
+    exists = exists_logits + message_a_to_e.sum(0)
+    assign = assign_logits + message_e_to_a
+    _warn_if_nan(exists, 'exists')
+    _warn_if_nan(assign, 'assign')
+    return exists, assign
+
+
+def compute_marginals_sparse_bp(num_objects, num_detections, edges,
+                                exists_logits, assign_logits, bp_iters):
+    """
+    This implements approximate inference of pairwise marginals via
+    loopy belief propagation, adapting the approach of [1].
+
+    See :class:`MarginalAssignmentSparse` for args and problem description.
+
+    [1] Jason L. Williams, Roslyn A. Lau (2014)
+        Approximate evaluation of marginal association probabilities with
+        belief propagation
+        https://arxiv.org/abs/1209.6299
+    """
+    exists_factor = exists_logits[edges[1]]
+
+    def sparse_sum(x, dim, keepdim=False):
+        assert dim in (0, 1)
+        x = x.new_zeros([num_objects, num_detections][dim]).scatter_add_(0, edges[1 - dim], x)
+        if keepdim:
+            x = x[edges[1 - dim]]
+        return x
+
+    message_e_to_a = exists_logits.new_zeros(assign_logits.shape)
+    message_a_to_e = exists_logits.new_zeros(assign_logits.shape)
+    for i in range(bp_iters):
+        message_e_to_a = -(message_a_to_e - sparse_sum(message_a_to_e, 0, True) - exists_factor).exp().log1p()
+        joint = (assign_logits + message_e_to_a).exp()
+        message_a_to_e = (assign_logits - torch.log1p(sparse_sum(joint, 1, True) - joint)).exp().log1p()
+        _warn_if_nan(message_e_to_a, 'message_e_to_a iter {}'.format(i))
+        _warn_if_nan(message_a_to_e, 'message_a_to_e iter {}'.format(i))
+
+    # Convert from probs to logits.
+    exists = exists_logits + sparse_sum(message_a_to_e, 0)
+    assign = assign_logits + message_e_to_a
+    _warn_if_nan(exists, 'exists')
+    _warn_if_nan(assign, 'assign')
+    return exists, assign
+
+
 def compute_marginals_persistent(exists_logits, assign_logits):
     """
     This implements exact inference of pairwise marginals via
     enumeration. This is very expensive and is only useful for testing.
+
+    See :class:`MarginalAssignmentPersistent` for args and problem description.
     """
     num_frames, num_detections, num_objects = assign_logits.shape
     assert exists_logits.shape == (num_objects,)
@@ -128,7 +332,7 @@ def compute_marginals_persistent(exists_logits, assign_logits):
                 for i, j in assign:
                     assign_probs[t, j, i] += prob
 
-    # convert from probs to logits
+    # Convert from probs to logits.
     exists = exists_probs.log() - (total - exists_probs).log()
     assign = assign_probs.log() - (total - assign_probs.sum(-1, True)).log()
     _warn_if_nan(exists, 'exists')
@@ -140,6 +344,8 @@ def compute_marginals_persistent_bp(exists_logits, assign_logits, bp_iters):
     """
     This implements approximate inference of pairwise marginals via
     loopy belief propagation, adapting the approach of [1], [2].
+
+    See :class:`MarginalAssignmentPersistent` for args and problem description.
 
     [1] Jason L. Williams, Roslyn A. Lau (2014)
         Approximate evaluation of marginal association probabilities with

--- a/pyro/contrib/tracking/assignment.py
+++ b/pyro/contrib/tracking/assignment.py
@@ -18,9 +18,9 @@ def _warn_if_nan(tensor, name):
 
 
 def _product(factors):
-    result = 1
+    result = 1.
     for factor in factors:
-        result *= factor
+        result = result * factor
     return result
 
 
@@ -220,6 +220,8 @@ def compute_marginals(exists_logits, assign_logits):
     assign = assign_probs.log()
     exists = exists[1] - exists[0]
     assign = assign[:, :-1] - assign[:, -1:]
+    _warn_if_nan(exists, 'exists')
+    _warn_if_nan(assign, 'assign')
     return exists, assign
 
 

--- a/tests/contrib/tracking/test_assignment.py
+++ b/tests/contrib/tracking/test_assignment.py
@@ -161,8 +161,8 @@ def test_persistent_smoke(bp_iters):
     for assign in assign_dist.enumerate_support():
         log_prob = assign_dist.log_prob(assign).sum()
         e_grad, a_grad = grad(log_prob, [exists_logits, assign_logits], create_graph=True)
-        assert_finite(e_grad, 'dexists_probs/dexists_logits')
-        assert_finite(a_grad, 'dexists_probs/dassign_logits')
+        assert_finite(e_grad, 'dassign_probs/dexists_logits')
+        assert_finite(a_grad, 'dassign_probs/dassign_logits')
 
 
 @pytest.mark.parametrize('e', [-1., 0., 1.])
@@ -216,7 +216,6 @@ def test_flat_exact_2_2(e1, e2, a11, a12, a22):
     assert_equal(expected.assign_dist.probs, actual.assign_dist.probs)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize('num_frames', [1, 2, 3, 4])
 @pytest.mark.parametrize('num_objects', [1, 2, 3, 4])
 def test_flat_vs_persistent_exact(num_objects, num_frames):
@@ -225,8 +224,8 @@ def test_flat_vs_persistent_exact(num_objects, num_frames):
     exists_flat, assign_flat = compute_marginals(exists_logits, assign_logits)
     exists_full, assign_full = compute_marginals_persistent(exists_logits, assign_logits.unsqueeze(-2))
     assert_equal(exists_flat, exists_full)
-    assert assign_full.shape == (num_objects, num_frames, 1)
-    assert_equal(assign_flat, assign_full.squeeze(-1))
+    assert assign_full.shape == (num_frames, 1, num_objects)
+    assert_equal(assign_flat, assign_full.squeeze(1))
 
 
 @pytest.mark.parametrize('num_detections', [1, 2, 3, 4])

--- a/tests/contrib/tracking/test_assignment.py
+++ b/tests/contrib/tracking/test_assignment.py
@@ -1,17 +1,132 @@
 from __future__ import absolute_import, division, print_function
 
+import pyro
+import pyro.distributions as dist
 import pytest
 import torch
+from pyro.contrib.tracking.assignment import (MarginalAssignment, MarginalAssignmentPersistent,
+                                              MarginalAssignmentSparse, compute_marginals, compute_marginals_persistent,
+                                              compute_marginals_persistent_bp)
 from torch.autograd import grad
 
-from pyro.contrib.tracking.assignment import MarginalAssignmentPersistent
-from tests.common import xfail_if_not_implemented
+from tests.common import assert_equal, xfail_if_not_implemented
 
 INF = float('inf')
 
 
 def assert_finite(tensor, name):
     assert ((tensor - tensor) == 0).all(), 'bad {}: {}'.format(tensor, name)
+
+
+def logit(p):
+    return p.log() - (-p).log1p()
+
+
+def dense_to_sparse(assign_logits):
+    num_detections, num_objects = assign_logits.shape
+    edges = torch.LongTensor([[j, i] for j in range(num_detections) for i in range(num_objects)]).t()
+    assign_logits = assign_logits[edges[0], edges[1]]
+    return edges, assign_logits
+
+
+def sparse_to_dense(num_objects, num_detections, edges, assign_logits):
+    result = assign_logits.new_empty(num_detections, num_objects).fill_(-INF)
+    result[edges[0], edges[1]] = assign_logits
+    return result
+
+
+def test_dense_smoke():
+    num_objects = 4
+    num_detections = 2
+    pyro.set_rng_seed(0)
+    exists_logits = torch.zeros(num_objects)
+    assign_logits = logit(torch.tensor([
+        [0.5, 0.5, 0.0, 0.0],
+        [0.0, 0.5, 0.5, 0.5],
+    ]))
+    assert assign_logits.shape == (num_detections, num_objects)
+
+    solver = MarginalAssignment(exists_logits, assign_logits, bp_iters=5)
+
+    assert solver.exists_dist.batch_shape == (num_objects,)
+    assert solver.exists_dist.event_shape == ()
+    assert solver.assign_dist.batch_shape == (num_detections,)
+    assert solver.assign_dist.event_shape == ()
+    assert solver.assign_dist.probs.shape[-1] == num_objects + 1  # true + spurious
+
+    # test dense matches sparse
+    edges, assign_logits = dense_to_sparse(assign_logits)
+    other = MarginalAssignmentSparse(num_objects, num_detections, edges, exists_logits, assign_logits, bp_iters=5)
+    assert_equal(other.exists_dist.probs, solver.exists_dist.probs, prec=1e-3)
+    assert_equal(other.assign_dist.probs, solver.assign_dist.probs, prec=1e-3)
+
+
+def test_sparse_smoke():
+    num_objects = 4
+    num_detections = 2
+    pyro.set_rng_seed(0)
+    exists_logits = torch.zeros(num_objects)
+    edges = torch.LongTensor([
+        [0, 0, 1, 0, 1, 0],
+        [0, 1, 1, 2, 2, 3],
+    ])
+    assign_logits = logit(torch.tensor([0.99, 0.8, 0.2, 0.2, 0.8, 0.9]))
+    assert assign_logits.shape == edges.shape[1:]
+
+    solver = MarginalAssignmentSparse(num_objects, num_detections, edges,
+                                      exists_logits, assign_logits, bp_iters=5)
+
+    assert solver.exists_dist.batch_shape == (num_objects,)
+    assert solver.exists_dist.event_shape == ()
+    assert solver.assign_dist.batch_shape == (num_detections,)
+    assert solver.assign_dist.event_shape == ()
+    assert solver.assign_dist.probs.shape[-1] == num_objects + 1  # true + spurious
+
+    # test dense matches sparse
+    assign_logits = sparse_to_dense(num_objects, num_detections, edges, assign_logits)
+    other = MarginalAssignment(exists_logits, assign_logits, bp_iters=5)
+    assert_equal(other.exists_dist.probs, solver.exists_dist.probs, prec=1e-3)
+    assert_equal(other.assign_dist.probs, solver.assign_dist.probs, prec=1e-3)
+
+
+def test_sparse_grid_smoke():
+
+    def my_existence_prior(ox, oy):
+        return -0.5
+
+    def my_assign_prior(ox, oy, dx, dy):
+        return 0.0
+
+    num_detections = 3 * 3
+    detections = [[0, 1, 2],
+                  [3, 4, 5],
+                  [6, 7, 8]]
+    num_objects = 2 * 2
+    objects = [[0, 1],
+               [2, 3]]
+    edges = []
+    edge_coords = []
+    for x in range(2):
+        for y in range(2):
+            object_id = objects[x][y]
+            for dx in [0, 1]:
+                for dy in [0, 1]:
+                    detection_id = detections[x + dx][y + dy]
+                    edges.append((detection_id, object_id))
+                    edge_coords.append((x, y, x + dx, y + dy))
+    edges = torch.LongTensor(edges).t()
+    assert edges.shape == (2, 4 * 4)
+
+    exists_logits = torch.empty(num_objects)
+    for x in range(2):
+        for y in range(2):
+            object_id = objects[x][y]
+            exists_logits[object_id] = my_existence_prior(x, y)
+    assign_logits = torch.tensor([my_assign_prior(ox, oy, dx, dy)
+                                  for ox, oy, dx, dy in edge_coords])
+    assign = MarginalAssignmentSparse(num_objects, num_detections, edges,
+                                      exists_logits, assign_logits, bp_iters=10)
+    assert isinstance(assign.assign_dist, dist.Categorical)
 
 
 @pytest.mark.parametrize('bp_iters', [None, 10], ids=['enum', 'bp'])
@@ -48,3 +163,81 @@ def test_persistent_smoke(bp_iters):
         e_grad, a_grad = grad(log_prob, [exists_logits, assign_logits], create_graph=True)
         assert_finite(e_grad, 'dexists_probs/dexists_logits')
         assert_finite(a_grad, 'dexists_probs/dassign_logits')
+
+
+@pytest.mark.parametrize('e', [-1., 0., 1.])
+@pytest.mark.parametrize('a', [-1., 0., 1.])
+def test_flat_exact_1_1(e, a):
+    exists_logits = torch.tensor([e])
+    assign_logits = torch.tensor([[a]])
+    expected = MarginalAssignment(exists_logits, assign_logits, None)
+    actual = MarginalAssignment(exists_logits, assign_logits, 10)
+    assert_equal(expected.exists_dist.probs, actual.exists_dist.probs)
+    assert_equal(expected.assign_dist.probs, actual.assign_dist.probs)
+
+
+@pytest.mark.parametrize('e', [-1., 0., 1.])
+@pytest.mark.parametrize('a11', [-1., 0., 1.])
+@pytest.mark.parametrize('a21', [-1., 0., 1.])
+def test_flat_exact_2_1(e, a11, a21):
+    exists_logits = torch.tensor([e])
+    assign_logits = torch.tensor([[a11], [a21]])
+    expected = MarginalAssignment(exists_logits, assign_logits, None)
+    actual = MarginalAssignment(exists_logits, assign_logits, 10)
+    assert_equal(expected.exists_dist.probs, actual.exists_dist.probs)
+    assert_equal(expected.assign_dist.probs, actual.assign_dist.probs)
+
+
+@pytest.mark.parametrize('e1', [-1., 0., 1.])
+@pytest.mark.parametrize('e2', [-1., 0., 1.])
+@pytest.mark.parametrize('a11', [-1., 0., 1.])
+@pytest.mark.parametrize('a12', [-1., 0., 1.])
+def test_flat_exact_1_2(e1, e2, a11, a12):
+    exists_logits = torch.tensor([e1, e2])
+    assign_logits = torch.tensor([[a11, a12]])
+    expected = MarginalAssignment(exists_logits, assign_logits, None)
+    actual = MarginalAssignment(exists_logits, assign_logits, 10)
+    assert_equal(expected.exists_dist.probs, actual.exists_dist.probs)
+    assert_equal(expected.assign_dist.probs, actual.assign_dist.probs)
+
+
+@pytest.mark.parametrize('e1', [-1., 1.])
+@pytest.mark.parametrize('e2', [-1., 1.])
+@pytest.mark.parametrize('a11', [-1., 1.])
+@pytest.mark.parametrize('a12', [-1., 1.])
+@pytest.mark.parametrize('a22', [-1., 1.])
+def test_flat_exact_2_2(e1, e2, a11, a12, a22):
+    a21 = -INF
+    exists_logits = torch.tensor([e1, e2])
+    assign_logits = torch.tensor([[a11, a12], [a21, a22]])
+    expected = MarginalAssignment(exists_logits, assign_logits, None)
+    actual = MarginalAssignment(exists_logits, assign_logits, 10)
+    assert_equal(expected.exists_dist.probs, actual.exists_dist.probs)
+    assert_equal(expected.assign_dist.probs, actual.assign_dist.probs)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize('num_frames', [1, 2, 3, 4])
+@pytest.mark.parametrize('num_objects', [1, 2, 3, 4])
+def test_flat_vs_persistent_exact(num_objects, num_frames):
+    exists_logits = -2 * torch.rand(num_objects)
+    assign_logits = -2 * torch.rand(num_frames, num_objects)
+    exists_flat, assign_flat = compute_marginals(exists_logits, assign_logits)
+    exists_full, assign_full = compute_marginals_persistent(exists_logits, assign_logits.unsqueeze(-2))
+    assert_equal(exists_flat, exists_full)
+    assert assign_full.shape == (num_objects, num_frames, 1)
+    assert_equal(assign_flat, assign_full.squeeze(-1))
+
+
+@pytest.mark.parametrize('num_detections', [1, 2, 3, 4])
+@pytest.mark.parametrize('num_frames', [1, 2, 3, 4])
+@pytest.mark.parametrize('num_objects', [1, 2, 3, 4])
+def test_persistent_exact(num_objects, num_frames, num_detections):
+    pyro.set_rng_seed(0)
+    exists_logits = -2 * torch.rand(num_objects)
+    assign_logits = -2 * torch.rand(num_frames, num_detections, num_objects)
+    expected_exists, expected_assign = compute_marginals_persistent(exists_logits, assign_logits)
+    with xfail_if_not_implemented():
+        actual_exists, actual_assign = compute_marginals_persistent_bp(exists_logits, assign_logits, 10)
+    assert_equal(expected_exists, actual_exists)
+    assert_equal(expected_assign, actual_assign)


### PR DESCRIPTION
~~Blocked by #1186~~ 
Addresses #1185 
See [generated docs](http://fritzo.org/temp/pyro/html/contrib.tracking.html#module-pyro.contrib.tracking.assignment)

This implements approximate marginal inference for half-constrained 2-D assignment problems, i.e. problems where detections have not been grouped into frames of mutual exclusion. These implementations include:
- dense exact (expensive, for testing only)
- dense belief prop
- sparse belief prop

## Tested

- smoke tests for dense/sparse agreement
- value tests of dense/exact agreement
- value tests for agreement between persistent and flat assignment solvers
- this was also tested on internal applications