### PR TITLE
Implement pyro.contrib.tracking.merge_points()

### DIFF
--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
+import heapq
 import itertools
 from collections import defaultdict
 from numbers import Number
+
+import torch
 
 
 class LSH(object):
@@ -131,3 +134,72 @@ class ApproxSet(object):
             return False
         self._bins.add(_hash)
         return True
+
+
+def merge_points(points, radius):
+    """
+    Greedily merge points that are closer than given radius.
+
+    This uses :class:`LSH` to achieve complexity that is linear in the number
+    of merged clusters and quadratic in the size of the largest merged cluster.
+
+    :param torch.Tensor points: A tensor of shape ``(K,D)`` where ``K`` is
+        the number of points and ``D`` is the number of dimensions.
+    :param float radius: The minimum distance nearer than which
+        points will be merged.
+    :return: A tuple ``(merged_points, groups)`` where ``merged_points`` is a
+        tensor of shape ``(J,D)`` where ``J <= K``, and ``groups`` is a list of
+        tuples of indices mapping merged points to original points. Note that
+        ``len(groups) == J`` and ``sum(len(group) for group in groups) == K``.
+    :rtype: tuple
+    """
+    if points.dim() != 2:
+        raise ValueError('Expected points.shape == (K,D), but got {}'.format(points.shape))
+    if not (isinstance(radius, Number) and radius > 0):
+        raise ValueError('Expected radius to be a positive number, but got {}'.format(radius))
+    radius = 0.99 * radius  # avoid merging points exactly radius apart, e.g. grid points
+    threshold = radius ** 2
+
+    # setup data structures to cheaply search for nearest pairs
+    lsh = LSH(radius)
+    priority_queue = []
+    for i, point in enumerate(points):
+        lsh.add(i, point)
+        for j in lsh.nearby(i):
+            d2 = (point - points[j]).pow(2).sum().item()
+            if d2 < threshold:
+                heapq.heappush(priority_queue, (d2, j, i))
+    if not priority_queue:
+        groups = [(i,) for i in range(len(points))]
+        return points, groups
+
+    # convert from dense to sparse representation
+    next_id = len(points)
+    points = dict(enumerate(points))
+    groups = {i: (i,) for i in range(len(points))}
+
+    # greedily merge
+    while priority_queue:
+        d1, i, j = heapq.heappop(priority_queue)
+        if i not in points or j not in points:
+            continue
+        k = next_id
+        next_id += 1
+        points[k] = (points.pop(i) + points.pop(j)) / 2
+        groups[k] = groups.pop(i) + groups.pop(j)
+        lsh.remove(i)
+        lsh.remove(j)
+        lsh.add(k, points[k])
+        for i in lsh.nearby(k):
+            if i == k:
+                continue
+            d2 = (points[i] - points[k]).pow(2).sum().item()
+            if d2 < threshold:
+                heapq.heappush(priority_queue, (d2, i, k))
+
+    # convert from sparse to dense representation
+    ids = sorted(points.keys())
+    points = torch.stack([points[i] for i in ids])
+    groups = [groups[i] for i in ids]
+
+    return points, groups

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -163,6 +163,7 @@ def merge_points(points, radius):
     # setup data structures to cheaply search for nearest pairs
     lsh = LSH(radius)
     priority_queue = []
+    groups = [(i,) for i in range(len(points))]
     for i, point in enumerate(points):
         lsh.add(i, point)
         for j in lsh.nearby(i):
@@ -170,13 +171,12 @@ def merge_points(points, radius):
             if d2 < threshold:
                 heapq.heappush(priority_queue, (d2, j, i))
     if not priority_queue:
-        groups = [(i,) for i in range(len(points))]
         return points, groups
 
     # convert from dense to sparse representation
     next_id = len(points)
     points = dict(enumerate(points))
-    groups = {i: (i,) for i in range(len(points))}
+    groups = dict(enumerate(groups))
 
     # greedily merge
     while priority_queue:

--- a/tests/contrib/tracking/test_hashing.py
+++ b/tests/contrib/tracking/test_hashing.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import torch
 
-from pyro.contrib.tracking.hashing import LSH, ApproxSet
+from pyro.contrib.tracking.hashing import LSH, ApproxSet, merge_points
 from tests.common import assert_equal
 
 
@@ -115,3 +115,20 @@ def test_aps_try_add(scale):
     assert_equal(aps.try_add(b), False)
     assert_equal(aps.try_add(c), True)
     assert_equal(aps.try_add(d), False)
+
+
+def test_merge_points():
+    points = torch.tensor([
+        [0., 0.],
+        [0., 1.],
+        [2., 0.],
+        [2., 0.5],
+        [2., 1.0],
+    ])
+    merged_points, groups = merge_points(points, radius=1.0)
+    assert len(merged_points) == 3
+    assert set(map(frozenset, groups)) == set(map(frozenset, [[0], [1], [2, 3, 4]]))
+    assert_equal(merged_points[0], points[0])
+    assert_equal(merged_points[1], points[1])
+    assert merged_points[2, 0] == 2
+    assert 0.325 <= merged_points[2, 1] <= 0.625

--- a/tests/contrib/tracking/test_hashing.py
+++ b/tests/contrib/tracking/test_hashing.py
@@ -117,7 +117,7 @@ def test_aps_try_add(scale):
     assert_equal(aps.try_add(d), False)
 
 
-def test_merge_points():
+def test_merge_points_small():
     points = torch.tensor([
         [0., 0.],
         [0., 1.],
@@ -126,9 +126,26 @@ def test_merge_points():
         [2., 1.0],
     ])
     merged_points, groups = merge_points(points, radius=1.0)
+
     assert len(merged_points) == 3
     assert set(map(frozenset, groups)) == set(map(frozenset, [[0], [1], [2, 3, 4]]))
     assert_equal(merged_points[0], points[0])
     assert_equal(merged_points[1], points[1])
     assert merged_points[2, 0] == 2
     assert 0.325 <= merged_points[2, 1] <= 0.625
+
+
+@pytest.mark.parametrize('radius', [0.01, 0.1, 1., 10., 100.])
+@pytest.mark.parametrize('dim', [1, 2, 3])
+def test_merge_points_large(dim, radius):
+    points = 10 * torch.randn(200, dim)
+    merged_points, groups = merge_points(points, radius)
+    print('merged {} -> {}'.format(len(points), len(merged_points)))
+
+    assert merged_points.dim() == 2
+    assert merged_points.shape[-1] == dim
+    assert len(groups) == len(merged_points)
+    assert sum(len(g) for g in groups) == len(points)
+    assert set(sum(groups, ())) == set(range(len(points)))
+    d2 = (merged_points.unsqueeze(-2) - merged_points.unsqueeze(-3)).pow(2).sum(-1)
+    assert d2.min() < radius ** 2


### PR DESCRIPTION
Addresses #1185 

This uses `pyro.contrib.tracking.hashing.LSH` to implement a cheap greedy merging algorithm that is useful for guides that do tracking or mapping.

Note that this greedily merges the input `points` tensor, but also supports merging other tensors via the returned `groups` indices.

## Tested

- added unit tests
- tested on internal applications