### PR TITLE
Make the BlockMessenger inside TracePosterior function correctly

### DIFF
--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -80,9 +80,10 @@ class TracePosterior(object):
         :param kwargs: optional keywords args taken by `self._traces`.
         """
         self._init()
-        for tr, logit in poutine.block(self._traces)(*args, **kwargs):
-            self.exec_traces.append(tr)
-            self.log_weights.append(logit)
+        with poutine.block():
+            for tr, logit in self._traces(*args, **kwargs):
+                self.exec_traces.append(tr)
+                self.log_weights.append(logit)
         self._categorical = Categorical(logits=torch.tensor(self.log_weights))
         return self
 


### PR DESCRIPTION
This PR fixes a small bug in nested inference where a `poutine.block` inside `TracePosterior.run` was having no effect and adds a regression test that would have caught it.