### PR TITLE
Separate trace from low rank mvn

### DIFF
--- a/pyro/distributions/lowrank_mvn.py
+++ b/pyro/distributions/lowrank_mvn.py
@@ -49,6 +49,7 @@ class LowRankMultivariateNormal(TorchDistribution):
     has_rsample = True
 
     def __init__(self, loc, W_term, D_term, trace_term=None):
+        W_term = W_term.t()
         if loc.shape[-1] != D_term.shape[0]:
             raise ValueError("Expected loc.shape == D_term.shape, but got {} vs {}".format(
                 loc.shape, D_term.shape))

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -153,7 +153,7 @@ continuous_dists = [
     Fixture(pyro_dist=dist.LowRankMultivariateNormal,
             scipy_dist=sp.multivariate_normal,
             examples=[
-                {'loc': [2.0, 1.0], 'D_term': [0.5, 0.5], 'W_term': [[1.0, 0.5]],
+                {'loc': [2.0, 1.0], 'D_term': [0.5, 0.5], 'W_term': [[1.0], [0.5]],
                  'test_data': [[2.0, 1.0], [9.0, 3.4]]},
             ],
             scipy_arg_fn=lambda loc, D_term=None, W_term=None:

--- a/tests/distributions/test_lowrank_mvn.py
+++ b/tests/distributions/test_lowrank_mvn.py
@@ -9,8 +9,8 @@ from tests.common import assert_equal
 def test_scale_tril():
     loc = torch.tensor([1.0, 2.0, 1.0, 2.0, 0.0])
     D = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
-    W = torch.tensor([[1.0, -1.0, 2.0, 3.0, 4.0], [2.0, 3.0, 1.0, 2.0, 4.0]])
-    cov = D.diag() + W.t().matmul(W)
+    W = torch.tensor([[1.0, 2.0], [-1.0, 3.0], [2.0, 1.0], [3.0, 2.0], [4.0, 4.0]])
+    cov = D.diag() + W.matmul(W.t())
 
     mvn = MultivariateNormal(loc, cov)
     lowrank_mvn = LowRankMultivariateNormal(loc, W, D)
@@ -21,9 +21,9 @@ def test_scale_tril():
 def test_log_prob():
     loc = torch.tensor([2.0, 1.0, 1.0, 2.0, 2.0])
     D = torch.tensor([1.0, 2.0, 3.0, 1.0, 3.0])
-    W = torch.tensor([[1.0, -1.0, 2.0, 2.0, 4.0], [2.0, 1.0, 1.0, 2.0, 6.0]])
+    W = torch.tensor([[1.0, 2.0], [-1.0, 1.0], [2.0, 1.0], [2.0, 2.0], [4.0, 6.0]])
     x = torch.tensor([2.0, 3.0, 4.0, 1.0, 7.0])
-    cov = D.diag() + W.t().matmul(W)
+    cov = D.diag() + W.matmul(W.t())
 
     mvn = MultivariateNormal(loc, cov)
     lowrank_mvn = LowRankMultivariateNormal(loc, W, D)
@@ -34,8 +34,8 @@ def test_log_prob():
 def test_variance():
     loc = torch.tensor([1.0, 1.0, 1.0, 2.0, 0.0])
     D = torch.tensor([1.0, 2.0, 2.0, 4.0, 5.0])
-    W = torch.tensor([[3.0, -1.0, 3.0, 3.0, 4.0], [2.0, 3.0, 1.0, 3.0, 4.0]])
-    cov = D.diag() + W.t().matmul(W)
+    W = torch.tensor([[3.0, 2.0], [-1.0, 3.0], [3.0, 1.0], [3.0, 3.0], [4.0, 4.0]])
+    cov = D.diag() + W.matmul(W.t())
 
     mvn = MultivariateNormal(loc, cov)
     lowrank_mvn = LowRankMultivariateNormal(loc, W, D)


### PR DESCRIPTION
The lowrank_mvn version in PyTorch will not have trace_term. To remedy it, I use the trick suggested by @eb8680 to add trace_term to the log_prob.

In addition, in PyTorch, covariance_matrix = W @ W.t() + D. In our lowrank_mvn, covariance_matrix = W.t() @ W + D. So I also make a small fix for it.