### PR TITLE
Revise pyro to match pytorch master

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -102,7 +102,7 @@ def partially_pooled(at_bats):
     """
     num_players = at_bats.shape[0]
     loc = pyro.sample("loc", Normal(at_bats.new_tensor(-1), at_bats.new_tensor(1)))
-    scale = pyro.sample("scale", HalfCauchy(at_bats.new_tensor(0), at_bats.new_tensor(1)))
+    scale = pyro.sample("scale", HalfCauchy(scale=at_bats.new_tensor(1)))
     alpha = pyro.sample("alpha", Normal(loc, scale).expand_by([num_players]).independent(1))
     return pyro.sample("obs", Binomial(at_bats, logits=alpha))
 
@@ -208,7 +208,7 @@ def evaluate_log_predictive_density(model, model_trace_posterior, baseball_datas
         trace_log_pdf.append(tr.log_prob_sum())
     # Use LogSumExp trick to evaluate $log(1/num_samples \sum_i p(new_data | \theta^{i})) $,
     # where $\theta^{i}$ are parameter samples from the model's posterior.
-    posterior_pred_density = log_sum_exp(torch.stack(trace_log_pdf)) - math.log(len(trace_log_pdf))
+    posterior_pred_density = log_sum_exp(torch.stack(trace_log_pdf), dim=-1) - math.log(len(trace_log_pdf))
     logging.info("\nLog posterior predictive density")
     logging.info("---------------------------------")
     logging.info("{:.4f}\n".format(posterior_pred_density))

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -22,7 +22,7 @@ pyro.set_rng_seed(0)
 def model(sigma):
     eta = pyro.sample('eta', dist.Normal(torch.zeros(data.J), torch.ones(data.J)))
     mu = pyro.sample('mu', dist.Normal(torch.zeros(1), 10 * torch.ones(1)))
-    tau = pyro.sample('tau', dist.HalfCauchy(torch.zeros(1), 25 * torch.ones(1)))
+    tau = pyro.sample('tau', dist.HalfCauchy(scale=25 * torch.ones(1)))
 
     theta = mu + tau * eta
 

--- a/examples/eight_schools/svi.py
+++ b/examples/eight_schools/svi.py
@@ -22,7 +22,7 @@ def model(data):
 
     eta = pyro.sample('eta', dist.Normal(torch.zeros(J), torch.ones(J)))
     mu = pyro.sample('mu', dist.Normal(torch.zeros(1), 10 * torch.ones(1)))
-    tau = pyro.sample('tau', dist.HalfCauchy(torch.zeros(1), 25 * torch.ones(1)))
+    tau = pyro.sample('tau', dist.HalfCauchy(scale=25 * torch.ones(1)))
 
     theta = mu + tau * eta
 

--- a/examples/rsa/search_inference.py
+++ b/examples/rsa/search_inference.py
@@ -84,13 +84,13 @@ class HashingMarginal(dist.Distribution):
                 value_hash = hash(value)
             if value_hash in logits:
                 # Value has already been seen.
-                logits[value_hash] = dist.util.log_sum_exp(torch.stack([logits[value_hash], logit]))
+                logits[value_hash] = dist.util.log_sum_exp(torch.stack([logits[value_hash], logit]), dim=-1)
             else:
                 logits[value_hash] = logit
                 values_map[value_hash] = value
 
         logits = torch.stack(list(logits.values())).contiguous().view(-1)
-        logits = logits - dist.util.log_sum_exp(logits)
+        logits = logits - dist.util.log_sum_exp(logits, dim=-1)
         d = dist.Categorical(logits=logits)
         return d, values_map
 

--- a/pyro/contrib/gp/models/gpr.py
+++ b/pyro/contrib/gp/models/gpr.py
@@ -78,7 +78,7 @@ class GPRegression(GPModel):
 
         N = self.X.shape[0]
         Kff = self.kernel(self.X)
-        Kff.view(-1, N * N)[:, ::N + 1] += noise  # add noise to diagonal
+        Kff.view(-1)[::N + 1] += noise  # add noise to diagonal
         Lff = Kff.potrf(upper=False)
 
         zero_loc = self.X.new_zeros(self.X.shape[0])
@@ -126,7 +126,7 @@ class GPRegression(GPModel):
 
         N = self.X.shape[0]
         Kff = self.kernel(self.X).contiguous()
-        Kff.view(-1, N * N)[:, ::N + 1] += noise  # add noise to the diagonal
+        Kff.view(-1)[::N + 1] += noise  # add noise to the diagonal
         Lff = Kff.potrf(upper=False)
 
         y_residual = self.y - self.mean_function(self.X)

--- a/pyro/contrib/gp/models/gpr.py
+++ b/pyro/contrib/gp/models/gpr.py
@@ -76,7 +76,9 @@ class GPRegression(GPModel):
 
         noise = self.get_param("noise")
 
-        Kff = self.kernel(self.X) + noise.expand(self.X.shape[0]).diag()
+        N = self.X.shape[0]
+        Kff = self.kernel(self.X)
+        Kff.view(-1, N * N)[:, ::N + 1] += noise  # add noise to diagonal
         Lff = Kff.potrf(upper=False)
 
         zero_loc = self.X.new_zeros(self.X.shape[0])
@@ -122,7 +124,9 @@ class GPRegression(GPModel):
         self._check_Xnew_shape(Xnew)
         noise = self.guide()
 
-        Kff = self.kernel(self.X) + noise.expand(self.X.shape[0]).diag()
+        N = self.X.shape[0]
+        Kff = self.kernel(self.X).contiguous()
+        Kff.view(-1, N * N)[:, ::N + 1] += noise  # add noise to the diagonal
         Lff = Kff.potrf(upper=False)
 
         y_residual = self.y - self.mean_function(self.X)
@@ -130,8 +134,10 @@ class GPRegression(GPModel):
                                full_cov, jitter=self.jitter)
 
         if full_cov and not noiseless:
-            cov = cov + noise.expand(Xnew.shape[0]).diag()
+            M = Xnew.shape[0]
+            cov = cov.contiguous()
+            cov.view(-1, M * M)[:, ::M + 1] += noise  # add noise to the diagonal
         if not full_cov and not noiseless:
-            cov = cov + noise.expand(Xnew.shape[0])
+            cov = cov + noise
 
         return loc + self.mean_function(Xnew), cov

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -129,7 +129,7 @@ class SparseGPRegression(GPModel):
 
         M = Xu.shape[0]
         Kuu = self.kernel(Xu).contiguous()
-        Kuu.view(-1, M * M)[:, ::M + 1] += self.jitter  # add jitter to the diagonal
+        Kuu.view(-1)[::M + 1] += self.jitter  # add jitter to the diagonal
         Luu = Kuu.potrf(upper=False)
         Kuf = self.kernel(Xu, self.X)
         W = Kuf.trtrs(Luu, upper=False)[0]
@@ -205,7 +205,7 @@ class SparseGPRegression(GPModel):
         M = Xu.shape[0]
 
         Kuu = self.kernel(Xu).contiguous()
-        Kuu.view(-1, M * M)[:, ::M + 1] += self.jitter  # add jitter to the diagonal
+        Kuu.view(-1)[::M + 1] += self.jitter  # add jitter to the diagonal
         Luu = Kuu.potrf(upper=False)
         Kus = self.kernel(Xu, Xnew)
         Kuf = self.kernel(Xu, self.X)
@@ -220,7 +220,7 @@ class SparseGPRegression(GPModel):
 
         W_Dinv = W / D
         K = W_Dinv.matmul(W.t()).contiguous()
-        K.view(-1, M * M)[:, ::M + 1] += 1  # add identity matrix to K
+        K.view(-1)[::M + 1] += 1  # add identity matrix to K
         L = K.potrf(upper=False)
 
         # get y_residual and convert it into 2D tensor for packing
@@ -239,8 +239,7 @@ class SparseGPRegression(GPModel):
         if full_cov:
             Kss = self.kernel(Xnew).contiguous()
             if not noiseless:
-                C = Xnew.shape[0]
-                Kss.view(-1, C * C)[:, ::C + 1] += noise  # add noise to the diagonal
+                Kss.view(-1)[::Xnew.shape[0] + 1] += noise  # add noise to the diagonal
             Qss = Ws.t().matmul(Ws)
             cov = Kss - Qss + Linv_Ws.t().matmul(Linv_Ws)
         else:

--- a/pyro/contrib/gp/models/vgp.py
+++ b/pyro/contrib/gp/models/vgp.py
@@ -89,7 +89,7 @@ class VariationalGP(GPModel):
 
         N = self.X.shape[0]
         Kff = self.kernel(self.X).contiguous()
-        Kff.view(-1, N * N)[:, ::N + 1] += self.jitter  # add jitter to the diagonal
+        Kff.view(-1)[::N + 1] += self.jitter  # add jitter to the diagonal
         Lff = Kff.potrf(upper=False)
 
         zero_loc = self.X.new_zeros(f_loc.shape)

--- a/pyro/contrib/gp/models/vgp.py
+++ b/pyro/contrib/gp/models/vgp.py
@@ -88,8 +88,8 @@ class VariationalGP(GPModel):
         f_scale_tril = self.get_param("f_scale_tril")
 
         N = self.X.shape[0]
-        Kff = self.kernel(self.X) + (torch.eye(N, out=self.X.new_empty(N, N)) *
-                                     self.jitter)
+        Kff = self.kernel(self.X).contiguous()
+        Kff.view(-1, N * N)[:, ::N + 1] += self.jitter  # add jitter to the diagonal
         Lff = Kff.potrf(upper=False)
 
         zero_loc = self.X.new_zeros(f_loc.shape)

--- a/pyro/contrib/gp/models/vsgp.py
+++ b/pyro/contrib/gp/models/vsgp.py
@@ -114,7 +114,7 @@ class VariationalSparseGP(GPModel):
 
         M = Xu.shape[0]
         Kuu = self.kernel(Xu).contiguous()
-        Kuu.view(-1, M * M)[:, ::M + 1] += self.jitter  # add jitter to the diagonal
+        Kuu.view(-1)[::M + 1] += self.jitter  # add jitter to the diagonal
         Luu = Kuu.potrf(upper=False)
 
         zero_loc = Xu.new_zeros(u_loc.shape)

--- a/pyro/contrib/gp/models/vsgp.py
+++ b/pyro/contrib/gp/models/vsgp.py
@@ -113,7 +113,8 @@ class VariationalSparseGP(GPModel):
         u_scale_tril = self.get_param("u_scale_tril")
 
         M = Xu.shape[0]
-        Kuu = self.kernel(Xu) + torch.eye(M, out=Xu.new_empty(M, M)) * self.jitter
+        Kuu = self.kernel(Xu).contiguous()
+        Kuu.view(-1, M * M)[:, ::M + 1] += self.jitter  # add jitter to the diagonal
         Luu = Kuu.potrf(upper=False)
 
         zero_loc = Xu.new_zeros(u_loc.shape)

--- a/pyro/contrib/gp/util.py
+++ b/pyro/contrib/gp/util.py
@@ -211,7 +211,8 @@ def conditional(Xnew, X, kernel, f_loc, f_scale_tril=None, Lff=None, full_cov=Fa
     latent_shape = f_loc.shape[:-1]
 
     if Lff is None:
-        Kff = kernel(X) + torch.eye(N, out=X.new_empty(N, N)) * jitter
+        Kff = kernel(X).contiguous()
+        Kff.view(-1, N * N)[:, ::N + 1] += jitter  # add jitter to diagonal
         Lff = Kff.potrf(upper=False)
     Kfs = kernel(X, Xnew)
 

--- a/pyro/contrib/gp/util.py
+++ b/pyro/contrib/gp/util.py
@@ -5,7 +5,6 @@ import torch.nn as nn
 
 import pyro
 import pyro.distributions as dist
-from pyro.distributions.util import matrix_triangular_solve_compat
 from pyro.params import param_with_module_name
 
 
@@ -228,7 +227,7 @@ def conditional(Xnew, X, kernel, f_loc, f_scale_tril=None, Lff=None, full_cov=Fa
 
     if whiten:
         v_2D = f_loc_2D
-        W = matrix_triangular_solve_compat(Kfs, Lff, upper=False)
+        W = Kfs.trtrs(Lff, upper=False)[0]
         if f_scale_tril is not None:
             S_2D = f_scale_tril_2D
     else:
@@ -236,7 +235,7 @@ def conditional(Xnew, X, kernel, f_loc, f_scale_tril=None, Lff=None, full_cov=Fa
         if f_scale_tril is not None:
             pack = torch.cat((pack, f_scale_tril_2D), dim=1)
 
-        Lffinv_pack = matrix_triangular_solve_compat(pack, Lff, upper=False)
+        Lffinv_pack = pack.trtrs(Lff, upper=False)[0]
         # unpack
         v_2D = Lffinv_pack[:, :f_loc_2D.shape[1]]
         W = Lffinv_pack[:, f_loc_2D.shape[1]:f_loc_2D.shape[1] + M]

--- a/pyro/contrib/gp/util.py
+++ b/pyro/contrib/gp/util.py
@@ -211,7 +211,7 @@ def conditional(Xnew, X, kernel, f_loc, f_scale_tril=None, Lff=None, full_cov=Fa
 
     if Lff is None:
         Kff = kernel(X).contiguous()
-        Kff.view(-1, N * N)[:, ::N + 1] += jitter  # add jitter to diagonal
+        Kff.view(-1)[::N + 1] += jitter  # add jitter to diagonal
         Lff = Kff.potrf(upper=False)
     Kfs = kernel(X, Xnew)
 

--- a/pyro/distributions/avf_mvn.py
+++ b/pyro/distributions/avf_mvn.py
@@ -57,7 +57,7 @@ class AVFMultivariateNormal(MultivariateNormal):
 class _AVFMVNSample(Function):
     @staticmethod
     def forward(ctx, loc, scale_tril, control_var, shape):
-        white = loc.new(shape).normal_()
+        white = loc.new_empty(shape).normal_()
         z = torch.matmul(white, scale_tril.t())
         ctx.save_for_backward(scale_tril, control_var, white)
         return loc + z

--- a/pyro/distributions/binomial.py
+++ b/pyro/distributions/binomial.py
@@ -57,7 +57,7 @@ class Binomial(torch.distributions.Distribution, TorchDistributionMixin):
         if is_scalar:
             batch_shape = torch.Size()
         else:
-            batch_shape = self._param.size()
+            batch_shape = self._param.shape
         super(Binomial, self).__init__(batch_shape, validate_args=validate_args)
 
     def _new(self, *args, **kwargs):
@@ -85,7 +85,7 @@ class Binomial(torch.distributions.Distribution, TorchDistributionMixin):
 
     @property
     def param_shape(self):
-        return self._param.size()
+        return self._param.shape
 
     def sample(self, sample_shape=torch.Size()):
         with torch.no_grad():

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -127,7 +127,7 @@ class Empirical(TorchDistribution):
             return self._log_weights.new_zeros(torch.Size()).log()
         idxs = torch.arange(self.sample_size)[selection_mask.min(dim=-1)[0]]
         log_probs = self._categorical.log_prob(idxs)
-        return log_sum_exp(log_probs)
+        return log_sum_exp(log_probs, dim=-1)
 
     def _weighted_mean(self, value, dim=0):
         weights = self._log_weights

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -98,8 +98,8 @@ class Empirical(TorchDistribution):
 
         # Seed the container tensors with the correct tensor types
         if self._samples is None:
-            self._samples = value.new()
-            self._log_weights = log_weight.new()
+            self._samples = value.new_tensor([])
+            self._log_weights = log_weight.new_tensor([])
         # Append to the buffer list
         self._samples_buffer.append(value)
         self._weights_buffer.append(log_weight)
@@ -118,8 +118,8 @@ class Empirical(TorchDistribution):
         :param torch.Tensor value: scalar or tensor value to be scored.
         """
         if self._validate_args:
-            if value.size() != self.event_shape:
-                raise ValueError("``value.size()`` must be {}".format(self.event_shape))
+            if value.shape != self.event_shape:
+                raise ValueError("``value.shape`` must be {}".format(self.event_shape))
         self._finalize()
         selection_mask = self._samples.eq(value).contiguous().view(self.sample_size, -1)
         # Return -Inf if value is outside the support.
@@ -141,7 +141,7 @@ class Empirical(TorchDistribution):
         self._finalize()
         if self._samples is None:
             return None
-        return self._samples.size()[1:]
+        return self._samples.shape[1:]
 
     @property
     def mean(self):

--- a/pyro/distributions/half_cauchy.py
+++ b/pyro/distributions/half_cauchy.py
@@ -22,7 +22,7 @@ class HalfCauchy(TransformedDistribution):
     arg_constraints = Cauchy.arg_constraints
     support = Cauchy.support
 
-    def __init__(self, loc, scale):
+    def __init__(self, loc=0, scale=1):
         loc, scale = broadcast_all(loc, scale)
         base_dist = Cauchy(0, scale)
         transforms = [AbsTransform(), AffineTransform(loc, 1)]

--- a/pyro/distributions/lowrank_mvn.py
+++ b/pyro/distributions/lowrank_mvn.py
@@ -7,7 +7,18 @@ from torch.distributions import constraints
 from torch.distributions.utils import lazy_property
 
 from pyro.distributions.torch_distribution import TorchDistribution
-from pyro.distributions.util import matrix_triangular_solve_compat
+
+
+def _matrix_triangular_solve_compat(b, A, upper=True):
+    """
+    Computes the solution to the linear equation AX = b,
+    where A is a triangular matrix.
+
+    :param b: A 1D or 2D tensor of size N or N x C.
+    :param A: A 2D tensor of size N X N.
+    :param upper: A flag if A is a upper triangular matrix or not.
+    """
+    return b.view(b.shape[0], -1).trtrs(A, upper=upper)[0].view(b.shape)
 
 
 class LowRankMultivariateNormal(TorchDistribution):
@@ -109,7 +120,7 @@ class LowRankMultivariateNormal(TorchDistribution):
         else:
             raise NotImplementedError("SparseMultivariateNormal distribution does not support "
                                       "computing log_prob for a tensor with more than 2 dimensionals.")
-        Linv_W_Dinv_y = matrix_triangular_solve_compat(W_Dinv_y, L, upper=False)
+        Linv_W_Dinv_y = _matrix_triangular_solve_compat(W_Dinv_y, L, upper=False)
         if y.dim() == 2:
             Linv_W_Dinv_y = Linv_W_Dinv_y.t()
 

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -188,18 +188,6 @@ def torch_sign(value):
     return torch.sign(value)
 
 
-def matrix_triangular_solve_compat(b, A, upper=True):
-    """
-    Computes the solution to the linear equation AX = b,
-    where A is a triangular matrix.
-
-    :param b: A 1D or 2D tensor of size N or N x C.
-    :param A: A 2D tensor of size N X N.
-    :param upper: A flag if A is a upper triangular matrix or not.
-    """
-    return b.view(b.shape[0], -1).trtrs(A, upper=upper)[0].view(b.shape)
-
-
 def log_sum_exp(tensor, dim=-1):
     """
     Numerically stable implementation for the `LogSumExp` operation. The

--- a/pyro/ops/newton.py
+++ b/pyro/ops/newton.py
@@ -44,7 +44,7 @@ def _inv_symmetric_3d(H):
     Calculates the inverse of a batched 3-D matrix
     """
     detH = _determinant_3d(H)
-    Hinv = H.new(H.shape)
+    Hinv = H.new_empty(H.shape)
     Hinv[..., 0, 0] = H[..., 1, 1] * H[..., 2, 2] - H[..., 1, 2] * H[..., 2, 1]
     Hinv[..., 1, 1] = H[..., 0, 0] * H[..., 2, 2] - H[..., 0, 2] * H[..., 2, 0]
     Hinv[..., 2, 2] = H[..., 0, 0] * H[..., 1, 1] - H[..., 0, 1] * H[..., 1, 0]
@@ -206,11 +206,11 @@ def newton_step_2d(loss, x, trust_radius=None):
         min_eig = mean_eig - (mean_eig ** 2 - detH).sqrt()
         regularizer = (g.pow(2).sum(-1).sqrt() / trust_radius - min_eig).clamp_(min=1e-8)
         warn_if_nan(regularizer, 'regularizer')
-        H = H + regularizer.unsqueeze(-1).unsqueeze(-1) * H.new(torch.eye(2))
+        H = H + regularizer.unsqueeze(-1).unsqueeze(-1) * H.new_tensor(torch.eye(2))
 
     # compute newton update
     detH = H[..., 0, 0] * H[..., 1, 1] - H[..., 0, 1] * H[..., 1, 0]
-    Hinv = H.new(H.shape)
+    Hinv = H.new_empty(H.shape)
     Hinv[..., 0, 0] = H[..., 1, 1]
     Hinv[..., 0, 1] = -H[..., 0, 1]
     Hinv[..., 1, 0] = -H[..., 1, 0]
@@ -263,7 +263,7 @@ def newton_step_3d(loss, x, trust_radius=None):
         min_eig, _, _ = _eig_3d(H)
         regularizer = (g.pow(2).sum(-1).sqrt() / trust_radius - min_eig).clamp_(min=1e-8)
         warn_if_nan(regularizer, 'regularizer')
-        H = H + regularizer.unsqueeze(-1).unsqueeze(-1) * H.new(torch.eye(3))
+        H = H + regularizer.unsqueeze(-1).unsqueeze(-1) * H.new_tensor(torch.eye(3))
 
     # compute newton update
     Hinv = _inv_symmetric_3d(H)

--- a/tests/common.py
+++ b/tests/common.py
@@ -136,16 +136,16 @@ def _safe_coalesce(t):
 
     new_indices = sorted(list(value_map.keys()))
     new_values = [value_map[idx] for idx in new_indices]
-    if t._values().ndimension() < 2:
-        new_values = t._values().new(new_values)
+    if t._values().dim() < 2:
+        new_values = t._values().new_tensor(new_values)
     else:
         new_values = torch.stack(new_values)
 
-    new_indices = t._indices().new(new_indices).t()
+    new_indices = t._indices().new_tensor(new_indices).t()
     tg = t.new(new_indices, new_values, t.size())
 
-    assert tc._indices() == tg._indices()
-    assert tc._values() == tg._values()
+    assert (tc._indices() == tg._indices()).all()
+    assert (tc._values() == tg._values()).all()
     return tg
 
 

--- a/tests/contrib/gp/test_models.py
+++ b/tests/contrib/gp/test_models.py
@@ -330,9 +330,10 @@ def _pre_test_mean_function():
     def f(x):
         return 2 * x + 3 + 5 * torch.sin(7 * x)
 
-    X = torch.arange(100)
+    tensor_holder = torch.tensor([])
+    X = tensor_holder.new_tensor(torch.arange(100))
     y = f(X)
-    Xnew = torch.arange(100, 150)
+    Xnew = tensor_holder.new_tensor(torch.arange(100, 150))
     ynew = f(Xnew)
 
     kernel = Cosine(input_dim=1)


### PR DESCRIPTION
This pull request revises the following points
+ Set default values for `loc` and `scale` of HalfCauchy, so when updating, it is enough to delete the implementation of HalfCauchy.
+ Add `dim` argument for `log_sum_exp` operator, so when updating, it is enough to change its name to `torch.logsumexp`
+ Make `matrix_triagular_solve_compat` function hidden inside `lowrank_mvn`. So when updating, it is enough to delete the implementation of lowrank_mvn. 
+ Use `torch.trtrs` directly in GP module
+ Use `.new_tensor`, `.new_empty` instead of `.new` at various places
+ Make the sum of a matrix with a diagonal matrix faster by using `view` trick.

There is still one thing needed to be updated relevant to `trace_term` of lowrank_mvn. I will address it in the other pull request.