### PR TITLE
add LSH to contrib.tracking

### DIFF
--- a/docs/source/contrib.tracking.rst
+++ b/docs/source/contrib.tracking.rst
@@ -8,3 +8,9 @@ Data Association
 .. automodule:: pyro.contrib.tracking.assignment
     :members:
     :member-order: bysource
+
+Hashing
+----------------
+.. automodule:: pyro.contrib.tracking.hashing
+    :members:
+    :member-order: bysource

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -33,7 +33,7 @@ class LSH(object):
         set(['a', 'c'])
         >>> lsh.remove('b')
         >>> lsh.nearby('a')
-        set()
+        set([])
 
 
     :param float radius: Scaling parameter used in hash function. Determines the size of the neighbourhood.

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -7,20 +7,46 @@ from numbers import Number
 
 class LSH(object):
     """
-    Implements locality-sensitive hash for low-dimensional euclidean space.
+    Implements locality-sensitive hashing. Allows to efficiently find neighbours
+    of a point. Provides 2 guarantees:
+    - Difference between coordinates of points not returned by :meth:`nearby`
+    and input point is larger than `radius`.
+    - Difference between coordinates of points returned by :meth:`nearby` and
+    input point is smaller than 2`radius`.
+    :param float radius: scaling parameter used in hash function. Determines
+    the size of the neighbourhood.
+
+    Example::
+        radius = 1
+        lsh = LSH(radius)
+        a = torch.tensor([-0.49, -0.49]) # hash(a)=(0,0)
+        b = torch.tensor([1.0, 1.0]) # hash(b)=(1,1)
+        c = torch.tensor([2.49, 2.49]) # hash(c)=(2,2)
+        lsh.add('a', a)
+        lsh.add('b', b)
+        lsh.add('c', c)
+        lsh.nearby('a') # {'b'}
+        lsh.nearby('b') # {'a','c'}
+        lsh.remove('b')
+        lsh.nearby('a') # {}
     """
-    def __init__(self, scale):
-        assert scale > 0 if isinstance(scale, Number) else (scale > 0).all(), \
-            "scale must be greater than 0, given: {}".format(scale)
-        self._scale = scale
+    def __init__(self, radius):
+        assert radius > 0 if isinstance(radius, Number) else (radius > 0).all(), \
+            "radius must be greater than 0, given: {}".format(radius)
+        self._radius = radius
         self._hash_to_key = defaultdict(set)
         self._key_to_hash = {}
 
     def _hash(self, point):
-        coords = (point.detach().cpu() / self._scale).round()
+        coords = (point.detach().cpu() / self._radius).round()
         return tuple(map(int, coords))
 
     def add(self, key, point):
+        """
+        Adds (`key`, `hash(point)`) pair to the hash
+        :param key: key used identify point
+        :param point: data, should be hashable
+        """
         _hash = self._hash(point)
         if key in self._key_to_hash.keys():
             self.remove(key)
@@ -28,10 +54,23 @@ class LSH(object):
         self._hash_to_key[_hash].add(key)
 
     def remove(self, key):
+        """
+        Removes (`key`, `hash(point)`) pair from the hash.
+        Raises KeyError if key is not in hash.
+        :param key: key used to identify point
+        """
         _hash = self._key_to_hash.pop(key)
         self._hash_to_key[_hash].remove(key)
 
     def nearby(self, key):
+        """
+        Returns a set of keys which are neighbours of the input point
+        identified by `key`. It returns all points where `abs(point[k]-input[k])<radius`,
+        and some points (all points not guaranteed) where `abs(point[k]-input[k])<2*radius`.
+        :param key: key used to identify input point
+        :return: set of keys identifying neighbours of the input point
+        :rtype: set
+        """
         _hash = self._key_to_hash[key]
         result = set()
         for nearby_hash in itertools.product(*[[i - 1, i, i + 1] for i in _hash]):
@@ -43,21 +82,27 @@ class LSH(object):
 class ApproxSet(object):
     """
     Queries low-dimensional euclidean space for approximate occupancy.
+    :param float radius: scaling parameter used in hash function. Determines
+    the size of the neighbourhood.
     """
-    def __init__(self, scale):
-        assert scale > 0 if isinstance(scale, Number) else (scale > 0).all(), \
-            "scale must be greater than 0, given: {}".format(scale)
-        self._scale = scale
+    def __init__(self, radius):
+        assert radius > 0 if isinstance(radius, Number) else (radius > 0).all(), \
+            "radius must be greater than 0, given: {}".format(radius)
+        self._radius = radius
         self._bins = set()
 
     def _hash(self, point):
-        coords = (point.detach().cpu() / self._scale).round()
+        coords = (point.detach().cpu() / self._radius).round()
         return tuple(map(int, coords))
 
     def try_add(self, point):
         """
-        If bin is unoccupied, adds to bin and returns True.
-        If bin is already occupied, returns False.
+        Attempts to add the point to hash. Only adds if neighboorhood of `point`
+        is unoccupied.
+        :param torch.Tensor point: point to be queried.
+        :return: `True` if point's bin is unoccupied, `False` if bin is already
+        occupied.
+        :rtype: bool
         """
         _hash = self._hash(point)
         if _hash in self._bins:

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -7,7 +7,7 @@ from numbers import Number
 
 class LSH(object):
     """
-    Implements locality-sensitive hashing.
+    Implements locality-sensitive hashing for low-dimensional euclidean space.
 
 
     Allows to efficiently find neighbours of a point. Provides 2 guarantees:
@@ -40,8 +40,8 @@ class LSH(object):
 
     """
     def __init__(self, radius):
-        assert radius > 0 if isinstance(radius, Number) else (radius > 0).all(), \
-            "radius must be greater than 0, given: {}".format(radius)
+        if not (isinstance(radius, Number) and radius > 0):
+            raise ValueError("radius must be float greater than 0, given: {}".format(radius))
         self._radius = radius
         self._hash_to_key = defaultdict(set)
         self._key_to_hash = {}
@@ -108,8 +108,8 @@ class ApproxSet(object):
                          See :class:`LSH` for details.
     """
     def __init__(self, radius):
-        assert radius > 0 if isinstance(radius, Number) else (radius > 0).all(), \
-            "radius must be greater than 0, given: {}".format(radius)
+        if not (isinstance(radius, Number) and radius > 0):
+            raise ValueError("radius must be float greater than 0, given: {}".format(radius))
         self._radius = radius
         self._bins = set()
 

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -30,7 +30,7 @@ class LSH(object):
         >>> lsh.nearby('a') # even though c is within 2radius of a
         set(['b'])
         >>> lsh.nearby('b')
-        set(['a','c'])
+        set(['a', 'c'])
         >>> lsh.remove('b')
         >>> lsh.nearby('a')
         set()

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -1,0 +1,65 @@
+from __future__ import absolute_import, division, print_function
+
+import heapq
+import itertools
+from collections import defaultdict
+from numbers import Number
+
+import torch
+
+
+class LSH(object):
+    """
+    Implements locality-sensitive hash for low-dimensional euclidean space.
+    """
+    def __init__(self, scale):
+        assert scale > 0 if isinstance(scale, Number) else (scale > 0).all(), \
+            "scale must be greater than 0, given:{}".format(scale)
+        self._scale = scale
+        self._hash_to_key = defaultdict(set)
+        self._key_to_hash = {}
+
+    def _hash(self, point):
+        coords = (point.detach().cpu() / self._scale).round()
+        return tuple(map(int, coords))
+
+    def add(self, key, point):
+        _hash = self._hash(point)
+        self._key_to_hash[key] = _hash
+        self._hash_to_key[_hash].add(key)
+
+    def remove(self, key):
+        _hash = self._key_to_hash.pop(key)
+        self._hash_to_key[_hash].remove(key)
+
+    def nearby(self, key):
+        _hash = self._key_to_hash[key]
+        result = set()
+        for nearby_hash in itertools.product(*[[i - 1, i, i + 1] for i in _hash]):
+            result |= self._hash_to_key[nearby_hash]
+        result.remove(key)
+        return result
+
+
+class ApproxSet(object):
+    """
+    Queries low-dimensional euclidean space for approximate occupancy.
+    """
+    def __init__(self, scale):
+        self._scale = scale
+        self._bins = set()
+
+    def _hash(self, point):
+        coords = (point.detach().cpu() / self._scale).round()
+        return tuple(map(int, coords))
+
+    def try_add(self, point):
+        """
+        If bin is unoccupied, adds to bin and returns True.
+        If bin is already occupied, returns False.
+        """
+        _hash = self._hash(point)
+        if _hash in self._bins:
+            return False
+        self._bins.add(_hash)
+        return True

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-import heapq
 import itertools
 from collections import defaultdict
 from numbers import Number
-
-import torch
 
 
 class LSH(object):
@@ -14,7 +11,7 @@ class LSH(object):
     """
     def __init__(self, scale):
         assert scale > 0 if isinstance(scale, Number) else (scale > 0).all(), \
-            "scale must be greater than 0, given:{}".format(scale)
+            "scale must be greater than 0, given: {}".format(scale)
         self._scale = scale
         self._hash_to_key = defaultdict(set)
         self._key_to_hash = {}
@@ -25,6 +22,8 @@ class LSH(object):
 
     def add(self, key, point):
         _hash = self._hash(point)
+        if key in self._key_to_hash.keys():
+            self.remove(key)
         self._key_to_hash[key] = _hash
         self._hash_to_key[_hash].add(key)
 
@@ -46,6 +45,8 @@ class ApproxSet(object):
     Queries low-dimensional euclidean space for approximate occupancy.
     """
     def __init__(self, scale):
+        assert scale > 0 if isinstance(scale, Number) else (scale > 0).all(), \
+            "scale must be greater than 0, given: {}".format(scale)
         self._scale = scale
         self._bins = set()
 

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -27,10 +27,13 @@ class LSH(object):
         >>> lsh.add('a', a)
         >>> lsh.add('b', b)
         >>> lsh.add('c', c)
-        >>> lsh.nearby('a') # {'b'}, even though c is within 2radius of a
-        >>> lsh.nearby('b') # {'a','c'}
+        >>> lsh.nearby('a') # even though c is within 2radius of a
+        set(['b'])
+        >>> lsh.nearby('b')
+        set(['a','c'])
         >>> lsh.remove('b')
-        >>> lsh.nearby('a') # {}
+        >>> lsh.nearby('a')
+        set()
 
 
     :param float radius: Scaling parameter used in hash function. Determines the size of the neighbourhood.

--- a/tests/contrib/tracking/test_hashing.py
+++ b/tests/contrib/tracking/test_hashing.py
@@ -2,11 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 import torch
-from torch.autograd import grad
 
-import pyro
-import pyro.distributions as dist
-from pyro.contrib.tracking.hashing import LSH
+from pyro.contrib.tracking.hashing import LSH, ApproxSet
 from tests.common import assert_equal
 
 
@@ -14,10 +11,121 @@ from tests.common import assert_equal
 def test_lsh_init(scale):
     num_error = 0
     try:
-        lsh = LSH(scale)
-    except AssertionError as e:
+        LSH(scale)
+    except AssertionError:
         num_error += 1
     else:
         pass
     finally:
         assert num_error > 0
+
+
+@pytest.mark.parametrize('scale', [0.1, 1, 10, 100])
+def test_lsh_add(scale):
+    lsh = LSH(scale)
+    a = torch.rand(10)
+    lsh.add('a', a)
+    assert lsh._hash_to_key[lsh._key_to_hash['a']] == {'a'}
+
+
+@pytest.mark.parametrize('scale', [0.1, 1, 10, 100])
+def test_lsh_hash_nearby(scale):
+    k = 10
+    lsh = LSH(scale)
+    a = -2 * scale + torch.rand(k) * scale * 0.49
+    b = -1 * scale + torch.rand(k) * scale * 0.49
+    c = torch.rand(k) * scale * 0.49
+    d = scale + torch.rand(k) * scale * 0.49
+    e = 2 * scale + torch.rand(k) * scale * 0.49
+    f = 4 * scale + torch.rand(k) * scale * 0.49
+
+    assert_equal(lsh._hash(a), (-2,) * k)
+    assert_equal(lsh._hash(b), (-1,) * k)
+    assert_equal(lsh._hash(c), (0,) * k)
+    assert_equal(lsh._hash(d), (1,) * k)
+    assert_equal(lsh._hash(e), (2,) * k)
+    assert_equal(lsh._hash(f), (4,) * k)
+
+    lsh.add('a', a)
+    lsh.add('b', b)
+    lsh.add('c', c)
+    lsh.add('d', d)
+    lsh.add('e', e)
+    lsh.add('f', f)
+
+    assert lsh.nearby('a') == {'b'}
+    assert lsh.nearby('b') == {'a', 'c'}
+    assert lsh.nearby('c') == {'b', 'd'}
+    assert lsh.nearby('d') == {'c', 'e'}
+    assert lsh.nearby('e') == {'d'}
+    assert lsh.nearby('f') == set()
+
+
+def test_lsh_overwrite():
+    lsh = LSH(1)
+    a = torch.zeros(2)
+    b = torch.ones(2)
+    lsh.add('a', a)
+    lsh.add('b', b)
+    assert lsh.nearby('a') == {'b'}
+    b = torch.ones(2) * 4
+    lsh.add('b', b)
+    assert lsh.nearby('a') == set()
+
+
+def test_lsh_remove():
+    lsh = LSH(1)
+    a = torch.zeros(2)
+    b = torch.ones(2)
+    lsh.add('a', a)
+    lsh.add('b', b)
+    assert lsh.nearby('a') == {'b'}
+    lsh.remove('b')
+    assert lsh.nearby('a') == set()
+
+
+@pytest.mark.parametrize('scale', [-1., 0., -1 * torch.ones(2, 2)])
+def test_as_init(scale):
+    num_error = 0
+    try:
+        ApproxSet(scale)
+    except AssertionError:
+        num_error += 1
+    else:
+        pass
+    finally:
+        assert num_error > 0
+
+
+@pytest.mark.parametrize('scale', [0.1, 1, 10, 100])
+def test_as_hash(scale):
+    k = 10
+    aps = ApproxSet(scale)
+    a = -2 * scale + torch.rand(k) * scale * 0.49
+    b = -1 * scale + torch.rand(k) * scale * 0.49
+    c = torch.rand(k) * scale * 0.49
+    d = scale + torch.rand(k) * scale * 0.49
+    e = 2 * scale + torch.rand(k) * scale * 0.49
+    f = 4 * scale + torch.rand(k) * scale * 0.49
+
+    assert_equal(aps._hash(a), (-2,) * k)
+    assert_equal(aps._hash(b), (-1,) * k)
+    assert_equal(aps._hash(c), (0,) * k)
+    assert_equal(aps._hash(d), (1,) * k)
+    assert_equal(aps._hash(e), (2,) * k)
+    assert_equal(aps._hash(f), (4,) * k)
+
+
+@pytest.mark.parametrize('scale', [0.1, 1, 10, 100])
+def test_as_try_add(scale):
+    k = 10
+    aps = ApproxSet(scale)
+    a = torch.rand(k) * scale * 0.49
+    b = torch.rand(k) * scale * 0.49
+    c = scale + torch.rand(k) * scale * 0.49
+    d = scale + torch.rand(k) * scale * 0.49
+
+    assert_equal(aps.try_add(a), True)
+    assert_equal(aps.try_add(b), False)
+    assert_equal(aps.try_add(c), True)
+    assert_equal(aps.try_add(d), False)

--- a/tests/contrib/tracking/test_hashing.py
+++ b/tests/contrib/tracking/test_hashing.py
@@ -30,7 +30,7 @@ def test_lsh_add(scale):
 
 @pytest.mark.parametrize('scale', [0.1, 1, 10, 100])
 def test_lsh_hash_nearby(scale):
-    k = 10
+    k = 5
     lsh = LSH(scale)
     a = -2 * scale + torch.rand(k) * scale * 0.49
     b = -1 * scale + torch.rand(k) * scale * 0.49

--- a/tests/contrib/tracking/test_hashing.py
+++ b/tests/contrib/tracking/test_hashing.py
@@ -9,15 +9,8 @@ from tests.common import assert_equal
 
 @pytest.mark.parametrize('scale', [-1., 0., -1 * torch.ones(2, 2)])
 def test_lsh_init(scale):
-    num_error = 0
-    try:
+    with pytest.raises(ValueError):
         LSH(scale)
-    except AssertionError:
-        num_error += 1
-    else:
-        pass
-    finally:
-        assert num_error > 0
 
 
 @pytest.mark.parametrize('scale', [0.1, 1, 10, 100])
@@ -85,20 +78,13 @@ def test_lsh_remove():
 
 
 @pytest.mark.parametrize('scale', [-1., 0., -1 * torch.ones(2, 2)])
-def test_as_init(scale):
-    num_error = 0
-    try:
+def test_aps_init(scale):
+    with pytest.raises(ValueError):
         ApproxSet(scale)
-    except AssertionError:
-        num_error += 1
-    else:
-        pass
-    finally:
-        assert num_error > 0
 
 
 @pytest.mark.parametrize('scale', [0.1, 1, 10, 100])
-def test_as_hash(scale):
+def test_aps_hash(scale):
     k = 10
     aps = ApproxSet(scale)
     a = -2 * scale + torch.rand(k) * scale * 0.49
@@ -117,7 +103,7 @@ def test_as_hash(scale):
 
 
 @pytest.mark.parametrize('scale', [0.1, 1, 10, 100])
-def test_as_try_add(scale):
+def test_aps_try_add(scale):
     k = 10
     aps = ApproxSet(scale)
     a = torch.rand(k) * scale * 0.49

--- a/tests/contrib/tracking/test_hashing.py
+++ b/tests/contrib/tracking/test_hashing.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+import torch
+from torch.autograd import grad
+
+import pyro
+import pyro.distributions as dist
+from pyro.contrib.tracking.hashing import LSH
+from tests.common import assert_equal
+
+
+@pytest.mark.parametrize('scale', [-1., 0., -1 * torch.ones(2, 2)])
+def test_lsh_init(scale):
+    num_error = 0
+    try:
+        lsh = LSH(scale)
+    except AssertionError as e:
+        num_error += 1
+    else:
+        pass
+    finally:
+        assert num_error > 0


### PR DESCRIPTION
Addresses #1185 

This PR adds LSH from pyro-iei to contrib.tracking. One design choice I made is to allow overwriting in `lsh.add`. We can easily change that to not allow overwriting in `lsh.add` and add `lsh.modify` to facilitate that need.  