### PR TITLE
Do not throw NaN warnings during NUTS/HMC adaptation

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -12,7 +12,7 @@ import pyro.poutine as poutine
 from pyro.infer.mcmc.trace_kernel import TraceKernel
 from pyro.ops.dual_averaging import DualAveraging
 from pyro.ops.integrator import single_step_velocity_verlet, velocity_verlet
-from pyro.util import torch_isinf, torch_isnan
+from pyro.util import torch_isinf, torch_isnan, optional
 
 
 class HMC(TraceKernel):
@@ -226,8 +226,7 @@ class HMC(TraceKernel):
 
         # Temporarily disable distributions args checking as
         # NaNs are expected during step size adaptation
-        dist_arg_check = False if self._adapt_phase else pyro.distributions.is_validation_enabled()
-        with dist.validation_enabled(dist_arg_check):
+        with optional(pyro.validation_enabled(False), self._adapt_phase):
             z_new, r_new = velocity_verlet(z, r,
                                            self._potential_energy,
                                            self.step_size,

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -4,6 +4,7 @@ from .handlers import block, broadcast, condition, do, enum, escape, indep, infe
     replay, queue, scale, trace
 from .runtime import NonlocalExit
 from .trace_struct import Trace
+from .util import enable_validation, is_validation_enabled
 
 
 __all__ = [
@@ -11,10 +12,12 @@ __all__ = [
     "broadcast",
     "condition",
     "do",
+    "enable_validation",
     "enum",
     "escape",
     "indep",
     "infer_config",
+    "is_validation_enabled",
     "lift",
     "NonlocalExit",
     "replay",

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -7,6 +7,7 @@ import networkx
 import torch
 
 from pyro.distributions.util import scale_tensor
+from pyro.poutine.util import is_validation_enabled
 from pyro.util import torch_isinf, torch_isnan
 
 
@@ -232,7 +233,8 @@ class Trace(object):
                     site_log_p = site["fn"].log_prob(site["value"], *args, **kwargs)
                     site_log_p = scale_tensor(site_log_p, site["scale"]).sum()
                     site["log_prob_sum"] = site_log_p
-                    _warn_if_nan(name, site_log_p)
+                    if is_validation_enabled():
+                        _warn_if_nan(name, site_log_p)
                 log_p += site_log_p
         return log_p
 
@@ -253,7 +255,8 @@ class Trace(object):
                     site_log_p = scale_tensor(site_log_p, site["scale"])
                     site["log_prob"] = site_log_p
                     site["log_prob_sum"] = site_log_p.sum()
-                    _warn_if_nan(name, site["log_prob_sum"])
+                    if is_validation_enabled():
+                        _warn_if_nan(name, site["log_prob_sum"])
 
     def compute_score_parts(self):
         """
@@ -270,7 +273,8 @@ class Trace(object):
                 site["score_parts"] = value
                 site["log_prob"] = value[0]
                 site["log_prob_sum"] = value[0].sum()
-                _warn_if_nan(name, site["log_prob_sum"])
+                if is_validation_enabled():
+                    _warn_if_nan(name, site["log_prob_sum"])
 
     @property
     def observation_nodes(self):

--- a/pyro/poutine/util.py
+++ b/pyro/poutine/util.py
@@ -1,6 +1,18 @@
 from __future__ import absolute_import, division, print_function
 
 
+_VALIDATION_ENABLED = False
+
+
+def enable_validation(is_validate):
+    global _VALIDATION_ENABLED
+    _VALIDATION_ENABLED = is_validate
+
+
+def is_validation_enabled():
+    return _VALIDATION_ENABLED
+
+
 def site_is_subsample(site):
     """
     Determines whether a trace site originated from a subsample statement inside an `iarange`.

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -449,9 +449,11 @@ def validation_enabled(is_validate=True):
     """
     infer_validation_status = infer.is_validation_enabled()
     distribution_validation_status = dist.is_validation_enabled()
+    poutine_validation_status = poutine.is_validation_enabled()
     try:
         enable_validation(is_validate)
         yield
     finally:
         dist.enable_validation(distribution_validation_status)
         infer.enable_validation(infer_validation_status)
+        poutine.enable_validation(poutine_validation_status)

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -5,6 +5,7 @@ import numbers
 import random
 import warnings
 from collections import defaultdict
+from contextlib import contextmanager
 
 import graphviz
 import torch
@@ -280,6 +281,18 @@ def check_traceenum_requirements(model_trace, guide_trace):
             irange_counters[name] = irange_counter
             if name in enumerated_sites:
                 enumerated_contexts[context].add(name)
+
+
+@contextmanager
+def optional(context_manager, condition):
+    """
+    Optionally wrap inside `context_manager` if condition is `True`.
+    """
+    if condition:
+        with context_manager:
+            yield
+    else:
+        yield
 
 
 def deep_getattr(obj, name):

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -252,7 +252,6 @@ def test_bernoulli_beta_with_dual_averaging():
     assert_equal(posterior.mean, true_probs, prec=0.05)
 
 
-@pytest.mark.filterwarnings("ignore:Encountered NAN")
 def test_normal_gamma_with_dual_averaging():
     def model(data):
         rate = torch.tensor([1.0, 1.0])

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -149,7 +149,6 @@ def test_bernoulli_beta_with_dual_averaging():
     assert_equal(posterior.mean, true_probs, prec=0.03)
 
 
-@pytest.mark.filterwarnings("ignore:Encountered NAN")
 def test_categorical_dirichlet():
     def model(data):
         concentration = torch.tensor([1.0, 1.0, 1.0])


### PR DESCRIPTION
Many users have complained about the cryptic `NaN` warnings during the adaptation phase of NUTS/HMC when we have sample sites with constrained support. e.g. this [forum post](https://forum.pyro.ai/t/nan-log-prob-sum-in-poisson-model/269/5). It seems reasonable to silence these warnings during the adaptation phase. Note that we are already doing this for distributions, but this particular error is thrown inside the `_warn_if_nan` function in the `poutine` module.

 - Extends the validation check toggle to the `poutine` module so that if the flag is disabled, we do not call the `_warn_if_nan` method.
 - Removes the pytest filer warnings from the tests since they are no longer needed.