### PR TITLE
Implement VonMises3D distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -134,6 +134,13 @@ VonMises
     :undoc-members:
     :show-inheritance:
 
+VonMises3D
+----------
+.. autoclass:: pyro.distributions.VonMises3D
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Transformed Distributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -16,6 +16,7 @@ from pyro.distributions.torch import *  # noqa F403
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.util import enable_validation, is_validation_enabled, validation_enabled
 from pyro.distributions.von_mises import VonMises
+from pyro.distributions.von_mises_3d import VonMises3D
 from pyro.distributions.relaxed_straight_through import RelaxedOneHotCategoricalStraightThrough
 from pyro.distributions.diag_normal_mixture_shared_cov import MixtureOfDiagNormalsSharedCovariance
 from pyro.distributions.relaxed_straight_through import RelaxedBernoulliStraightThrough
@@ -39,6 +40,7 @@ __all__ = [
     "RelaxedOneHotCategoricalStraightThrough",
     "TorchDistribution",
     "VonMises",
+    "VonMises3D",
 ]
 
 # Import all torch distributions from `pyro.distributions.torch_distribution`

--- a/pyro/distributions/binomial.py
+++ b/pyro/distributions/binomial.py
@@ -124,7 +124,7 @@ class Binomial(torch.distributions.Distribution, TorchDistributionMixin):
         try:
             return super(Binomial, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             total_count = self.total_count.expand(batch_shape)
             if 'probs' in self.__dict__:
                 probs = self.probs.expand(batch_shape)

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -43,7 +43,7 @@ class Delta(TorchDistribution):
         super(Delta, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape):
-        validate_args = self.__dict__.get('validate_args')
+        validate_args = self.__dict__.get('_validate_args')
         v = self.v.expand(batch_shape + self.event_shape)
         log_density = self.log_density.expand(batch_shape)
         return Delta(v, log_density, self.event_dim, validate_args=validate_args)

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -10,7 +10,7 @@ class Bernoulli(torch.distributions.Bernoulli, TorchDistributionMixin):
         try:
             return super(Bernoulli, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             if 'probs' in self.__dict__:
                 probs = self.probs.expand(batch_shape)
                 return type(self)(probs=probs, validate_args=validate_args)
@@ -24,7 +24,7 @@ class Beta(torch.distributions.Beta, TorchDistributionMixin):
         try:
             return super(Beta, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             concentration1 = self.concentration1.expand(batch_shape)
             concentration0 = self.concentration0.expand(batch_shape)
             return type(self)(concentration1, concentration0, validate_args=validate_args)
@@ -36,7 +36,7 @@ class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
             return super(Categorical, self).expand(batch_shape)
         except NotImplementedError:
             batch_shape = torch.Size(batch_shape)
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             if 'probs' in self.__dict__:
                 probs = self.probs.expand(batch_shape + self.probs.shape[-1:])
                 return type(self)(probs=probs, validate_args=validate_args)
@@ -50,7 +50,7 @@ class Cauchy(torch.distributions.Cauchy, TorchDistributionMixin):
         try:
             return super(Cauchy, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             loc = self.loc.expand(batch_shape)
             scale = self.scale.expand(batch_shape)
             return type(self)(loc, scale, validate_args=validate_args)
@@ -61,7 +61,7 @@ class Chi2(torch.distributions.Chi2, TorchDistributionMixin):
         try:
             return super(Chi2, self).expand_by(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             df = self.df.expand(batch_shape)
             return type(self)(df, validate_args=validate_args)
 
@@ -72,7 +72,7 @@ class Dirichlet(torch.distributions.Dirichlet, TorchDistributionMixin):
             return super(Dirichlet, self).expand(batch_shape)
         except NotImplementedError:
             batch_shape = torch.Size(batch_shape)
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             concentration = self.concentration.expand(batch_shape + self.event_shape)
             return type(self)(concentration, validate_args=validate_args)
 
@@ -82,7 +82,7 @@ class Exponential(torch.distributions.Exponential, TorchDistributionMixin):
         try:
             return super(Exponential, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             rate = self.rate.expand(batch_shape)
             return type(self)(rate, validate_args=validate_args)
 
@@ -92,7 +92,7 @@ class Gamma(torch.distributions.Gamma, TorchDistributionMixin):
         try:
             return super(Gamma, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             concentration = self.concentration.expand(batch_shape)
             rate = self.rate.expand(batch_shape)
             return type(self)(concentration, rate, validate_args=validate_args)
@@ -103,7 +103,7 @@ class Geometric(torch.distributions.Geometric, TorchDistributionMixin):
         try:
             return super(Geometric, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             if 'probs' in self.__dict__:
                 probs = self.probs.expand(batch_shape)
                 return type(self)(probs=probs, validate_args=validate_args)
@@ -117,7 +117,7 @@ class Gumbel(torch.distributions.Gumbel, TorchDistributionMixin):
         try:
             return super(Gumbel, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             loc = self.loc.expand(batch_shape)
             scale = self.scale.expand(batch_shape)
             return type(self)(loc, scale, validate_args=validate_args)
@@ -126,7 +126,7 @@ class Gumbel(torch.distributions.Gumbel, TorchDistributionMixin):
 class Independent(torch.distributions.Independent, TorchDistributionMixin):
     def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
-        validate_args = self.__dict__.get('validate_args')
+        validate_args = self.__dict__.get('_validate_args')
         extra_shape = self.base_dist.event_shape[:self.reinterpreted_batch_ndims]
         base_dist = self.base_dist.expand(batch_shape + extra_shape)
         return Independent(base_dist, self.reinterpreted_batch_ndims, validate_args=validate_args)
@@ -137,7 +137,7 @@ class Laplace(torch.distributions.Laplace, TorchDistributionMixin):
         try:
             return super(Laplace, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             loc = self.loc.expand(batch_shape)
             scale = self.scale.expand(batch_shape)
             return type(self)(loc, scale, validate_args=validate_args)
@@ -148,7 +148,7 @@ class LogNormal(torch.distributions.LogNormal, TorchDistributionMixin):
         try:
             return super(LogNormal, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             loc = self.loc.expand(batch_shape)
             scale = self.scale.expand(batch_shape)
             return type(self)(loc, scale, validate_args=validate_args)
@@ -160,7 +160,7 @@ class Multinomial(torch.distributions.Multinomial, TorchDistributionMixin):
             return super(Multinomial, self).expand(batch_shape)
         except NotImplementedError:
             batch_shape = torch.Size(batch_shape)
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             if 'probs' in self.__dict__:
                 probs = self.probs.expand(batch_shape + self.event_shape)
                 return type(self)(self.total_count, probs=probs, validate_args=validate_args)
@@ -175,7 +175,7 @@ class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributi
             return super(MultivariateNormal, self).expand(batch_shape)
         except NotImplementedError:
             batch_shape = torch.Size(batch_shape)
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             loc = self.loc.expand(batch_shape + self.event_shape)
             if 'scale_tril' in self.__dict__:
                 scale_tril = self.scale_tril.expand(batch_shape + self.event_shape + self.event_shape)
@@ -193,7 +193,7 @@ class Normal(torch.distributions.Normal, TorchDistributionMixin):
         try:
             return super(Normal, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             loc = self.loc.expand(batch_shape)
             scale = self.scale.expand(batch_shape)
             return type(self)(loc, scale, validate_args=validate_args)
@@ -205,7 +205,7 @@ class OneHotCategorical(torch.distributions.OneHotCategorical, TorchDistribution
             return super(OneHotCategorical, self).expand(batch_shape)
         except NotImplementedError:
             batch_shape = torch.Size(batch_shape)
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             if 'probs' in self.__dict__:
                 probs = self.probs.expand(batch_shape + self.event_shape)
                 return type(self)(probs=probs, validate_args=validate_args)
@@ -219,7 +219,7 @@ class Poisson(torch.distributions.Poisson, TorchDistributionMixin):
         try:
             return super(Poisson, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             rate = self.rate.expand(batch_shape)
             return type(self)(rate, validate_args=validate_args)
 
@@ -229,7 +229,7 @@ class StudentT(torch.distributions.StudentT, TorchDistributionMixin):
         try:
             return super(StudentT, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             df = self.df.expand(batch_shape)
             loc = self.loc.expand(batch_shape)
             scale = self.scale.expand(batch_shape)
@@ -247,7 +247,7 @@ class Uniform(torch.distributions.Uniform, TorchDistributionMixin):
         try:
             return super(Uniform, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             low = self.low.expand(batch_shape)
             high = self.high.expand(batch_shape)
             return type(self)(low, high, validate_args=validate_args)

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -45,6 +45,13 @@ class VonMises(TorchDistribution):
     """
     A circular von Mises distribution.
 
+    This implementation uses polar coordinates. The ``loc`` and ``value`` args
+    can be any real number (to facilitate unconstrained optimization), but are
+    interpreted as angles modulo 2 pi.
+
+    See :class:`~pyro.distributions.VonMises3D` for a 3D cartesian coordinate
+    cousin of this distribution.
+
     Currently only :meth:`log_prob` is implemented.
 
     :param torch.Tensor loc: an angle in radians.

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -68,7 +68,7 @@ class VonMises(TorchDistribution):
         try:
             return super(VonMises, self).expand(batch_shape)
         except NotImplementedError:
-            validate_args = self.__dict__.get('validate_args')
+            validate_args = self.__dict__.get('_validate_args')
             loc = self.loc.expand(batch_shape)
             concentration = self.concentration.expand(batch_shape)
             return type(self)(loc, concentration, validate_args=validate_args)

--- a/pyro/distributions/von_mises_3d.py
+++ b/pyro/distributions/von_mises_3d.py
@@ -12,6 +12,12 @@ class VonMises3D(TorchDistribution):
     """
     Spherical von Mises distribution.
     https://en.wikipedia.org/wiki/Von_Mises%E2%80%93Fisher_distribution
+
+    Currently only :meth:`log_prob` is implemented.
+
+    :param torch.Tensor concentration: A combined location-and-concentration
+        vector. The direction of this vector is the location, and its
+        magnitude is the contration.
     """
     arg_constraints = {'concentration': constraints.real}
     support = constraints.real  # TODO implement constraints.sphere or similar

--- a/pyro/distributions/von_mises_3d.py
+++ b/pyro/distributions/von_mises_3d.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, division, print_function
+
+import math
+
+import torch
+from torch.distributions import constraints
+
+from pyro.distributions import TorchDistribution
+
+
+class VonMises3D(TorchDistribution):
+    """
+    Spherical von Mises distribution.
+    https://en.wikipedia.org/wiki/Von_Mises%E2%80%93Fisher_distribution
+    """
+    arg_constraints = {'concentration': constraints.real}
+    support = constraints.real  # TODO implement constraints.sphere or similar
+
+    def __init__(self, concentration, validate_args=None):
+        if concentration.dim() < 1 or concentration.shape[-1] != 3:
+            raise ValueError('Expected concentration to have rightmost dim 3, actual shape = {}'.format(
+                concentration.shape))
+        self.concentration = concentration
+        batch_shape, event_shape = concentration.shape[:-1], concentration.shape[-1:]
+        super(VonMises3D, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+
+    def log_prob(self, value):
+        if self._validate_args:
+            if value.dim() < 1 or value.shape[-1] != 3:
+                raise ValueError('Expected value to have rightmost dim 3, actual shape = {}'.format(
+                    value.shape))
+            if not (torch.abs(value.norm(2, -1) - 1) < 1e-6).all():
+                raise ValueError('direction vectors are not normalized')
+        scale = self.concentration.norm(2, -1)
+        log_normalizer = scale.log() - scale.sinh().log() - math.log(4 * math.pi)
+        return (self.concentration * value).sum(-1) + log_normalizer
+
+    def expand(self, batch_shape):
+        try:
+            return super(VonMises3D, self).expand(batch_shape)
+        except NotImplementedError:
+            validate_args = self.__dict__.get('_validate_args')
+            concentration = self.concentration.expand(torch.Size(batch_shape) + (3,))
+            return type(self)(concentration, validate_args=validate_args)

--- a/pyro/distributions/von_mises_3d.py
+++ b/pyro/distributions/von_mises_3d.py
@@ -11,13 +11,20 @@ from pyro.distributions import TorchDistribution
 class VonMises3D(TorchDistribution):
     """
     Spherical von Mises distribution.
-    https://en.wikipedia.org/wiki/Von_Mises%E2%80%93Fisher_distribution
+
+    This implementation combines the direction parameter and concentration
+    parameter into a single combined parameter that contains both direction and
+    magnitude. The ``value`` arg is represented in cartesian coordinates: it
+    must be a normalized 3-vector that lies on the 2-sphere.
+
+    See :class:`~pyro.distributions.VonMises` for a 2D polar coordinate cousin
+    of this distribution.
 
     Currently only :meth:`log_prob` is implemented.
 
     :param torch.Tensor concentration: A combined location-and-concentration
         vector. The direction of this vector is the location, and its
-        magnitude is the contration.
+        magnitude is the concentration.
     """
     arg_constraints = {'concentration': constraints.real}
     support = constraints.real  # TODO implement constraints.sphere or similar

--- a/tests/distributions/test_von_mises.py
+++ b/tests/distributions/test_von_mises.py
@@ -5,7 +5,7 @@ import math
 import pytest
 import torch
 
-from pyro.distributions import VonMises
+from pyro.distributions import VonMises, VonMises3D
 
 
 @pytest.mark.parametrize('concentration', [0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0, 100.0])
@@ -14,3 +14,19 @@ def test_log_prob_normalized(concentration):
     prob = VonMises(0.0, concentration).log_prob(grid).exp()
     norm = prob.mean().item() * 2 * math.pi
     assert abs(norm - 1) < 1e-3, norm
+
+
+@pytest.mark.parametrize('scale', [0.1, 0.5, 0.9, 1.0, 1.1, 2.0, 10.0])
+def test_von_mises_3d(scale):
+    concentration = torch.randn(3)
+    concentration = concentration * (scale / concentration.norm(2))
+
+    num_samples = 100000
+    samples = torch.randn(num_samples, 3)
+    samples = samples / samples.norm(2, dim=-1, keepdim=True)
+
+    d = VonMises3D(concentration, validate_args=True)
+    actual_total = d.log_prob(samples).exp().mean()
+    expected_total = 1 / (4 * math.pi)
+    ratio = actual_total / expected_total
+    assert torch.abs(ratio - 1) < 0.01, ratio


### PR DESCRIPTION
This implements the `.log_prob()` part of a `VonMises3D` distribution, similar to the 2D `VonMises` distribution.

This also fixes an attribute name bug (my fault) introduced in #1187.

## Tested

- [x] simple normalization test
- [x] tested on internal applications
- [ ] any other tests?