### PR TITLE
Implement compute_marginals_persistent_bp()

### DIFF
--- a/pyro/contrib/tracking/assignment.py
+++ b/pyro/contrib/tracking/assignment.py
@@ -374,7 +374,7 @@ def compute_marginals_persistent_bp(exists_logits, assign_logits, bp_iters):
         odds_a = (assign_logits + message_b_to_a).exp()
         message_a_to_b = assign_logits - (odds_a.sum(1, True) - odds_a).log1p()
         message_b_to_e = (message_a_to_b.exp().sum(1).reciprocal() + 1).reciprocal().log1p()
-        message_e_to_b = message_b_to_e.sum(0) - message_b_to_e + exists_logits
+        message_e_to_b = exists_logits + message_b_to_e.sum(0) - message_b_to_e
         odds_b = (message_a_to_b * message_e_to_b.unsqueeze(1)).exp()
         message_b_to_a = message_e_to_b.unsqueeze(1) - (odds_b.sum(2, True) - odds_b).log1p()
 

--- a/pyro/contrib/tracking/assignment.py
+++ b/pyro/contrib/tracking/assignment.py
@@ -357,4 +357,35 @@ def compute_marginals_persistent_bp(exists_logits, assign_logits, bp_iters):
         A Complete Variational Tracker
         https://papers.nips.cc/paper/5572-a-complete-variational-tracker.pdf
     """
-    raise NotImplementedError
+    # This implements forward-backward message passing among three sets of variables:
+    #
+    #   a[t,j] ~ Categorical(num_objects + 1), detection -> object assignment
+    #   b[t,i] ~ Categorical(num_detections + 1), object -> detection assignment
+    #     e[i] ~ Bernonulli, whether each object exists
+    #
+    # Only assign = a and exists = e are returned.
+    num_frames, num_detections, num_objects = assign_logits.shape
+    message_a_to_b = assign_logits.new_zeros(num_frames, num_detections, num_objects)
+    message_b_to_a = assign_logits.new_zeros(num_frames, num_detections, num_objects)
+    message_b_to_e = assign_logits.new_zeros(num_frames, num_objects)
+    message_e_to_b = assign_logits.new_zeros(num_frames, num_objects)
+
+    for i in range(bp_iters):
+        odds_a = (assign_logits + message_b_to_a).exp()
+        message_a_to_b = assign_logits - (odds_a.sum(1, True) - odds_a).log1p()
+        message_b_to_e = (message_a_to_b.exp().sum(1).reciprocal() + 1).reciprocal().log1p()
+        message_e_to_b = message_b_to_e.sum(0) - message_b_to_e + exists_logits
+        odds_b = (message_a_to_b * message_e_to_b.unsqueeze(1)).exp()
+        message_b_to_a = message_e_to_b.unsqueeze(1) - (odds_b.sum(2, True) - odds_b).log1p()
+
+        _warn_if_nan(message_a_to_b, 'message_a_to_b iter {}'.format(i))
+        _warn_if_nan(message_b_to_e, 'message_b_to_e iter {}'.format(i))
+        _warn_if_nan(message_e_to_b, 'message_e_to_b iter {}'.format(i))
+        _warn_if_nan(message_b_to_a, 'message_b_to_a iter {}'.format(i))
+
+    # Convert from probs to logits.
+    exists = exists_logits + message_b_to_e.sum(0)
+    assign = assign_logits + message_b_to_a
+    _warn_if_nan(exists, 'exists')
+    _warn_if_nan(assign, 'assign')
+    return exists, assign

--- a/pyro/contrib/tracking/assignment.py
+++ b/pyro/contrib/tracking/assignment.py
@@ -370,11 +370,11 @@ def compute_marginals_persistent_bp(exists_logits, assign_logits, bp_iters):
 
     for i in range(bp_iters):
         odds_a = (assign_logits + message_b_to_a).exp()
-        message_a_to_b = assign_logits - (odds_a.sum(1, True) - odds_a).log1p()
-        message_b_to_e = (message_a_to_b.exp().sum(1).reciprocal() + 1).reciprocal().log1p()
+        message_a_to_b = assign_logits - (odds_a.sum(2, True) - odds_a).log1p()
+        message_b_to_e = message_a_to_b.exp().sum(1).log1p()
         message_e_to_b = exists_logits + message_b_to_e.sum(0) - message_b_to_e
-        odds_b = (message_a_to_b + message_e_to_b.unsqueeze(1)).exp()
-        message_b_to_a = message_e_to_b.unsqueeze(1) - (odds_b.sum(2, True) - odds_b).log1p()
+        odds_b = message_a_to_b.exp()
+        message_b_to_a = -((-message_e_to_b).exp().unsqueeze(1) + (1 + odds_b.sum(1, True) - odds_b)).log()
 
         _warn_if_nan(message_a_to_b, 'message_a_to_b iter {}'.format(i))
         _warn_if_nan(message_b_to_e, 'message_b_to_e iter {}'.format(i))

--- a/tests/contrib/tracking/test_assignment.py
+++ b/tests/contrib/tracking/test_assignment.py
@@ -213,6 +213,19 @@ def test_flat_exact_2_2(e1, e2, a11, a12, a22):
     assert_equal(expected.assign_dist.probs, actual.assign_dist.probs)
 
 
+@pytest.mark.parametrize('num_detections', [1, 2, 3, 4])
+@pytest.mark.parametrize('num_objects', [1, 2, 3, 4])
+def test_flat_bp_vs_exact(num_objects, num_detections):
+    pyro.set_rng_seed(0)
+    exists_logits = -2 * torch.rand(num_objects)
+    assign_logits = -2 * torch.rand(num_detections, num_objects)
+    expected = MarginalAssignment(exists_logits, assign_logits, None)
+    actual = MarginalAssignment(exists_logits, assign_logits, 10)
+    # these should only approximately agree
+    assert_equal(expected.exists_dist.probs, actual.exists_dist.probs, prec=0.01)
+    assert_equal(expected.assign_dist.probs, actual.assign_dist.probs, prec=0.01)
+
+
 @pytest.mark.parametrize('num_frames', [1, 2, 3, 4])
 @pytest.mark.parametrize('num_objects', [1, 2, 3, 4])
 @pytest.mark.parametrize('bp_iters', [None, 10], ids=['enum', 'bp'])
@@ -228,11 +241,12 @@ def test_flat_vs_persistent(num_objects, num_frames, bp_iters):
 @pytest.mark.parametrize('num_detections', [1, 2, 3, 4])
 @pytest.mark.parametrize('num_frames', [1, 2, 3, 4])
 @pytest.mark.parametrize('num_objects', [1, 2, 3, 4])
-def test_persistent_exact(num_objects, num_frames, num_detections):
+def test_persistent_bp_vs_exact(num_objects, num_frames, num_detections):
     pyro.set_rng_seed(0)
     exists_logits = -2 * torch.rand(num_objects)
     assign_logits = -2 * torch.rand(num_frames, num_detections, num_objects)
     expected = MarginalAssignmentPersistent(exists_logits, assign_logits, None)
     actual = MarginalAssignmentPersistent(exists_logits, assign_logits, 10)
-    assert_equal(expected.exists_dist.probs, actual.exists_dist.probs, prec=0.1)
-    assert_equal(expected.assign_dist.probs, actual.assign_dist.probs, prec=0.1)
+    # these should only approximately agree
+    assert_equal(expected.exists_dist.probs, actual.exists_dist.probs, prec=0.01)
+    assert_equal(expected.assign_dist.probs, actual.assign_dist.probs, prec=0.01)

--- a/tests/contrib/tracking/test_assignment.py
+++ b/tests/contrib/tracking/test_assignment.py
@@ -9,7 +9,7 @@ from pyro.contrib.tracking.assignment import (MarginalAssignment, MarginalAssign
                                               compute_marginals_persistent_bp)
 from torch.autograd import grad
 
-from tests.common import assert_equal, xfail_if_not_implemented
+from tests.common import assert_equal
 
 INF = float('inf')
 
@@ -141,8 +141,7 @@ def test_persistent_smoke(bp_iters):
                                   [[-1., -1., 1.],
                                    [1., 1., -1.]]], requires_grad=True)
 
-    with xfail_if_not_implemented():
-        assignment = MarginalAssignmentPersistent(exists_logits, assign_logits, bp_iters=bp_iters)
+    assignment = MarginalAssignmentPersistent(exists_logits, assign_logits, bp_iters=bp_iters)
     assert assignment.num_frames == 4
     assert assignment.num_detections == 2
     assert assignment.num_objects == 3
@@ -236,7 +235,6 @@ def test_persistent_exact(num_objects, num_frames, num_detections):
     exists_logits = -2 * torch.rand(num_objects)
     assign_logits = -2 * torch.rand(num_frames, num_detections, num_objects)
     expected_exists, expected_assign = compute_marginals_persistent(exists_logits, assign_logits)
-    with xfail_if_not_implemented():
-        actual_exists, actual_assign = compute_marginals_persistent_bp(exists_logits, assign_logits, 10)
-    assert_equal(expected_exists, actual_exists)
-    assert_equal(expected_assign, actual_assign)
+    actual_exists, actual_assign = compute_marginals_persistent_bp(exists_logits, assign_logits, 10)
+    assert_equal(expected_exists, actual_exists, prec=0.5)
+    assert_equal(expected_assign, actual_assign, prec=0.5)


### PR DESCRIPTION
Addresses #1185 

This implements loopy belief propagation for multi-frame multi-object data association.

## Tests

The following tests pass:

- [x] smoke tests
- [x] tested two different BP algorithms against each other in `test_flat_vs_persistent`. they should agree up to numerical precision.
- [x] tested exact vs BP. they agree approximately, to within 1%