### PR TITLE
Fix RNG seed for each replication of benchmark test

### DIFF
--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -45,6 +45,7 @@ def register_model(**model_kwargs):
 @register_model(reparameterized=False, Elbo=TraceGraph_ELBO, id='PoissonGamma::reparam=False_TraceGraph')
 @register_model(reparameterized=False, Elbo=Trace_ELBO, id='PoissonGamma::reparam=False_Trace')
 def poisson_gamma_model(reparameterized, Elbo):
+    pyro.set_rng_seed(0)
     alpha0 = torch.tensor(1.0)
     beta0 = torch.tensor(1.0)
     data = torch.tensor([1.0, 2.0, 3.0])
@@ -96,6 +97,7 @@ def bernoulli_beta_hmc(**kwargs):
         pyro.sample("obs", dist.Bernoulli(p_latent), obs=data)
         return p_latent
 
+    pyro.set_rng_seed(0)
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
     kernel = kwargs.pop('kernel')
@@ -109,6 +111,7 @@ def bernoulli_beta_hmc(**kwargs):
 @register_model(num_steps=2000, whiten=True, id='SVGP::MultiClass_whiten=True')
 def svgp_multiclass(num_steps, whiten):
     # adapted from http://gpflow.readthedocs.io/en/latest/notebooks/multiclass.html
+    pyro.set_rng_seed(0)
     X = torch.rand(100, 1)
     K = (-0.5 * (X - X.t()).pow(2) / 0.01).exp() + torch.eye(100) * 1e-6
     f = K.potrf(upper=False).matmul(torch.randn(100, 3))


### PR DESCRIPTION
The benchmark module runs each of the models multiple times to get a distribution of the running time. While it sets the random seed for each model like any other test invoked from pytest, we would like the replications (number of rounds each model is run) themselves to start from the same seed, otherwise we will get a larger variance across rounds. This fixes this issue.

Not part of this PR, but for isolating these jobs on my workstation, I am using [cset shield](http://manpages.ubuntu.com/manpages/trusty/man1/cset-shield.1.html) in the cron job which I have found to be particularly useful for getting stable benchmarking results.