### PR TITLE
Add coercion and overlap checking to MixedMultiOptimizer constructor

### DIFF
--- a/tests/contrib/tracking/test_em.py
+++ b/tests/contrib/tracking/test_em.py
@@ -12,7 +12,7 @@ import pyro.poutine as poutine
 from pyro.contrib.tracking.assignment import MarginalAssignment
 from pyro.infer import SVI, TraceEnum_ELBO
 from pyro.optim import Adam
-from pyro.optim.multi import MixedMultiOptimizer, Newton, PyroMultiOptimizer
+from pyro.optim.multi import MixedMultiOptimizer, Newton
 
 
 def make_args():
@@ -188,7 +188,7 @@ def test_svi_multi():
 
     # Learn object_loc via Newton and noise_scale via Adam.
     elbo = TraceEnum_ELBO(max_iarange_nesting=2)
-    adam = PyroMultiOptimizer(Adam({'lr': 0.1}))
+    adam = Adam({'lr': 0.1})
     newton = Newton(trust_radii={'objects_loc': 1.0})
     optim = MixedMultiOptimizer([(['noise_scale'], adam),
                                  (['objects_loc'], newton)])

--- a/tests/optim/test_multi.py
+++ b/tests/optim/test_multi.py
@@ -17,6 +17,8 @@ FACTORIES = [
     lambda: Newton(trust_radii={'z': 0.2}),
     lambda: MixedMultiOptimizer([(['y'], PyroMultiOptimizer(pyro.optim.Adam({'lr': 0.05}))),
                                  (['x', 'z'], Newton())]),
+    lambda: MixedMultiOptimizer([(['y'], pyro.optim.Adam({'lr': 0.05})),
+                                 (['x', 'z'], Newton())]),
 ]
 
 
@@ -49,3 +51,16 @@ def test_optimizers(factory):
         expected = loc.expand(actual.shape)
         assert_equal(actual, expected, prec=1e-2,
                      msg='{} in correct: {} vs {}'.format(name, actual, expected))
+
+
+def test_multi_optimizer_disjoint_ok():
+    parts = [(['w', 'x'], pyro.optim.Adam({'lr': 0.1})),
+             (['y', 'z'], pyro.optim.Adam({'lr': 0.01}))]
+    MixedMultiOptimizer(parts)
+
+
+def test_multi_optimizer_overlap_error():
+    parts = [(['x', 'y'], pyro.optim.Adam({'lr': 0.1})),
+             (['y', 'z'], pyro.optim.Adam({'lr': 0.01}))]
+    with pytest.raises(ValueError):
+        MixedMultiOptimizer(parts)


### PR DESCRIPTION
This adds:
- a check in `MixedMultiOptimizer.__init__()` to ensure that each parameter is optimized by at most one optimizer
- automatic coercion so e.g. users can pass in `Adam(...)` rather than `PyroMultiOptimizer(Adam(...))`.

## Tested:

- added ok+error tests for the new check
- added a coercion example
- simplified test_em.py to use coercion.