### PR TITLE
Numerically stable log slice computation in NUTS

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -200,7 +200,8 @@ class HMC(TraceKernel):
             z = {name: node["value"] for name, node in trace.iter_stochastic_nodes()}
             for name, transform in self.transforms.items():
                 z[name] = transform(z[name])
-            self.step_size = self._find_reasonable_step_size(z)
+            with pyro.validation_enabled(False):
+                self.step_size = self._find_reasonable_step_size(z)
             self.num_steps = max(1, int(self.trajectory_length / self.step_size))
             # make prox-center for Dual Averaging scheme
             loc = math.log(10 * self.step_size)

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -37,7 +37,9 @@ class NUTS(HMC):
     **References**
 
     [1] `The No-U-turn sampler: adaptively setting path lengths in Hamiltonian Monte Carlo`,
-    Matthew D. Hoffman, and Andrew Gelman
+    Matthew D. Hoffman, and Andrew Gelman.
+    [2] `A Conceptual Introduction to Hamiltonian Monte Carlo`, Michael Betancourt
+    [3] `Slice Sampling`, Radford M. Neal
 
     :param model: Python callable containing Pyro primitives.
     :param float step_size: Determines the size of a single step taken by the
@@ -211,17 +213,14 @@ class NUTS(HMC):
         #     first sampling u from initial state (z_0, r_0) according to u ~ Uniform(0, p(z_0, r_0)),
         #     then sampling state (z, r) from the integrator trajectory according to
         #         (z, r) ~ Uniform({(z', r') in trajectory | p(z', r') >= u}).
-        # For more information about slice sampling method, see
-        #     `Slice sampling` by Radford M. Neal.
+        #
+        # For more information about slice sampling method, see [3].
         # For another version of NUTS which uses multinomial sampling instead of slice sampling, see
-        #     `A Conceptual Introduction to Hamiltonian Monte Carlo` by Michael Betancourt.
-        joint_prob = torch.exp(-energy_current)
-        if joint_prob == 0:
-            slice_var = energy_current.new_tensor(0.0)
-        else:
-            slice_var = pyro.sample("slicevar_t={}".format(self._t),
-                                    dist.Uniform(torch.zeros(1), joint_prob))
-        log_slice = slice_var.log()
+        # [2].
+
+        # Rather than sampling the slice variable from `Uniform(0, exp(-energy))`, we can sample
+        # log_slice directly using `energy`, so as to avoid underflow issues ([2]).
+        log_slice = -energy_current - dist.Exponential(energy_current.new_tensor(1.)).sample()
 
         z_left = z_right = z
         r_left = r_right = r

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -220,7 +220,9 @@ class NUTS(HMC):
 
         # Rather than sampling the slice variable from `Uniform(0, exp(-energy))`, we can sample
         # log_slice directly using `energy`, so as to avoid underflow issues ([2]).
-        log_slice = -energy_current - dist.Exponential(energy_current.new_tensor(1.)).sample()
+        slice_exp_term = pyro.sample("slicevar_exp_t={}".format(self._t),
+                                     dist.Exponential(energy_current.new_tensor(1.)))
+        log_slice = -energy_current - slice_exp_term
 
         z_left = z_right = z
         r_left = r_right = r

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -218,8 +218,9 @@ class NUTS(HMC):
         # For another version of NUTS which uses multinomial sampling instead of slice sampling, see
         # [2].
 
-        # Rather than sampling the slice variable from `Uniform(0, exp(-energy))`, we can sample
-        # log_slice directly using `energy`, so as to avoid underflow issues ([2]).
+        # Rather than sampling the slice variable from `Uniform(0, exp(-energy))`, we can
+        # sample log_slice directly using `energy`, so as to avoid potential underflow or
+        # overflow issues ([2]).
         slice_exp_term = pyro.sample("slicevar_exp_t={}".format(self._t),
                                      dist.Exponential(energy_current.new_tensor(1.)))
         log_slice = -energy_current - slice_exp_term

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -171,7 +171,7 @@ def test_logistic_regression():
     assert_equal(rmse(true_coefs, beta_posterior.mean).item(), 0.0, prec=0.1)
 
 
-def test_bernoulli_beta():
+def test_beta_bernoulli():
     def model(data):
         alpha = torch.tensor([1.1, 1.1])
         beta = torch.tensor([1.1, 1.1])
@@ -187,7 +187,7 @@ def test_bernoulli_beta():
     assert_equal(posterior.mean, true_probs, prec=0.05)
 
 
-def test_normal_gamma():
+def test_gamma_normal():
     def model(data):
         rate = torch.tensor([1.0, 1.0])
         concentration = torch.tensor([1.0, 1.0])
@@ -203,7 +203,7 @@ def test_normal_gamma():
     assert_equal(posterior.mean, true_std, prec=0.05)
 
 
-def test_categorical_dirichlet():
+def test_dirichlet_categorical():
     def model(data):
         concentration = torch.tensor([1.0, 1.0, 1.0])
         p_latent = pyro.sample('p_latent', dist.Dirichlet(concentration))
@@ -236,7 +236,7 @@ def test_logistic_regression_with_dual_averaging():
     assert_equal(rmse(posterior.mean, true_coefs).item(), 0.0, prec=0.1)
 
 
-def test_bernoulli_beta_with_dual_averaging():
+def test_beta_bernoulli_with_dual_averaging():
     def model(data):
         alpha = torch.tensor([1.1, 1.1])
         beta = torch.tensor([1.1, 1.1])
@@ -252,7 +252,7 @@ def test_bernoulli_beta_with_dual_averaging():
     assert_equal(posterior.mean, true_probs, prec=0.05)
 
 
-def test_normal_gamma_with_dual_averaging():
+def test_gamma_normal_with_dual_averaging():
     def model(data):
         rate = torch.tensor([1.0, 1.0])
         concentration = torch.tensor([1.0, 1.0])


### PR DESCRIPTION
Fixes #1174. 

We were having problems with certain models (e.g. in #1174) where the acceptance probability was extremely low in NUTS (with or without step size adaptation). The issue was that if we are in a state such that the energy term is a high negative number (similar issue with high positive value), then `exp(-energy)` blows up to infinity. This results in a inf `log_slice` term that would result in rejections no matter what the new state is (the base tree itself would be marked as diverging). 

This makes a minor change to the computation of the `log_slice` variable in NUTS so that we do not need to exponentiate the energy term, but can use it directly with the existing energy term which can have very high/low values (e.g. +/- 400). The trick (as mentioned by Neal in his Slice Sampling paper) is that instead of sampling a uniform random from `U(0, e(-energy))` and taking the log, we instead sample an auxiliary z from an exponential distribution with mean 1, and use `log u = -energy - z, where z ~ Exp(1)`. Tested using the model from #1174, which works now. 

Additionally, some minor clean up: 
 - Changed the test names to correspond to the convention of specifying the latent variable first. We have a few tests that use the opposite convention in `test_inference.py` which we should change as well.
 - Another minor change is to disable arg validation during the initial step size adaptation in setup (it is already disabled during the adaptation phase).