### PR TITLE
Consolidate *ELBO._get_trace

### DIFF
--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -1,9 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 from six.moves.queue import LifoQueue
 
 from pyro import poutine
 from pyro.poutine import Trace
+
+from pyro.infer.util import is_validation_enabled
+from pyro.poutine.util import prune_subsample_sites
+from pyro.util import check_model_guide_match, check_site_shape
 
 
 def _iter_discrete_escape(trace, msg):
@@ -23,6 +29,39 @@ def _iter_discrete_extend(trace, site, **ignored):
         extended_trace = trace.copy()
         extended_trace.add_node(site["name"], **extended_site)
         yield extended_trace
+
+
+def _get_importance_trace(graph_type, max_iarange_nesting, model, guide, *args, **kwargs):
+    """
+    Returns a single trace from the guide, and the model that is run
+    against it.
+    """
+    guide_trace = poutine.trace(guide, graph_type=graph_type).get_trace(*args, **kwargs)
+    model_trace = poutine.trace(poutine.replay(model, trace=guide_trace),
+                                graph_type=graph_type).get_trace(*args, **kwargs)
+    if is_validation_enabled():
+        check_model_guide_match(model_trace, guide_trace)
+        enumerated_sites = [name for name, site in guide_trace.nodes.items()
+                            if site["type"] == "sample" and site["infer"].get("enumerate")]
+        if enumerated_sites:
+            warnings.warn('\n'.join([
+                'Trace_ELBO found sample sites configured for enumeration:'
+                ', '.join(enumerated_sites),
+                'If you want to enumerate sites, you need to use TraceEnum_ELBO instead.']))
+    guide_trace = prune_subsample_sites(guide_trace)
+    model_trace = prune_subsample_sites(model_trace)
+
+    model_trace.compute_log_prob()
+    guide_trace.compute_score_parts()
+    if is_validation_enabled():
+        for site in model_trace.nodes.values():
+            if site["type"] == "sample":
+                check_site_shape(site, max_iarange_nesting)
+        for site in guide_trace.nodes.values():
+            if site["type"] == "sample":
+                check_site_shape(site, max_iarange_nesting)
+
+    return model_trace, guide_trace
 
 
 def iter_discrete_traces(graph_type, fn, *args, **kwargs):

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -10,14 +10,14 @@ from pyro.poutine.util import prune_subsample_sites
 from pyro.util import check_model_guide_match, check_site_shape
 
 
-def _iter_discrete_escape(trace, msg):
+def iter_discrete_escape(trace, msg):
     return ((msg["type"] == "sample") and
             (not msg["is_observed"]) and
             (msg["infer"].get("enumerate") == "sequential") and  # only sequential
             (msg["name"] not in trace))
 
 
-def _iter_discrete_extend(trace, site, **ignored):
+def iter_discrete_extend(trace, site, **ignored):
     values = site["fn"].enumerate_support()
     for i, value in enumerate(values):
         extended_site = site.copy()
@@ -29,7 +29,7 @@ def _iter_discrete_extend(trace, site, **ignored):
         yield extended_trace
 
 
-def _get_importance_trace(graph_type, max_iarange_nesting, model, guide, *args, **kwargs):
+def get_importance_trace(graph_type, max_iarange_nesting, model, guide, *args, **kwargs):
     """
     Returns a single trace from the guide, and the model that is run
     against it.
@@ -73,7 +73,7 @@ def iter_discrete_traces(graph_type, fn, *args, **kwargs):
     queue = LifoQueue()
     queue.put(Trace())
     traced_fn = poutine.trace(
-        poutine.queue(fn, queue, escape_fn=_iter_discrete_escape, extend_fn=_iter_discrete_extend),
+        poutine.queue(fn, queue, escape_fn=iter_discrete_escape, extend_fn=iter_discrete_extend),
         graph_type=graph_type)
     while not queue.empty():
         yield traced_fn.get_trace(*args, **kwargs)

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import warnings
-
 from six.moves.queue import LifoQueue
 
 from pyro import poutine
@@ -40,14 +38,8 @@ def _get_importance_trace(graph_type, max_iarange_nesting, model, guide, *args, 
     model_trace = poutine.trace(poutine.replay(model, trace=guide_trace),
                                 graph_type=graph_type).get_trace(*args, **kwargs)
     if is_validation_enabled():
-        check_model_guide_match(model_trace, guide_trace)
-        enumerated_sites = [name for name, site in guide_trace.nodes.items()
-                            if site["type"] == "sample" and site["infer"].get("enumerate")]
-        if enumerated_sites:
-            warnings.warn('\n'.join([
-                'Trace_ELBO found sample sites configured for enumeration:'
-                ', '.join(enumerated_sites),
-                'If you want to enumerate sites, you need to use TraceEnum_ELBO instead.']))
+        check_model_guide_match(model_trace, guide_trace, max_iarange_nesting)
+
     guide_trace = prune_subsample_sites(guide_trace)
     model_trace = prune_subsample_sites(model_trace)
 

--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
 import math
+import warnings
 
 import torch
 
 from pyro.distributions.util import is_identically_zero, log_sum_exp
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import _get_importance_trace
-from pyro.infer.util import torch_item
+from pyro.infer.util import is_validation_enabled, torch_item
 from pyro.util import warn_if_nan
 
 
@@ -66,7 +67,18 @@ class RenyiELBO(ELBO):
         Returns a single trace from the guide, and the model that is run
         against it.
         """
-        return _get_importance_trace("flat", self.max_iarange_nesting, model, guide, *args, **kwargs)
+        model_trace, guide_trace = _get_importance_trace(
+            "flat", self.max_iarange_nesting, model, guide, *args, **kwargs)
+        if is_validation_enabled():
+            enumerated_sites = [name for name, site in guide_trace.nodes.items()
+                                if site["type"] == "sample" and site["infer"].get("enumerate")]
+            if enumerated_sites:
+                warnings.warn('\n'.join([
+                    'Renyi_ELBO found sample sites configured for enumeration:'
+                    ', '.join(enumerated_sites),
+                    'If you want to enumerate sites, you need to use TraceEnum_ELBO instead.']))
+
+        return model_trace, guide_trace
 
     def loss(self, model, guide, *args, **kwargs):
         """

--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -1,16 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
 import math
-import warnings
 
 import torch
 
-import pyro.poutine as poutine
 from pyro.distributions.util import is_identically_zero, log_sum_exp
 from pyro.infer.elbo import ELBO
-from pyro.infer.util import is_validation_enabled, torch_item
-from pyro.poutine.util import prune_subsample_sites
-from pyro.util import check_model_guide_match, check_site_shape, warn_if_nan
+from pyro.infer.enum import _get_importance_trace
+from pyro.infer.util import torch_item
+from pyro.util import warn_if_nan
 
 
 class RenyiELBO(ELBO):
@@ -68,31 +66,7 @@ class RenyiELBO(ELBO):
         Returns a single trace from the guide, and the model that is run
         against it.
         """
-        guide_trace = poutine.trace(guide).get_trace(*args, **kwargs)
-        model_trace = poutine.trace(poutine.replay(model, trace=guide_trace)).get_trace(*args, **kwargs)
-        if is_validation_enabled():
-            check_model_guide_match(model_trace, guide_trace)
-            enumerated_sites = [name for name, site in guide_trace.nodes.items()
-                                if site["type"] == "sample" and site["infer"].get("enumerate")]
-            if enumerated_sites:
-                warnings.warn('\n'.join([
-                    'Trace_ELBO found sample sites configured for enumeration:'
-                    ', '.join(enumerated_sites),
-                    'If you want to enumerate sites, you need to use TraceEnum_ELBO instead.']))
-        guide_trace = prune_subsample_sites(guide_trace)
-        model_trace = prune_subsample_sites(model_trace)
-
-        model_trace.compute_log_prob()
-        guide_trace.compute_score_parts()
-        if is_validation_enabled():
-            for site in model_trace.nodes.values():
-                if site["type"] == "sample":
-                    check_site_shape(site, self.max_iarange_nesting)
-            for site in guide_trace.nodes.values():
-                if site["type"] == "sample":
-                    check_site_shape(site, self.max_iarange_nesting)
-
-        return model_trace, guide_trace
+        return _get_importance_trace("flat", self.max_iarange_nesting, model, guide, *args, **kwargs)
 
     def loss(self, model, guide, *args, **kwargs):
         """

--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -6,7 +6,7 @@ import torch
 
 from pyro.distributions.util import is_identically_zero, log_sum_exp
 from pyro.infer.elbo import ELBO
-from pyro.infer.enum import _get_importance_trace
+from pyro.infer.enum import get_importance_trace
 from pyro.infer.util import is_validation_enabled, torch_item
 from pyro.util import check_if_enumerated, warn_if_nan
 
@@ -66,7 +66,7 @@ class RenyiELBO(ELBO):
         Returns a single trace from the guide, and the model that is run
         against it.
         """
-        model_trace, guide_trace = _get_importance_trace(
+        model_trace, guide_trace = get_importance_trace(
             "flat", self.max_iarange_nesting, model, guide, *args, **kwargs)
         if is_validation_enabled():
             check_if_enumerated(guide_trace)

--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import math
-import warnings
 
 import torch
 
@@ -9,7 +8,7 @@ from pyro.distributions.util import is_identically_zero, log_sum_exp
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import _get_importance_trace
 from pyro.infer.util import is_validation_enabled, torch_item
-from pyro.util import warn_if_nan
+from pyro.util import check_if_enumerated, warn_if_nan
 
 
 class RenyiELBO(ELBO):
@@ -70,14 +69,7 @@ class RenyiELBO(ELBO):
         model_trace, guide_trace = _get_importance_trace(
             "flat", self.max_iarange_nesting, model, guide, *args, **kwargs)
         if is_validation_enabled():
-            enumerated_sites = [name for name, site in guide_trace.nodes.items()
-                                if site["type"] == "sample" and site["infer"].get("enumerate")]
-            if enumerated_sites:
-                warnings.warn('\n'.join([
-                    'Renyi_ELBO found sample sites configured for enumeration:'
-                    ', '.join(enumerated_sites),
-                    'If you want to enumerate sites, you need to use TraceEnum_ELBO instead.']))
-
+            check_if_enumerated(guide_trace)
         return model_trace, guide_trace
 
     def loss(self, model, guide, *args, **kwargs):

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -6,7 +6,7 @@ import pyro
 import pyro.ops.jit
 from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
-from pyro.infer.enum import _get_importance_trace
+from pyro.infer.enum import get_importance_trace
 from pyro.infer.util import MultiFrameTensor, get_iarange_stacks, is_validation_enabled, torch_item
 from pyro.util import check_if_enumerated, warn_if_nan
 
@@ -48,7 +48,7 @@ class Trace_ELBO(ELBO):
         Returns a single trace from the guide, and the model that is run
         against it.
         """
-        model_trace, guide_trace = _get_importance_trace(
+        model_trace, guide_trace = get_importance_trace(
             "flat", self.max_iarange_nesting, model, guide, *args, **kwargs)
         if is_validation_enabled():
             check_if_enumerated(guide_trace)

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -1,16 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
-import warnings
 import weakref
 
 import pyro
 import pyro.ops.jit
-import pyro.poutine as poutine
 from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
-from pyro.infer.util import MultiFrameTensor, get_iarange_stacks, is_validation_enabled, torch_item
-from pyro.poutine.util import prune_subsample_sites
-from pyro.util import check_model_guide_match, check_site_shape, warn_if_nan
+from pyro.infer.enum import _get_importance_trace
+from pyro.infer.util import MultiFrameTensor, get_iarange_stacks, torch_item
+from pyro.util import warn_if_nan
 
 
 def _compute_log_r(model_trace, guide_trace):
@@ -50,31 +48,7 @@ class Trace_ELBO(ELBO):
         Returns a single trace from the guide, and the model that is run
         against it.
         """
-        guide_trace = poutine.trace(guide).get_trace(*args, **kwargs)
-        model_trace = poutine.trace(poutine.replay(model, trace=guide_trace)).get_trace(*args, **kwargs)
-        if is_validation_enabled():
-            check_model_guide_match(model_trace, guide_trace)
-            enumerated_sites = [name for name, site in guide_trace.nodes.items()
-                                if site["type"] == "sample" and site["infer"].get("enumerate")]
-            if enumerated_sites:
-                warnings.warn('\n'.join([
-                    'Trace_ELBO found sample sites configured for enumeration:'
-                    ', '.join(enumerated_sites),
-                    'If you want to enumerate sites, you need to use TraceEnum_ELBO instead.']))
-        guide_trace = prune_subsample_sites(guide_trace)
-        model_trace = prune_subsample_sites(model_trace)
-
-        model_trace.compute_log_prob()
-        guide_trace.compute_score_parts()
-        if is_validation_enabled():
-            for site in model_trace.nodes.values():
-                if site["type"] == "sample":
-                    check_site_shape(site, self.max_iarange_nesting)
-            for site in guide_trace.nodes.values():
-                if site["type"] == "sample":
-                    check_site_shape(site, self.max_iarange_nesting)
-
-        return model_trace, guide_trace
+        return _get_importance_trace("flat", self.max_iarange_nesting, model, guide, *args, **kwargs)
 
     def loss(self, model, guide, *args, **kwargs):
         """

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import warnings
 import weakref
 
 import pyro
@@ -9,7 +8,7 @@ from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import _get_importance_trace
 from pyro.infer.util import MultiFrameTensor, get_iarange_stacks, is_validation_enabled, torch_item
-from pyro.util import warn_if_nan
+from pyro.util import check_if_enumerated, warn_if_nan
 
 
 def _compute_log_r(model_trace, guide_trace):
@@ -52,14 +51,7 @@ class Trace_ELBO(ELBO):
         model_trace, guide_trace = _get_importance_trace(
             "flat", self.max_iarange_nesting, model, guide, *args, **kwargs)
         if is_validation_enabled():
-            enumerated_sites = [name for name, site in guide_trace.nodes.items()
-                                if site["type"] == "sample" and site["infer"].get("enumerate")]
-            if enumerated_sites:
-                warnings.warn('\n'.join([
-                    'Trace_ELBO found sample sites configured for enumeration:'
-                    ', '.join(enumerated_sites),
-                    'If you want to enumerate sites, you need to use TraceEnum_ELBO instead.']))
-
+            check_if_enumerated(guide_trace)
         return model_trace, guide_trace
 
     def loss(self, model, guide, *args, **kwargs):

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import warnings
 import weakref
 
 import pyro
@@ -7,7 +8,7 @@ import pyro.ops.jit
 from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import _get_importance_trace
-from pyro.infer.util import MultiFrameTensor, get_iarange_stacks, torch_item
+from pyro.infer.util import MultiFrameTensor, get_iarange_stacks, is_validation_enabled, torch_item
 from pyro.util import warn_if_nan
 
 
@@ -48,7 +49,18 @@ class Trace_ELBO(ELBO):
         Returns a single trace from the guide, and the model that is run
         against it.
         """
-        return _get_importance_trace("flat", self.max_iarange_nesting, model, guide, *args, **kwargs)
+        model_trace, guide_trace = _get_importance_trace(
+            "flat", self.max_iarange_nesting, model, guide, *args, **kwargs)
+        if is_validation_enabled():
+            enumerated_sites = [name for name, site in guide_trace.nodes.items()
+                                if site["type"] == "sample" and site["infer"].get("enumerate")]
+            if enumerated_sites:
+                warnings.warn('\n'.join([
+                    'Trace_ELBO found sample sites configured for enumeration:'
+                    ', '.join(enumerated_sites),
+                    'If you want to enumerate sites, you need to use TraceEnum_ELBO instead.']))
+
+        return model_trace, guide_trace
 
     def loss(self, model, guide, *args, **kwargs):
         """

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -12,7 +12,7 @@ import pyro.ops.jit
 import pyro.poutine as poutine
 from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
-from pyro.infer.enum import _get_importance_trace, _iter_discrete_escape, _iter_discrete_extend
+from pyro.infer.enum import get_importance_trace, iter_discrete_escape, iter_discrete_extend
 from pyro.infer.util import Dice, is_validation_enabled
 from pyro.util import check_traceenum_requirements, warn_if_nan
 
@@ -74,7 +74,7 @@ class TraceEnum_ELBO(ELBO):
         Returns a single trace from the guide, and the model that is run
         against it.
         """
-        model_trace, guide_trace = _get_importance_trace(
+        model_trace, guide_trace = get_importance_trace(
             "flat", self.max_iarange_nesting, model, guide, *args, **kwargs)
 
         if is_validation_enabled():
@@ -105,8 +105,8 @@ class TraceEnum_ELBO(ELBO):
         guide = poutine.enum(guide, first_available_dim=self.max_iarange_nesting)
         q = queue.LifoQueue()
         guide = poutine.queue(guide, q,
-                              escape_fn=_iter_discrete_escape,
-                              extend_fn=_iter_discrete_extend)
+                              escape_fn=iter_discrete_escape,
+                              extend_fn=iter_discrete_extend)
         for i in range(1 if self.vectorize_particles else self.num_particles):
             q.put(poutine.Trace())
             while not q.empty():

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -9,13 +9,12 @@ import torch
 
 import pyro
 import pyro.ops.jit
-import pyro.poutine as poutine
 from pyro.distributions.util import is_identically_zero
 from pyro.infer import ELBO
-from pyro.infer.util import (MultiFrameTensor, detach_iterable, get_iarange_stacks, is_validation_enabled,
+from pyro.infer.enum import _get_importance_trace
+from pyro.infer.util import (MultiFrameTensor, detach_iterable, get_iarange_stacks,
                              torch_backward, torch_item)
-from pyro.poutine.util import prune_subsample_sites
-from pyro.util import check_model_guide_match, check_site_shape, warn_if_nan
+from pyro.util import warn_if_nan
 
 
 def _get_baseline_options(site):
@@ -192,25 +191,16 @@ class TraceGraph_ELBO(ELBO):
         Returns a single trace from the guide, and the model that is run
         against it.
         """
-        guide_trace = poutine.trace(guide,
-                                    graph_type="dense").get_trace(*args, **kwargs)
-        model_trace = poutine.trace(poutine.replay(model, trace=guide_trace),
-                                    graph_type="dense").get_trace(*args, **kwargs)
-        if is_validation_enabled():
-            check_model_guide_match(model_trace, guide_trace)
-            enumerated_sites = [name for name, site in guide_trace.nodes.items()
-                                if site["type"] == "sample" and site["infer"].get("enumerate")]
-            if enumerated_sites:
-                warnings.warn('\n'.join([
-                    'TraceGraph_ELBO found sample sites configured for enumeration:'
-                    ', '.join(enumerated_sites),
-                    'If you want to enumerate sites, you need to use TraceEnum_ELBO instead.']))
-
-        guide_trace = prune_subsample_sites(guide_trace)
-        model_trace = prune_subsample_sites(model_trace)
-
-        weight = 1.0 / self.num_particles
-        return weight, model_trace, guide_trace
+        model_trace, guide_trace = _get_importance_trace(
+            "dense", self.max_iarange_nesting, model, guide, *args, **kwargs)
+        enumerated_sites = [name for name, site in guide_trace.nodes.items()
+                            if site["type"] == "sample" and site["infer"].get("enumerate")]
+        if enumerated_sites:
+            warnings.warn('\n'.join([
+                'TraceGraph_ELBO found sample sites configured for enumeration:'
+                ', '.join(enumerated_sites),
+                'If you want to enumerate sites, you need to use TraceEnum_ELBO instead.']))
+        return model_trace, guide_trace
 
     def loss(self, model, guide, *args, **kwargs):
         """
@@ -220,9 +210,9 @@ class TraceGraph_ELBO(ELBO):
         Evaluates the ELBO with an estimator that uses num_particles many samples/particles.
         """
         elbo = 0.0
-        for weight, model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
             elbo_particle = torch_item(model_trace.log_prob_sum()) - torch_item(guide_trace.log_prob_sum())
-            elbo += weight * elbo_particle
+            elbo += elbo_particle / float(self.num_particles)
 
         loss = -elbo
         warn_if_nan(loss, "loss")
@@ -238,23 +228,12 @@ class TraceGraph_ELBO(ELBO):
         If baselines are present, a baseline loss is also constructed and differentiated.
         """
         loss = 0.0
-        for weight, model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+        weight = 1./self.num_particles
+        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
             loss += self._loss_and_grads_particle(weight, model_trace, guide_trace)
         return loss
 
     def _loss_and_grads_particle(self, weight, model_trace, guide_trace):
-        # have the trace compute all the individual (batch) log pdf terms
-        # and score function terms (if present) so that they are available below
-        model_trace.compute_log_prob()
-        guide_trace.compute_score_parts()
-        if is_validation_enabled():
-            for site in model_trace.nodes.values():
-                if site["type"] == "sample":
-                    check_site_shape(site, self.max_iarange_nesting)
-            for site in guide_trace.nodes.values():
-                if site["type"] == "sample":
-                    check_site_shape(site, self.max_iarange_nesting)
-
         # compute elbo for reparameterized nodes
         non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
         elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace, non_reparam_nodes)
@@ -309,16 +288,6 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
                 loss = 0.0
                 surrogate_loss = 0.0
                 for weight, model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
-                    model_trace.compute_log_prob()
-                    guide_trace.compute_score_parts()
-                    if is_validation_enabled():
-                        for site in model_trace.nodes.values():
-                            if site["type"] == "sample":
-                                check_site_shape(site, self.max_iarange_nesting)
-                        for site in guide_trace.nodes.values():
-                            if site["type"] == "sample":
-                                check_site_shape(site, self.max_iarange_nesting)
-
                     # compute elbo for reparameterized nodes
                     non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
                     elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace, non_reparam_nodes)

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -281,7 +281,8 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
                 self = weakself()
                 loss = 0.0
                 surrogate_loss = 0.0
-                for weight, model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+                weight = 1.0 / self.num_particles
+                for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
                     # compute elbo for reparameterized nodes
                     non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
                     elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace, non_reparam_nodes)

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -10,7 +10,7 @@ import pyro
 import pyro.ops.jit
 from pyro.distributions.util import is_identically_zero
 from pyro.infer import ELBO
-from pyro.infer.enum import _get_importance_trace
+from pyro.infer.enum import get_importance_trace
 from pyro.infer.util import (MultiFrameTensor, detach_iterable, get_iarange_stacks,
                              is_validation_enabled, torch_backward, torch_item)
 from pyro.util import check_if_enumerated, warn_if_nan
@@ -190,7 +190,7 @@ class TraceGraph_ELBO(ELBO):
         Returns a single trace from the guide, and the model that is run
         against it.
         """
-        model_trace, guide_trace = _get_importance_trace(
+        model_trace, guide_trace = get_importance_trace(
             "dense", self.max_iarange_nesting, model, guide, *args, **kwargs)
         if is_validation_enabled():
             check_if_enumerated(guide_trace)

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -309,6 +309,16 @@ def check_traceenum_requirements(model_trace, guide_trace):
                 enumerated_contexts[context].add(name)
 
 
+def check_if_enumerated(guide_trace):
+    enumerated_sites = [name for name, site in guide_trace.nodes.items()
+                        if site["type"] == "sample" and site["infer"].get("enumerate")]
+    if enumerated_sites:
+        warnings.warn('\n'.join([
+            'Found sample sites configured for enumeration:'
+            ', '.join(enumerated_sites),
+            'If you want to enumerate sites, you need to use TraceEnum_ELBO instead.']))
+
+
 @contextmanager
 def optional(context_manager, condition):
     """


### PR DESCRIPTION
Part of #1234 

The ELBO implementations have some duplicated functionality in their `_get_trace`/`_get_traces` methods.  This PR collects some of that functionality (mostly `_get_trace`) into one place and reuses it across the different ELBOs.

`TraceEnum_ELBO` is still a bit awkward because I wanted to limit the scope of the changes in this PR and avoid changing tests and validation logic.  I'd like to continue reorganizing the SVI code in followup PR(s), starting with removing `pyro.infer.enum.iter_discrete_traces` which is now deprecated.