### PR TITLE
Welford's Scheme Implementation

### DIFF
--- a/pyro/ops/welford.py
+++ b/pyro/ops/welford.py
@@ -17,9 +17,9 @@ class WelfordCovariance(object):
         self.diagonal = diagonal
         self.reset()
 
-    def _deltas(self, z):
+    def _deltas(self, sample):
         deltas = []
-        for i, x in enumerate(z):
+        for i, x in enumerate(sample):
             if i > len(self.means) - 1:
                 self.means.append(0.)
             mean = self.means[i]
@@ -29,9 +29,9 @@ class WelfordCovariance(object):
             deltas.append((updated_mean, delta_pre, delta_post))
         return deltas
 
-    def _unroll(self, z):
+    def _unroll(self, sample):
         unrolled = []
-        for rolled in z:
+        for rolled in sample:
             unrolled.extend(rolled.reshape(-1).data.tolist())
         return unrolled
 
@@ -40,9 +40,9 @@ class WelfordCovariance(object):
         self.variances = defaultdict(float)
         self.n_samples = 0
 
-    def update(self, z):
+    def update(self, sample):
         self.n_samples += 1
-        deltas = self._deltas(self._unroll(z))
+        deltas = self._deltas(self._unroll(sample))
         for i, (mean_x, delta_x_pre, delta_x_post) in enumerate(deltas):
             self.means[i] = mean_x
             for j, (mean_y, delta_y_pre, delta_y_post) in enumerate(deltas):

--- a/pyro/ops/welford.py
+++ b/pyro/ops/welford.py
@@ -22,25 +22,25 @@ class WelfordCovariance(object):
         return unrolled
 
     def reset(self):
-        self.means = 0.
-        self.variances = 0.
+        self._mean = 0.
+        self._m2 = 0.
         self.n_samples = 0
 
     def update(self, sample):
         self.n_samples += 1
-        delta_pre = sample - self.means
-        self.means = self.means + delta_pre / self.n_samples
-        delta_post = sample - self.means
+        delta_pre = sample - self._mean
+        self._mean = self._mean + delta_pre / self.n_samples
+        delta_post = sample - self._mean
 
         if self.diagonal:
-            self.variances += delta_pre * delta_post
+            self._m2 += delta_pre * delta_post
         else:
-            self.variances += delta_pre * delta_post.reshape(-1, 1)
+            self._m2 += delta_pre * delta_post.reshape(-1, 1)
 
-    def get_estimates(self, regularize=True):
+    def get_covariance(self, regularize=True):
         if self.n_samples < 2:
             raise RuntimeError('Insufficient samples to estimate covariance')
-        cov = self.variances / (self.n_samples - 1)
+        cov = self._m2 / (self.n_samples - 1)
         if regularize:
             # Regularization from stan
             scaled_cov = (self.n_samples / (self.n_samples + 5.)) * cov

--- a/pyro/ops/welford.py
+++ b/pyro/ops/welford.py
@@ -15,12 +15,6 @@ class WelfordCovariance(object):
         self.diagonal = diagonal
         self.reset()
 
-    def _unroll(self, sample):
-        unrolled = []
-        for rolled in sample:
-            unrolled.extend(rolled.reshape(-1).data.tolist())
-        return unrolled
-
     def reset(self):
         self._mean = 0.
         self._m2 = 0.

--- a/pyro/ops/welford.py
+++ b/pyro/ops/welford.py
@@ -1,0 +1,70 @@
+from collections import defaultdict
+
+import torch
+
+
+class WelfordCovariance(object):
+    """
+    Implements Welford's online scheme for estimating (co)variance (see :math:`[1]`).
+    Useful for adapting diagonal and dense mass structures for HMC.
+
+    **References**
+
+    [1] `The Art of Computer Programming`,
+    Donald E. Knuth
+    """
+    def __init__(self, diagonal=True):
+        self.diagonal = diagonal
+        self.reset()
+
+    def _deltas(self, z):
+        deltas = []
+        for i, x in enumerate(z):
+            if i > len(self.means) - 1:
+                self.means.append(0.)
+            mean = self.means[i]
+            delta_pre = x - mean
+            updated_mean = mean + delta_pre / self.n_samples
+            delta_post = x - updated_mean
+            deltas.append((updated_mean, delta_pre, delta_post))
+        return deltas
+
+    def _unroll(self, z):
+        unrolled = []
+        for rolled in z:
+            unrolled.extend(rolled.reshape(-1).data.tolist())
+        return unrolled
+
+    def reset(self):
+        self.means = []
+        self.variances = defaultdict(float)
+        self.n_samples = 0
+
+    def update(self, z):
+        self.n_samples += 1
+        deltas = self._deltas(self._unroll(z))
+        for i, (mean_x, delta_x_pre, delta_x_post) in enumerate(deltas):
+            self.means[i] = mean_x
+            for j, (mean_y, delta_y_pre, delta_y_post) in enumerate(deltas):
+                # Only compute the upper triangular covariance.
+                if i == j or (i < j and not self.diagonal):
+                    self.variances[(i, j)] += delta_x_pre * delta_y_post
+
+    def get_estimates(self, regularize=True):
+        if self.n_samples < 2:
+            raise RuntimeError('Insufficient samples to estimate covariance')
+        rows = []
+        for i in range(len(self.means)):
+            row = []
+            for j in range(len(self.means)):
+                if i == j or not self.diagonal:
+                    key = (i, j) if i <= j else (j, i)
+                    estimate = self.variances[key] / (self.n_samples - 1)
+                    if regularize:
+                        # Regularization from stan
+                        scaled_estimate = (self.n_samples / (self.n_samples + 5.)) * estimate
+                        shrinkage = 1e-3 * (5. / (self.n_samples + 5.0)) if i == j else 0.
+                        estimate = scaled_estimate + shrinkage
+                    row.append(estimate)
+            rows.append(row)
+        return torch.tensor(rows)

--- a/pyro/ops/welford.py
+++ b/pyro/ops/welford.py
@@ -29,7 +29,7 @@ class WelfordCovariance(object):
         if self.diagonal:
             self._m2 += delta_pre * delta_post
         else:
-            self._m2 += delta_pre * delta_post.reshape(-1, 1)
+            self._m2 += torch.matmul(delta_post.unsqueeze(-1), delta_pre.unsqueeze(-2))
 
     def get_covariance(self, regularize=True):
         if self.n_samples < 2:
@@ -42,5 +42,6 @@ class WelfordCovariance(object):
             if self.diagonal:
                 cov = scaled_cov + shrinkage
             else:
-                cov = scaled_cov + torch.diagflat(shrinkage)
+                scaled_cov.view(-1)[::scaled_cov.shape[0]+1] += shrinkage
+                cov = scaled_cov
         return cov

--- a/tests/ops/test_welford.py
+++ b/tests/ops/test_welford.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+import torch
+
+from pyro.ops.welford import WelfordCovariance
+from tests.common import assert_equal
+
+
+@pytest.mark.parametrize('n_samples,dim_size', [(1000, 1),
+                                                (1000, 7),
+                                                pytest.mark.xfail((1, 1))])  # Insufficient samples
+@pytest.mark.init(rng_seed=7)
+def test_welford_diagonal(n_samples, dim_size):
+    w = WelfordCovariance(diagonal=True)
+    loc = torch.zeros(dim_size)
+    cov_diagonal = torch.rand(dim_size)
+    cov = torch.diag(cov_diagonal)
+    dist = torch.distributions.MultivariateNormal(loc=loc, covariance_matrix=cov)
+    samples = []
+    for _ in range(n_samples):
+        sample = dist.sample()
+        samples.append(sample)
+        w.update([x for x in sample])
+
+    sample_variance = torch.stack(samples).var(dim=0, unbiased=True)
+    estimates = w.get_estimates(regularize=False).squeeze(-1)
+    assert_equal(estimates, sample_variance)
+
+
+@pytest.mark.parametrize('n_samples,dim_size', [(1000, 1),
+                                                (1000, 7),
+                                                pytest.mark.xfail((1, 1))])
+@pytest.mark.init(rng_seed=7)
+def test_welford_dense(n_samples, dim_size):
+    w = WelfordCovariance(diagonal=False)
+    loc = torch.zeros(dim_size)
+    cov = torch.randn(dim_size, dim_size)
+    cov = torch.mm(cov, cov.t())
+    dist = torch.distributions.MultivariateNormal(loc=loc, covariance_matrix=cov)
+    samples = []
+    for _ in range(n_samples):
+        sample = dist.sample()
+        samples.append(sample)
+        w.update([x for x in sample])
+
+    sample_cov = np.cov(torch.stack(samples).data.numpy(), bias=False, rowvar=False)
+    estimates = w.get_estimates(regularize=False).data.numpy()
+    assert_equal(estimates, sample_cov)

--- a/tests/ops/test_welford.py
+++ b/tests/ops/test_welford.py
@@ -23,7 +23,7 @@ def test_welford_diagonal(n_samples, dim_size):
         w.update(sample)
 
     sample_variance = torch.stack(samples).var(dim=0, unbiased=True)
-    estimates = w.get_estimates(regularize=False)
+    estimates = w.get_covariance(regularize=False)
     assert_equal(estimates, sample_variance)
 
 
@@ -44,5 +44,5 @@ def test_welford_dense(n_samples, dim_size):
         w.update(sample)
 
     sample_cov = np.cov(torch.stack(samples).data.numpy(), bias=False, rowvar=False)
-    estimates = w.get_estimates(regularize=False).data.numpy()
+    estimates = w.get_covariance(regularize=False).data.numpy()
     assert_equal(estimates, sample_cov)

--- a/tests/ops/test_welford.py
+++ b/tests/ops/test_welford.py
@@ -20,10 +20,10 @@ def test_welford_diagonal(n_samples, dim_size):
     for _ in range(n_samples):
         sample = dist.sample()
         samples.append(sample)
-        w.update([x for x in sample])
+        w.update(sample)
 
     sample_variance = torch.stack(samples).var(dim=0, unbiased=True)
-    estimates = w.get_estimates(regularize=False).squeeze(-1)
+    estimates = w.get_estimates(regularize=False)
     assert_equal(estimates, sample_variance)
 
 
@@ -41,7 +41,7 @@ def test_welford_dense(n_samples, dim_size):
     for _ in range(n_samples):
         sample = dist.sample()
         samples.append(sample)
-        w.update([x for x in sample])
+        w.update(sample)
 
     sample_cov = np.cov(torch.stack(samples).data.numpy(), bias=False, rowvar=False)
     estimates = w.get_estimates(regularize=False).data.numpy()


### PR DESCRIPTION
This implements [Welford's online scheme](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm) for calculating (co)variance.

_Note: This is one component of mass matrix adaptation for the HMC and NUTS samplers (The original PR: #1178 is being broken into multiple smaller PRs)._

### Usage
```python
from pyro.ops.welford import WelfordCovariance

# Diagonal can be set to True to save resources if the
# user is only interested in the diagonal.
w = WelfordCovariance(diagonal=False)

# Each sample should be a list of numbers or tensors,
# where each index in the list corresponds to a variable.
samples = [
    [var1_0, var2_0, var3_0],
    [var1_1, var2_1, var3_1],
    [var1_1, var2_2, var3_2]]
for s in samples:
    w.update(s)

# The co-variance matrix is regularized towards the identity matrix by default
# but this can be disabled by passing regualrize=False
covariance_matrix = w.get_estimates(regularize=True)
```

### Tests
 - A couple tests using random dummy data and comparing the answer against `pytorch` / `numpy` co-variance calculations.
 - A test to ensure an error is raised if `get_estimates()` is called when fewer than 2 samples have been observed.


(Sorry this took so long everyone! I meant to get it done sooner but alas, life gets in the way sometimes. I think I've incorporated all of the changes suggested in #1178 but please let me know if I missed any.) 