### PR TITLE
Documentation was confusing

### DIFF
--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -16,9 +16,9 @@ class SVI(object):
     :type optim: pyro.optim.PyroOptim
     :param loss: an instance of a subclass of :class:`~pyro.infer.elbo.ELBO`.
         Pyro provides three built-in losses:
-        :class:`trace_elbo.Trace_ELBO <pyro.infer.trace_elbo.Trace_ELBO>`,
-        :class:`tracegraph_elbo.Trace_ELBO <pyro.infer.tracegraph_elbo.Trace_ELBO>`, and
-        :class:`traceenum_elbo.Trace_ELBO <pyro.infer.traceenum_elbo.Trace_ELBO>`.
+        :class:`pyro.infer.trace_elbo.Trace_ELBO`,
+        :class:`pyro.infer.tracegraph_elbo.TraceGraph_ELBO`, and
+        :class:`pyro.infer.traceenum_elbo.TraceEnum_ELBO`.
         See the :class:`~pyro.infer.elbo.ELBO` docs to learn how to implement
         a custom loss.
     :type loss: pyro.infer.elbo.ELBO

--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -16,9 +16,9 @@ class SVI(object):
     :type optim: pyro.optim.PyroOptim
     :param loss: an instance of a subclass of :class:`~pyro.infer.elbo.ELBO`.
         Pyro provides three built-in losses:
-        :class:`~pyro.infer.trace_elbo.Trace_ELBO`,
-        :class:`~pyro.infer.tracegraph_elbo.Trace_ELBO`, and
-        :class:`~pyro.infer.traceenum_elbo.Trace_ELBO`.
+        :class:`trace_elbo.Trace_ELBO <pyro.infer.trace_elbo.Trace_ELBO>`,
+        :class:`tracegraph_elbo.Trace_ELBO <pyro.infer.tracegraph_elbo.Trace_ELBO>`, and
+        :class:`traceenum_elbo.Trace_ELBO <pyro.infer.traceenum_elbo.Trace_ELBO>`.
         See the :class:`~pyro.infer.elbo.ELBO` docs to learn how to implement
         a custom loss.
     :type loss: pyro.infer.elbo.ELBO

--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -16,9 +16,9 @@ class SVI(object):
     :type optim: pyro.optim.PyroOptim
     :param loss: an instance of a subclass of :class:`~pyro.infer.elbo.ELBO`.
         Pyro provides three built-in losses:
-        :class:`pyro.infer.trace_elbo.Trace_ELBO`,
-        :class:`pyro.infer.tracegraph_elbo.TraceGraph_ELBO`, and
-        :class:`pyro.infer.traceenum_elbo.TraceEnum_ELBO`.
+        :class:`~pyro.infer.trace_elbo.Trace_ELBO`,
+        :class:`~pyro.infer.tracegraph_elbo.TraceGraph_ELBO`, and
+        :class:`~pyro.infer.traceenum_elbo.TraceEnum_ELBO`.
         See the :class:`~pyro.infer.elbo.ELBO` docs to learn how to implement
         a custom loss.
     :type loss: pyro.infer.elbo.ELBO


### PR DESCRIPTION
Due to the re-use of the class name, the doc read as

> Pyro provides three built-in losses: `Trace_ELBO`, `Trace_ELBO`, and `Trace_ELBO`.

So I modified it to include the specific module.