### PR TITLE
Add momentum to compute_marginals_persistent_bp()

### DIFF
--- a/pyro/contrib/tracking/assignment.py
+++ b/pyro/contrib/tracking/assignment.py
@@ -174,7 +174,6 @@ class MarginalAssignmentPersistent(object):
         assert exists_logits.dim() == 1, exists_logits.shape
         assert assign_logits.dim() == 3, assign_logits.shape
         assert assign_logits.shape[-1] == exists_logits.shape[-1]
-        assert 0 <= bp_momentum < 1, bp_momentum
         self.num_frames, self.num_detections, self.num_objects = assign_logits.shape
 
         # Clamp to avoid NANs.

--- a/pyro/contrib/tracking/assignment.py
+++ b/pyro/contrib/tracking/assignment.py
@@ -174,6 +174,7 @@ class MarginalAssignmentPersistent(object):
         assert exists_logits.dim() == 1, exists_logits.shape
         assert assign_logits.dim() == 3, assign_logits.shape
         assert assign_logits.shape[-1] == exists_logits.shape[-1]
+        assert 0 <= bp_momentum < 1, bp_momentum
         self.num_frames, self.num_detections, self.num_objects = assign_logits.shape
 
         # Clamp to avoid NANs.


### PR DESCRIPTION
This also sets momentum = 0.5 by default.

## Tested

- strengthened existing test parameter ranges
- added an exact test on a tree-shaped graph
- tested inside tracking_1d.ipynb; momentum successfully avoided oscillation