### PR TITLE
Fix incorrect EscapeMessenger semantics in the presence of BlockMessenger

### DIFF
--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -80,6 +80,8 @@ class NonlocalExit(Exception):
         """
         for frame in _PYRO_STACK:
             frame._reset()
+            if type(frame).__name__ == "BlockMessenger" and frame.hide_fn(self.site):
+                break
 
 
 def validate_message(msg):

--- a/tests/poutine/test_nesting.py
+++ b/tests/poutine/test_nesting.py
@@ -1,0 +1,25 @@
+import pyro
+import pyro.poutine as poutine
+import pyro.distributions as dist
+import pyro.poutine.runtime
+
+
+def test_nested_reset():
+
+    def nested_model():
+        pyro.sample("internal0", dist.Bernoulli(0.5))
+        with poutine.escape(escape_fn=lambda msg: msg["name"] == "internal2"):
+            pyro.sample("internal1", dist.Bernoulli(0.5))
+            pyro.sample("internal2", dist.Bernoulli(0.5))
+            pyro.sample("internal3", dist.Bernoulli(0.5))
+
+    with poutine.trace() as t2:
+        with poutine.block(hide=["internal2"]):
+            with poutine.trace() as t1:
+                try:
+                    nested_model()
+                except poutine.NonlocalExit as site_container:
+                    site_container.reset_stack()
+                    print(pyro.poutine.runtime._PYRO_STACK)
+                    assert "internal1" not in t1.trace
+                    assert "internal1" in t2.trace


### PR DESCRIPTION
This PR fixes an extremely nasty bug I ran into today and adds a simple regression test that would have caught it.

Currently, calling `NonlocalExit.reset_stack()` will call `_reset()` on every handler in the stack, clearing out any internal state.  When doing nested inference, this will reset `TraceMessenger`s outside the enclosing inference algorithm, causing variables not to show up in traces and breaking marginal likelihood calculations.  This PR modifies `NonlocalExit.reset_stack()` so that only the handlers inside the innermost remaining blocking `BlockMessenger` are actually reset.