### PR TITLE
Implement TraceEnum_ELBO.differentiable_loss() method

### DIFF
--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -131,6 +131,33 @@ class TraceEnum_ELBO(ELBO):
         warn_if_nan(loss, "loss")
         return loss
 
+    def differentiable_loss(self, model, guide, *args, **kwargs):
+        """
+        :returns: returns an estimate of the ELBO
+        :rtype: torch.Tensor
+        :raises ValueError: if the ELBO is not differentiable (e.g. is
+            identically zero)
+
+        Estimates a differentiable ELBO using ``num_particles`` many samples
+        (particles).  The result should be infinitely differentiable (as long
+        as underlying derivatives have been implemented).
+        """
+        elbo = 0.0
+        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+            elbo_particle = _compute_dice_elbo(model_trace, guide_trace)
+            if is_identically_zero(elbo_particle):
+                continue
+
+            elbo = elbo + elbo_particle
+        elbo = elbo / self.num_particles
+
+        if not torch.is_tensor(elbo) or not elbo.requires_grad:
+            raise ValueError('ELBO is cannot be differentiated: {}'.format(elbo))
+
+        loss = -elbo
+        warn_if_nan(loss, "loss")
+        return loss
+
     def loss_and_grads(self, model, guide, *args, **kwargs):
         """
         :returns: returns an estimate of the ELBO

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -114,7 +114,7 @@ class TraceEnum_ELBO(ELBO):
 
     def loss(self, model, guide, *args, **kwargs):
         """
-        :returns: returns an estimate of the ELBO
+        :returns: an estimate of the ELBO
         :rtype: float
 
         Estimates the ELBO using ``num_particles`` many samples (particles).
@@ -133,7 +133,7 @@ class TraceEnum_ELBO(ELBO):
 
     def differentiable_loss(self, model, guide, *args, **kwargs):
         """
-        :returns: returns an estimate of the ELBO
+        :returns: a differentiable estimate of the ELBO
         :rtype: torch.Tensor
         :raises ValueError: if the ELBO is not differentiable (e.g. is
             identically zero)
@@ -160,7 +160,7 @@ class TraceEnum_ELBO(ELBO):
 
     def loss_and_grads(self, model, guide, *args, **kwargs):
         """
-        :returns: returns an estimate of the ELBO
+        :returns: an estimate of the ELBO
         :rtype: float
 
         Estimates the ELBO using ``num_particles`` many samples (particles).


### PR DESCRIPTION
Addresses #1234 

This exposes the DiCE operator as a `.differentiable_loss()` method for use by e.g. the `Newton` optimizer.

Note that this keeps around the old `.loss()` method for three reasons:
- minor performance: `.loss()` frees the compute graph after each particle, whereas `.differentiable_loss().item()` requires `num_particles`-times more memory.
- minor accuracy: `.loss()` accumulates loss terms as python floats (64 bit) rather than typical PyTorch floats (32-bit)
- backwards compatbility: we currently assume `.loss()` returns a float.

## Tested
- added `.differentiable_loss` assertions or variants to a few existing tests
- tested agreement between `differentiable_loss` and `loss_and_grads`