### PR TITLE
Refactor to use generic newton solver in pyro.optim.multi

### DIFF
--- a/tests/optim/test_multi.py
+++ b/tests/optim/test_multi.py
@@ -8,15 +8,15 @@ import pyro
 import pyro.distributions as dist
 import pyro.optim
 import pyro.poutine as poutine
-from pyro.optim.multi import MixedMultiOptimizer, Newton2d, PyroMultiOptimizer, TorchMultiOptimizer
+from pyro.optim.multi import MixedMultiOptimizer, Newton, PyroMultiOptimizer, TorchMultiOptimizer
 from tests.common import assert_equal
 
 FACTORIES = [
     lambda: PyroMultiOptimizer(pyro.optim.Adam({'lr': 0.05})),
     lambda: TorchMultiOptimizer(torch.optim.Adam, {'lr': 0.05}),
-    lambda: Newton2d(trust_radii={'z': 0.2}),
+    lambda: Newton(trust_radii={'z': 0.2}),
     lambda: MixedMultiOptimizer([(['y'], PyroMultiOptimizer(pyro.optim.Adam({'lr': 0.05}))),
-                                 (['x', 'z'], Newton2d())]),
+                                 (['x', 'z'], Newton())]),
 ]
 
 
@@ -39,7 +39,9 @@ def test_optimizers(factory):
     for step in range(200):
         tr = poutine.trace(model).get_trace(loc, cov)
         loss = -tr.log_prob_sum()
-        params = {name: pyro.param(name).unconstrained() for name in ["x", "y", "z"]}
+        params = {name: site['value'].unconstrained()
+                  for name, site in tr.nodes.items()
+                  if site['type'] == 'param'}
         optim.step(loss, params)
 
     for name in ["x", "y", "z"]:


### PR DESCRIPTION
This is the first step in refactoring our multi-optimizers
1. Switches from `Newton2d` to a more general `Newton` optimizer, following #1210 .
2. Changes the example and test to use `trace.nodes` rather than `pyro.get_param_store()`. The class interface remains unchanged.

We may follow this PR up with a second PR to switch dicts from name-to-tensor to name-to-site, but I'm not totally sure this is necessary.