### PR TITLE
Fix bug in dist.Delta.expand() type

### DIFF
--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -44,6 +44,7 @@ class Delta(TorchDistribution):
 
     def expand(self, batch_shape):
         validate_args = self.__dict__.get('_validate_args')
+        batch_shape = torch.Size(batch_shape)
         v = self.v.expand(batch_shape + self.event_shape)
         log_density = self.log_density.expand(batch_shape)
         return Delta(v, log_density, self.event_dim, validate_args=validate_args)

--- a/tests/distributions/test_delta.py
+++ b/tests/distributions/test_delta.py
@@ -61,3 +61,10 @@ def test_shapes(batch_dim, event_dim, has_log_density):
     x = d.rsample()
     assert (x == v).all()
     assert (d.log_prob(x) == log_density).all()
+
+
+@pytest.mark.parametrize('batch_shape', [(), [], (2,), [2], torch.Size([2]), [2, 3]])
+def test_expand(batch_shape):
+    d1 = dist.Delta(torch.tensor(1.234))
+    d2 = d1.expand(batch_shape)
+    assert d2.batch_shape == torch.Size(batch_shape)


### PR DESCRIPTION
The bug was that `dist.Delta.expand()` required a `torch.Size`, but we sometimes call `.expand()` with lists internally. The fix is to cast `batch_shape` to a `torch.Size`, as is done in other distributions.

## Tested

- added a regression test
- tested on a tutorial that is under development