### PR TITLE
Marginalize out discrete latent sites in HMC via enumeration

### DIFF
--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -201,7 +201,7 @@ except ImportError:
         :param keepdim: Whether to retain the dimension
             that is summed out.
         """
-        max_val = tensor.max(dim)[0].unsqueeze(dim)
+        max_val = tensor.max(dim, keepdim=keepdim)[0]
         return max_val + (tensor - max_val).exp().sum(dim=dim, keepdim=keepdim).log()
 
 

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -201,8 +201,9 @@ except ImportError:
         :param keepdim: Whether to retain the dimension
             that is summed out.
         """
-        max_val = tensor.max(dim, keepdim=keepdim)[0]
-        return max_val + (tensor - max_val).exp().sum(dim=dim, keepdim=keepdim).log()
+        max_val = tensor.max(dim, keepdim=True)[0]
+        log_sum_exp = max_val + (tensor - max_val).exp().sum(dim=dim, keepdim=True).log()
+        return log_sum_exp if keepdim else log_sum_exp.squeeze(dim)
 
 
 log_sum_exp = logsumexp  # DEPRECATED

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -191,16 +191,18 @@ def torch_sign(value):
 try:
     from torch import logsumexp  # for pytorch 0.4.1 and later
 except ImportError:
-    def logsumexp(tensor, dim=-1):
+    def logsumexp(tensor, dim=-1, keepdim=False):
         """
         Numerically stable implementation for the `LogSumExp` operation. The
         summing is done along the dimension specified by ``dim``.
 
         :param torch.Tensor tensor: Input tensor.
         :param dim: Dimension to be summed out.
+        :param keepdim: Whether to retain the dimension
+            that is summed out.
         """
         max_val = tensor.max(dim)[0]
-        return max_val + (tensor - max_val.unsqueeze(dim)).exp().sum(dim=dim).log()
+        return max_val + (tensor - max_val.unsqueeze(dim)).exp().sum(dim=dim, keepdim=keepdim).log()
 
 
 log_sum_exp = logsumexp  # DEPRECATED

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -201,8 +201,8 @@ except ImportError:
         :param keepdim: Whether to retain the dimension
             that is summed out.
         """
-        max_val = tensor.max(dim)[0]
-        return max_val + (tensor - max_val.unsqueeze(dim)).exp().sum(dim=dim, keepdim=keepdim).log()
+        max_val = tensor.max(dim)[0].unsqueeze(dim)
+        return max_val + (tensor - max_val).exp().sum(dim=dim, keepdim=keepdim).log()
 
 
 log_sum_exp = logsumexp  # DEPRECATED

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -9,13 +9,13 @@ from torch.distributions import biject_to, constraints
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-from pyro.infer import config_enumerate, is_validation_enabled
+from pyro.infer import config_enumerate
 from pyro.infer.mcmc.trace_kernel import TraceKernel
 from pyro.infer.mcmc.util import EnumTraceProbEvaluator
 from pyro.ops.dual_averaging import DualAveraging
 from pyro.ops.integrator import single_step_velocity_verlet, velocity_verlet
 from pyro.primitives import _Subsample
-from pyro.util import torch_isinf, torch_isnan, optional, check_site_shape
+from pyro.util import torch_isinf, torch_isnan, optional
 
 
 class HMC(TraceKernel):

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -24,7 +24,6 @@ class EnumTraceProbEvaluator(object):
                  max_iarange_nesting=float("inf")):
         self.has_enumerable_sites = has_enumerable_sites
         self.max_iarange_nesting = max_iarange_nesting
-        default_cond_stack = (CondIndepStackFrame(name="default", dim=0, size=0, counter=None),)
         # To be populated using the model trace once.
         self._log_probs = {}
         self._children = defaultdict(list)
@@ -128,4 +127,4 @@ class EnumTraceProbEvaluator(object):
         if not self.has_enumerable_sites:
             return model_trace.log_prob_sum()
         self._compute_log_prob_terms(model_trace)
-        return self._aggregate_log_probs(frozenset()).sum()
+        return self._aggregate_log_probs(ordinal=frozenset()).sum()

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -39,8 +39,7 @@ class EnumTraceProbEvaluator(object):
         self._compute_log_prob_terms(model_trace)
         # 1. Infer model structure - compute parent-child relationship.
         sorted_ordinals = sorted(self._log_probs.keys())
-        for i in range(len(sorted_ordinals)):
-            child_node = sorted_ordinals[i]
+        for i, child_node in enumerate(sorted_ordinals):
             for j in range(i-1, -1, -1):
                 cur_node = sorted_ordinals[j]
                 if cur_node < child_node:
@@ -60,7 +59,7 @@ class EnumTraceProbEvaluator(object):
         enum_dims = set((i for i in range(-log_prob.dim(), -self.max_iarange_nesting)
                          if log_prob.shape[i] > 1))
         self._iarange_dims[ordinal] = iarange_dims
-        self._enum_dims[ordinal] = sorted(list(enum_dims - parent_enum_dims))
+        self._enum_dims[ordinal] = sorted(enum_dims - parent_enum_dims)
         for c in self._children[ordinal]:
             self._populate_cache(c, ordinal, enum_dims)
 

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -1,4 +1,3 @@
-import torch
 from collections import defaultdict
 
 from pyro.distributions.util import logsumexp
@@ -123,4 +122,5 @@ class EnumTraceProbEvaluator(object):
         if not self.has_enumerable_sites:
             return model_trace.log_prob_sum()
         self._compute_log_prob_terms(model_trace)
+        print(self._aggregate_log_probs(ordinal=frozenset()).shape)
         return self._aggregate_log_probs(ordinal=frozenset()).sum()

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -49,13 +49,14 @@ class EnumTraceProbEvaluator(object):
                 if cur_node < child_node:
                     self._children[cur_node].append(child_node)
                     break  # at most 1 parent.
-        # 2. Populate `marginal_dims` and `enum_dims` for each ordinal.
+        # 2. Populate `iarange_dims` and `enum_dims` to be evaluated/
+        #    enumerated out at each ordinal.
         self._populate_dims(self.root, frozenset(), set())
 
     def _populate_dims(self, ordinal, parent_ordinal, parent_enum_dims):
         """
         For each ordinal, populate the `iarange` and `enum` dims to be
-        marginalized out.
+        evaluated or enumerated out.
         """
         log_prob = self._log_probs[ordinal]
         iarange_dims = sorted([frame.dim for frame in ordinal - parent_ordinal])

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -12,7 +12,7 @@ class EnumTraceProbEvaluator(object):
     Computes the log probability density of a trace that possibly contains
     discrete sample sites enumerated in parallel.
 
-    :param model_trace: execution trace from the model.
+    :param model_trace: execution trace from a static model.
     :param bool has_enumerable_sites: whether the trace contains any
         discrete enumerable sites.
     :param int max_iarange_nesting: Optional bound on max number of nested
@@ -51,9 +51,9 @@ class EnumTraceProbEvaluator(object):
                     break  # at most 1 parent.
         # 2. Populate `iarange_dims` and `enum_dims` to be evaluated/
         #    enumerated out at each ordinal.
-        self._populate_dims(self.root, frozenset(), set())
+        self._populate_cache(self.root, frozenset(), set())
 
-    def _populate_dims(self, ordinal, parent_ordinal, parent_enum_dims):
+    def _populate_cache(self, ordinal, parent_ordinal, parent_enum_dims):
         """
         For each ordinal, populate the `iarange` and `enum` dims to be
         evaluated or enumerated out.
@@ -65,7 +65,7 @@ class EnumTraceProbEvaluator(object):
         self._iarange_dims[ordinal] = iarange_dims
         self._enum_dims[ordinal] = sorted(list(enum_dims - parent_enum_dims))
         for c in self._children[ordinal]:
-            self._populate_dims(c, ordinal, enum_dims)
+            self._populate_cache(c, ordinal, enum_dims)
 
     def _compute_log_prob_terms(self, model_trace):
         """

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -1,0 +1,105 @@
+from collections import defaultdict
+
+from pyro.distributions.util import log_sum_exp
+from pyro.infer.util import is_validation_enabled
+from pyro.util import check_site_shape
+
+
+class EnumTraceProbEvaluator(object):
+    def __init__(self,
+                 model_trace,
+                 has_enumerable_sites=False,
+                 max_iarange_nesting=float("inf")):
+        """
+        Computes the log probability density of a trace that possibly contains
+        discrete sample sites enumerated in parallel.
+
+        :param model_trace: execution trace from the model.
+        :param bool has_enumerable_sites: whether the trace contains any
+            discrete enumerable sites.
+        :param int max_iarange_nesting: Optional bound on max number of nested
+            :func:`pyro.iarange` contexts.
+        """
+        self.model_trace = model_trace
+        self.has_enumerable_sites = has_enumerable_sites
+        self.max_iarange_nesting = max_iarange_nesting
+        self.log_probs = defaultdict(list)
+        self._log_factors_cache = {}
+        self._predecessors_cache = {}
+
+    def _get_predecessors_log_factors(self, target_ordinal):
+        """
+        Returns the list of predecessors for `target_ordinal `and
+        their log_prob factors.
+        """
+        if target_ordinal in self._predecessors_cache:
+            return self._predecessors_cache[target_ordinal],\
+                   self._log_factors_cache[target_ordinal]
+        log_factors = []
+        predecessors = set()
+
+        for ordinal, term in self.log_probs.items():
+            if ordinal < target_ordinal:
+                log_factors += term
+                predecessors.add(ordinal)
+
+        self._log_factors_cache[target_ordinal] = log_factors
+        self._predecessors_cache[target_ordinal] = predecessors
+        return predecessors, log_factors
+
+    def _compute_log_prob_terms(self):
+        """
+        Computes the conditional probabilities for each of the sites
+        in the model trace, and stores the result in `self.log_probs`.
+        """
+        if len(self.log_probs) > 0:
+            return
+        self.model_trace.compute_log_prob()
+        ordering = {name: frozenset(site["cond_indep_stack"])
+                    for name, site in self.model_trace.nodes.items()
+                    if site["type"] == "sample"}
+
+        # Collect log prob terms per independence context.
+        for name, site in self.model_trace.nodes.items():
+            if site["type"] == "sample":
+                if is_validation_enabled():
+                    check_site_shape(site, self.max_iarange_nesting)
+                self.log_probs[ordering[name]].append(site["log_prob"])
+
+    def log_prob(self):
+        """
+        Returns the log pdf of `model_trace` by appropriate handling
+        of the enumerated log prob factors.
+
+        :return: log pdf of the trace.
+        """
+        if not self.has_enumerable_sites:
+            return self.model_trace.log_prob_sum()
+        if self.max_iarange_nesting == float("inf"):
+            raise ValueError("Finite value required for `max_iarange_nesting` when model "
+                             "has discrete (enumerable) sites.")
+        self._compute_log_prob_terms()
+
+        # Sum up terms from predecessor, and gather leaf nodes.
+        leaves_log_probs = {}
+        for target_ordinal, log_prob in self.log_probs.items():
+            leaves_log_probs[target_ordinal] = log_prob
+            predecessors, log_factors = self._get_predecessors_log_factors(target_ordinal)
+            leaves_log_probs[target_ordinal] = sum(leaves_log_probs[target_ordinal] + log_factors)
+            for ordinal in predecessors:
+                if ordinal in leaves_log_probs:
+                    del leaves_log_probs[ordinal]
+
+        # Reduce the log prob terms for each leaf node:
+        # - taking log_sum_exp of factors in enum dims (i.e.
+        # adding up the probability terms).
+        # - summing up the dims within `max_iarange_nesting`.
+        # (i.e. multiplying probs within independent batches).
+        log_prob_sum = 0.
+        for ordinal in leaves_log_probs:
+            log_prob = leaves_log_probs[ordinal]
+            enum_dim = log_prob.dim() - self.max_iarange_nesting
+            if enum_dim > 0:
+                log_prob = log_sum_exp(log_prob.reshape(-1, *log_prob.shape[enum_dim:]), dim=0)
+            log_prob_sum += log_prob.sum()
+        return log_prob_sum

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -35,7 +35,7 @@ class EnumTraceProbEvaluator(object):
 
     def _parse_model_structure(self, model_trace):
         if not self.has_enumerable_sites:
-            return model_trace.log_prob_sum()
+            return
         if self.max_iarange_nesting == float("inf"):
             raise ValueError("Finite value required for `max_iarange_nesting` when model "
                              "has discrete (enumerable) sites.")
@@ -73,7 +73,6 @@ class EnumTraceProbEvaluator(object):
         in the model trace, and stores the result in `self._log_probs`.
         """
         model_trace.compute_log_prob()
-
         ordering = {}
         for name, site in model_trace.nodes.items():
             if site["type"] == "sample":
@@ -132,5 +131,7 @@ class EnumTraceProbEvaluator(object):
 
         :return: log pdf of the trace.
         """
+        if not self.has_enumerable_sites:
+            return model_trace.log_prob_sum()
         self._compute_log_prob_terms(model_trace)
         return self._aggregate_log_probs(self.root).sum()

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -122,5 +122,4 @@ class EnumTraceProbEvaluator(object):
         if not self.has_enumerable_sites:
             return model_trace.log_prob_sum()
         self._compute_log_prob_terms(model_trace)
-        print(self._aggregate_log_probs(ordinal=frozenset()).shape)
         return self._aggregate_log_probs(ordinal=frozenset()).sum()

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -82,8 +82,8 @@ class EnumTraceProbEvaluator(object):
 
         # Sum up terms from predecessor, and gather leaf nodes.
         leaves_log_probs = {}
-        for target_ordinal, log_prob in self.log_probs.items():
-            leaves_log_probs[target_ordinal] = log_prob
+        for target_ordinal in sorted(self.log_probs.keys()):
+            leaves_log_probs[target_ordinal] = self.log_probs[target_ordinal]
             predecessors, log_factors = self._get_predecessors_log_factors(target_ordinal)
             leaves_log_probs[target_ordinal] = sum(leaves_log_probs[target_ordinal] + log_factors)
             for ordinal in predecessors:

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -12,6 +12,7 @@ import pyro.distributions as dist
 from pyro.infer import EmpiricalMarginal
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.mcmc import MCMC
+import pyro.poutine as poutine
 from tests.common import assert_equal
 
 logger = logging.getLogger(__name__)
@@ -241,12 +242,13 @@ def test_beta_bernoulli_with_dual_averaging():
         alpha = torch.tensor([1.1, 1.1])
         beta = torch.tensor([1.1, 1.1])
         p_latent = pyro.sample('p_latent', dist.Beta(alpha, beta))
-        pyro.sample('obs', dist.Bernoulli(p_latent), obs=data)
+        with pyro.iarange("data", data.shape[0], dim=-2):
+            pyro.sample('obs', dist.Bernoulli(p_latent), obs=data)
         return p_latent
 
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
-    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True)
+    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True, max_iarange_nesting=2)
     mcmc_run = MCMC(hmc_kernel, num_samples=800, warmup_steps=500).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='p_latent')
     assert_equal(posterior.mean, true_probs, prec=0.05)
@@ -266,3 +268,47 @@ def test_gamma_normal_with_dual_averaging():
     mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='p_latent')
     assert_equal(posterior.mean, true_std, prec=0.05)
+
+
+def test_gaussian_mixture_model():
+    K, N = 3, 1000
+
+    @poutine.broadcast
+    def gmm(data):
+        with pyro.iarange("num_clusters", K):
+            mix_proportions = pyro.sample("phi", dist.Dirichlet(torch.tensor(1.)))
+            cluster_means = pyro.sample("cluster_means", dist.Normal(torch.arange(K), 1.))
+        with pyro.iarange("data", data.shape[0]):
+            assignments = pyro.sample("assignments", dist.Categorical(mix_proportions))
+            pyro.sample("obs", dist.Normal(cluster_means[assignments], 1.), obs=data)
+        return cluster_means
+
+    true_cluster_means = torch.tensor([1., 5., 10.])
+    true_mix_proportions = torch.tensor([0.1, 0.3, 0.6])
+    cluster_assignments = dist.Categorical(true_mix_proportions).sample(torch.Size((N,)))
+    data = dist.Normal(true_cluster_means[cluster_assignments], 1.0).sample()
+    hmc_kernel = HMC(gmm, trajectory_length=1, adapt_step_size=True, max_iarange_nesting=1)
+    mcmc_run = MCMC(hmc_kernel, num_samples=600, warmup_steps=200).run(data)
+    posterior = EmpiricalMarginal(mcmc_run, sites=["phi", "cluster_means"]).mean.sort()[0]
+    assert_equal(posterior[0], true_mix_proportions, prec=0.05)
+    assert_equal(posterior[1], true_cluster_means, prec=0.2)
+
+
+def test_bernoulli_latent_model():
+    @poutine.broadcast
+    def model(data):
+        y_prob = pyro.sample("y_prob", dist.Beta(1.1, 1.1))
+        with pyro.iarange("data", data.shape[0]):
+            y = pyro.sample("y", dist.Bernoulli(y_prob))
+            z = pyro.sample("z", dist.Bernoulli(0.65 * y + 0.1))
+            pyro.sample("obs", dist.Normal(2. * z, 1.), obs=data)
+
+    N = 2000
+    y_prob = torch.tensor(0.3)
+    y = dist.Bernoulli(y_prob).sample(torch.Size((N,)))
+    z = dist.Bernoulli(0.65 * y + 0.1).sample()
+    data = dist.Normal(2. * z, 1.0).sample()
+    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True, max_iarange_nesting=1)
+    mcmc_run = MCMC(hmc_kernel, num_samples=600, warmup_steps=200).run(data)
+    posterior = EmpiricalMarginal(mcmc_run, sites="y_prob").mean
+    assert_equal(posterior, y_prob, prec=0.05)

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -298,8 +298,8 @@ def test_bernoulli_latent_model():
     @poutine.broadcast
     def model(data):
         y_prob = pyro.sample("y_prob", dist.Beta(1.1, 1.1))
+        y = pyro.sample("y", dist.Bernoulli(y_prob))
         with pyro.iarange("data", data.shape[0]):
-            y = pyro.sample("y", dist.Bernoulli(y_prob))
             z = pyro.sample("z", dist.Bernoulli(0.65 * y + 0.1))
             pyro.sample("obs", dist.Normal(2. * z, 1.), obs=data)
 

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -297,11 +297,12 @@ def test_gaussian_mixture_model():
 def test_bernoulli_latent_model():
     @poutine.broadcast
     def model(data):
-        y_prob = pyro.sample("y_prob", dist.Beta(1.1, 1.1))
+        y_prob = pyro.sample("y_prob", dist.Beta(1.0, 1.0))
         y = pyro.sample("y", dist.Bernoulli(y_prob))
         with pyro.iarange("data", data.shape[0]):
             z = pyro.sample("z", dist.Bernoulli(0.65 * y + 0.1))
             pyro.sample("obs", dist.Normal(2. * z, 1.), obs=data)
+        pyro.sample("nuisance", dist.Bernoulli(0.3))
 
     N = 2000
     y_prob = torch.tensor(0.3)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -11,6 +11,7 @@ import pyro.distributions as dist
 from pyro.infer import EmpiricalMarginal
 from pyro.infer.mcmc.mcmc import MCMC
 from pyro.infer.mcmc.nuts import NUTS
+import pyro.poutine as poutine
 from tests.common import assert_equal
 
 from .test_hmc import TEST_CASES, TEST_IDS, T, rmse
@@ -179,3 +180,47 @@ def test_gamma_beta():
     mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=200).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites=['alpha', 'beta'])
     assert_equal(posterior.mean, torch.stack([true_alpha, true_beta]), prec=0.05)
+
+
+def test_gaussian_mixture_model():
+    K, N = 3, 1000
+
+    @poutine.broadcast
+    def gmm(data):
+        with pyro.iarange("num_clusters", K):
+            mix_proportions = pyro.sample("phi", dist.Dirichlet(torch.tensor(1.)))
+            cluster_means = pyro.sample("cluster_means", dist.Normal(torch.arange(K), 1.))
+        with pyro.iarange("data", data.shape[0]):
+            assignments = pyro.sample("assignments", dist.Categorical(mix_proportions))
+            pyro.sample("obs", dist.Normal(cluster_means[assignments], 1.), obs=data)
+        return cluster_means
+
+    true_cluster_means = torch.tensor([1., 5., 10.])
+    true_mix_proportions = torch.tensor([0.1, 0.3, 0.6])
+    cluster_assignments = dist.Categorical(true_mix_proportions).sample(torch.Size((N,)))
+    data = dist.Normal(true_cluster_means[cluster_assignments], 1.0).sample()
+    nuts_kernel = NUTS(gmm, adapt_step_size=True, max_iarange_nesting=1)
+    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=200).run(data)
+    posterior = EmpiricalMarginal(mcmc_run, sites=["phi", "cluster_means"]).mean.sort()[0]
+    assert_equal(posterior[0], true_mix_proportions, prec=0.05)
+    assert_equal(posterior[1], true_cluster_means, prec=0.2)
+
+
+def test_bernoulli_latent_model():
+    @poutine.broadcast
+    def model(data):
+        y_prob = pyro.sample("y_prob", dist.Beta(1.1, 1.1))
+        with pyro.iarange("data", data.shape[0]):
+            y = pyro.sample("y", dist.Bernoulli(y_prob))
+            z = pyro.sample("z", dist.Bernoulli(0.65 * y + 0.1))
+            pyro.sample("obs", dist.Normal(2. * z, 1.), obs=data)
+
+    N = 2000
+    y_prob = torch.tensor(0.3)
+    y = dist.Bernoulli(y_prob).sample(torch.Size((N,)))
+    z = dist.Bernoulli(0.65 * y + 0.1).sample()
+    data = dist.Normal(2. * z, 1.0).sample()
+    nuts_kernel = NUTS(model, adapt_step_size=True, max_iarange_nesting=1)
+    mcmc_run = MCMC(nuts_kernel, num_samples=600, warmup_steps=200).run(data)
+    posterior = EmpiricalMarginal(mcmc_run, sites="y_prob").mean
+    assert_equal(posterior, y_prob, prec=0.05)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -209,7 +209,7 @@ def test_gaussian_mixture_model():
 def test_bernoulli_latent_model():
     @poutine.broadcast
     def model(data):
-        y_prob = pyro.sample("y_prob", dist.Beta(1.1, 1.1))
+        y_prob = pyro.sample("y_prob", dist.Beta(1., 1.))
         with pyro.iarange("data", data.shape[0]):
             y = pyro.sample("y", dist.Bernoulli(y_prob))
             z = pyro.sample("z", dist.Bernoulli(0.65 * y + 0.1))

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -118,6 +118,8 @@ def test_log_prob_eval_iterates_in_correct_order():
     for key in reversed(sorted(trace_prob_evaluator._log_probs.keys(), key=lambda x: (len(x), x))):
         iarange_dims.append(trace_prob_evaluator._iarange_dims[key])
         enum_dims.append(trace_prob_evaluator._enum_dims[key])
+    # The reduction operation returns a singleton with dimensions preserved.
+    assert not any(i != 1 for i in trace_prob_evaluator._aggregate_log_probs(frozenset()).shape)
     assert iarange_dims == [[-4, -3], [-2], [-1], []]
     assert enum_dims, [[-8], [-9, -6], [-7], [-5]]
 

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -1,13 +1,20 @@
+import logging
+
 import torch
 
 import pytest
+from torch.nn.functional import sigmoid
 
 import pyro
 import pyro.distributions as dist
 from pyro.infer import config_enumerate
 from pyro.infer.mcmc import MCMC, HMC, NUTS
 import pyro.poutine as poutine
+from pyro.infer.mcmc.util import EnumTraceProbEvaluator
+from pyro.primitives import _Subsample
 from tests.common import assert_equal
+
+logger = logging.getLogger(__name__)
 
 
 def assert_ok(mcmc_kernel):
@@ -23,6 +30,13 @@ def assert_error(mcmc_kernel):
     """
     with pytest.raises(ValueError):
         MCMC(mcmc_kernel, num_samples=10, warmup_steps=10).run()
+
+
+def print_debug_info(model_trace):
+    model_trace.compute_log_prob()
+    for name, site in model_trace.nodes.items():
+        if site["type"] == "sample" and not isinstance(site["fn"], _Subsample):
+            logger.debug("log_prob( {} ):\n {}".format(name, site["log_prob"].exp()))
 
 
 @pytest.mark.parametrize("kernel, kwargs", [
@@ -46,9 +60,6 @@ def test_model_error_stray_batch_dims(kernel, kwargs):
     # Error due to batch dims not inside iarange.
     mcmc_kernel = kernel(gmm, max_iarange_nesting=1, **kwargs)
     assert_error(mcmc_kernel)
-    # No error with validation disabled.
-    with pyro.validation_enabled(False):
-        assert_ok(mcmc_kernel)
 
 
 @pytest.mark.parametrize("kernel, kwargs", [
@@ -73,9 +84,10 @@ def test_model_error_enum_dim_clash(kernel, kwargs):
 
 @pytest.mark.parametrize("data, expected_log_prob", [
     (torch.tensor([1.]), torch.tensor(-1.3434)),
-    (torch.tensor([1., 0., 0.]), torch.tensor(-4.1813))
+    (torch.tensor([0.]), torch.tensor(-1.4189)),
+    (torch.tensor([1., 0., 0.]), torch.tensor(-4.1813)),
 ])
-def test_log_prob_computation(data, expected_log_prob):
+def test_enum_log_prob_continuous_observed(data, expected_log_prob):
     @poutine.broadcast
     def model(data):
         p = pyro.sample("p", dist.Uniform(0., 1.))
@@ -86,13 +98,133 @@ def test_log_prob_computation(data, expected_log_prob):
             mean = 2 * z - 1
             pyro.sample("obs", dist.Normal(mean, 1.), obs=data)
 
-    hmc_kernel = HMC(model, adapt_step_size=True, num_steps=3, max_iarange_nesting=1)
-    hmc_kernel._has_enumerable_sites = True
     conditioned_model = poutine.enum(
         config_enumerate(poutine.condition(model, {"p": torch.tensor(0.4)}),
                          default="parallel"),
         first_available_dim=1)
     model_trace = poutine.trace(conditioned_model).get_trace(data)
-    assert_equal(hmc_kernel._compute_trace_log_prob(model_trace),
+    print_debug_info(model_trace)
+    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 1)
+    assert_equal(trace_prob_evaluator.log_prob(),
+                 expected_log_prob,
+                 prec=1e-3)
+
+
+@pytest.mark.parametrize("data, expected_log_prob", [
+    (torch.tensor([1.]), torch.tensor(-3.5237)),
+    (torch.tensor([0.]), torch.tensor(-3.7091)),
+    (torch.tensor([1., 1.]), torch.tensor(-7.0474)),
+    (torch.tensor([1., 0., 0.]), torch.tensor(-10.9418)),
+])
+def test_enum_log_prob_continuous_sampled(data, expected_log_prob):
+    @poutine.broadcast
+    def model(data):
+        p = pyro.sample("p", dist.Uniform(0., 1.))
+        y = pyro.sample("y", dist.Bernoulli(p))
+        mean = 2 * y - 1
+        n = pyro.sample("n", dist.Normal(mean, 1.))
+        with pyro.iarange("data", len(data)):
+            pyro.sample("obs", dist.Bernoulli(sigmoid(n)), obs=data)
+
+    conditioned_model = poutine.enum(
+        config_enumerate(
+            poutine.condition(model, {
+                "p": torch.tensor(0.4),
+                "n": torch.tensor([[1.], [-1.]]),
+            }),
+            default="parallel"),
+        first_available_dim=1)
+    model_trace = poutine.trace(conditioned_model).get_trace(data)
+    print_debug_info(model_trace)
+    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 1)
+    assert_equal(trace_prob_evaluator.log_prob(),
+                 expected_log_prob,
+                 prec=1e-3)
+
+
+@pytest.mark.parametrize("data, expected_log_prob", [
+    (torch.tensor([1.]), torch.tensor(-0.5798)),
+    (torch.tensor([1., 1.]), torch.tensor(-1.1596)),
+    (torch.tensor([1., 0., 0.]), torch.tensor(-2.2218)),
+])
+def test_enum_log_prob_discrete_observed(data, expected_log_prob):
+    @poutine.broadcast
+    def model(data):
+        p = pyro.sample("p", dist.Uniform(0., 1.))
+        y = pyro.sample("y", dist.Bernoulli(p))
+        q = 0.25 * y + 0.5
+        with pyro.iarange("data", len(data)):
+            z = pyro.sample("z", dist.Bernoulli(q))
+            p = 0.6 * z + 0.2
+            pyro.sample("obs", dist.Bernoulli(p), obs=data)
+
+    conditioned_model = poutine.enum(
+        config_enumerate(poutine.condition(model, {"p": torch.tensor(0.4)}),
+                         default="parallel"),
+        first_available_dim=1)
+    model_trace = poutine.trace(conditioned_model).get_trace(data)
+    print_debug_info(model_trace)
+    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 1)
+    assert_equal(trace_prob_evaluator.log_prob(),
+                 expected_log_prob,
+                 prec=1e-3)
+
+
+@pytest.mark.parametrize("data, expected_log_prob", [
+    (torch.tensor([1.]), torch.tensor(-2.7622)),
+    (torch.tensor([0.]), torch.tensor(-3.069)),
+    (torch.tensor([1., 0., 0.]), torch.tensor(-8.901)),
+])
+def test_enum_log_prob_multiple_iarange(data, expected_log_prob):
+    @poutine.broadcast
+    def model(data):
+        p = pyro.sample("p", dist.Uniform(0., 1.))
+        y = pyro.sample("y", dist.Bernoulli(p))
+        q = 0.5 + 0.25 * y
+        with pyro.iarange("data1", len(data)):
+            v = pyro.sample("v", dist.Bernoulli(q))
+            pyro.sample("obs1", dist.Normal(2 * v, 1.), obs=data)
+        with pyro.iarange("data2", len(data)):
+            z = pyro.sample("z", dist.Bernoulli(q))
+            pyro.sample("obs2", dist.Normal(2 * z - 1, 1.), obs=data)
+
+    conditioned_model = poutine.enum(
+        config_enumerate(poutine.condition(model, {"p": torch.tensor(0.4)}),
+                         default="parallel"),
+        first_available_dim=1)
+    model_trace = poutine.trace(conditioned_model).get_trace(data)
+    print_debug_info(model_trace)
+    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 1)
+    assert_equal(trace_prob_evaluator.log_prob(),
+                 expected_log_prob,
+                 prec=1e-3)
+
+
+@pytest.mark.parametrize("data, expected_log_prob", [
+    (torch.tensor([1.]), torch.tensor(-1.5478)),
+    (torch.tensor([0.]), torch.tensor(-1.4189)),
+    (torch.tensor([1., 0., 0.]), torch.tensor(-4.3857)),
+])
+def test_enum_log_prob_nested_iarange(data, expected_log_prob):
+    @poutine.broadcast
+    def model(data):
+        p = pyro.sample("p", dist.Uniform(0., 1.))
+        y = pyro.sample("y", dist.Bernoulli(p))
+        q = 0.5 + 0.25 * y
+        with pyro.iarange("intermediate", 1, dim=-2):
+            v = pyro.sample("v", dist.Bernoulli(q))
+            with pyro.iarange("data", len(data), dim=-1):
+                r = 0.4 + 0.1 * v
+                z = pyro.sample("z", dist.Bernoulli(r))
+                pyro.sample("obs", dist.Normal(2 * z - 1, 1.), obs=data)
+
+    conditioned_model = poutine.enum(
+        config_enumerate(poutine.condition(model, {"p": torch.tensor(0.4)}),
+                         default="parallel"),
+        first_available_dim=2)
+    model_trace = poutine.trace(conditioned_model).get_trace(data)
+    print_debug_info(model_trace)
+    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 2)
+    assert_equal(trace_prob_evaluator.log_prob(),
                  expected_log_prob,
                  prec=1e-3)

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -36,7 +36,7 @@ def print_debug_info(model_trace):
     model_trace.compute_log_prob()
     for name, site in model_trace.nodes.items():
         if site["type"] == "sample" and not isinstance(site["fn"], _Subsample):
-            logger.debug("log_prob( {} ):\n {}".format(name, site["log_prob"].exp()))
+            logger.debug("prob( {} ):\n {}".format(name, site["log_prob"].exp()))
 
 
 @pytest.mark.parametrize("kernel, kwargs", [

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -118,8 +118,8 @@ def test_log_prob_eval_iterates_in_correct_order():
     for key in reversed(sorted(trace_prob_evaluator._log_probs.keys())):
         iarange_dims.append(trace_prob_evaluator._iarange_dims[key])
         enum_dims.append(trace_prob_evaluator._enum_dims[key])
-    assert_equal(iarange_dims, [[-4, -3], [-2], [-1], [0]])
-    assert_equal(enum_dims, [[-8], [-9, -6], [-7], [-5]])
+    assert iarange_dims == [[-4, -3], [-2], [-1], [0]]
+    assert enum_dims, [[-8], [-9, -6], [-7], [-5]]
 
 
 def test_all_discrete_sites_log_prob():

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -118,7 +118,7 @@ def test_log_prob_eval_iterates_in_correct_order():
     for key in reversed(sorted(trace_prob_evaluator._log_probs.keys(), key=lambda x: (len(x), x))):
         iarange_dims.append(trace_prob_evaluator._iarange_dims[key])
         enum_dims.append(trace_prob_evaluator._enum_dims[key])
-    assert iarange_dims == [[-4, -3], [-2], [-1], [0]]
+    assert iarange_dims == [[-4, -3], [-2], [-1], []]
     assert enum_dims, [[-8], [-9, -6], [-7], [-5]]
 
 

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -1,0 +1,69 @@
+import torch
+
+import pytest
+
+import pyro
+import pyro.distributions as dist
+from pyro.infer.mcmc import MCMC, HMC, NUTS
+import pyro.poutine as poutine
+
+
+def assert_ok(mcmc_kernel):
+    """
+    Assert that inference works without warnings or errors.
+    """
+    MCMC(mcmc_kernel, num_samples=10, warmup_steps=10).run()
+
+
+def assert_error(mcmc_kernel):
+    """
+    Assert that inference fails with an error.
+    """
+    with pytest.raises(ValueError):
+        MCMC(mcmc_kernel, num_samples=10, warmup_steps=10).run()
+
+
+@pytest.mark.parametrize("kernel, kwargs", [
+    (HMC, {"adapt_step_size": True, "num_steps": 3}),
+    (NUTS, {"adapt_step_size": True}),
+])
+def test_model_error_stray_batch_dims(kernel, kwargs):
+    @poutine.broadcast
+    def gmm():
+        data = torch.tensor([0., 0., 3., 3., 3., 5., 5.])
+        mix_proportions = pyro.sample("phi", dist.Dirichlet(torch.ones(3)))
+        cluster_means = pyro.sample("cluster_means", dist.Normal(torch.arange(3), 1.))
+        with pyro.iarange("data", data.shape[0]):
+            assignments = pyro.sample("assignments", dist.Categorical(mix_proportions))
+            pyro.sample("obs", dist.Normal(cluster_means[assignments], 1.), obs=data)
+        return cluster_means
+
+    mcmc_kernel = kernel(gmm, **kwargs)
+    # Error due to non finite value for `max_iarange_nesting`.
+    assert_error(mcmc_kernel)
+    # Error due to batch dims not inside iarange.
+    mcmc_kernel = kernel(gmm, max_iarange_nesting=1, **kwargs)
+    assert_error(mcmc_kernel)
+    # No error with validation disabled.
+    with pyro.validation_enabled(False):
+        assert_ok(mcmc_kernel)
+
+
+@pytest.mark.parametrize("kernel, kwargs", [
+    (HMC, {"adapt_step_size": True, "num_steps": 3}),
+    (NUTS, {"adapt_step_size": True}),
+])
+def test_model_error_enum_dim_clash(kernel, kwargs):
+    @poutine.broadcast
+    def gmm():
+        data = torch.tensor([0., 0., 3., 3., 3., 5., 5.])
+        with pyro.iarange("num_clusters", 3):
+            mix_proportions = pyro.sample("phi", dist.Dirichlet(torch.tensor(1.)))
+            cluster_means = pyro.sample("cluster_means", dist.Normal(torch.arange(3), 1.))
+        with pyro.iarange("data", data.shape[0]):
+            assignments = pyro.sample("assignments", dist.Categorical(mix_proportions))
+            pyro.sample("obs", dist.Normal(cluster_means[assignments], 1.), obs=data)
+        return cluster_means
+
+    mcmc_kernel = kernel(gmm, max_iarange_nesting=0, **kwargs)
+    assert_error(mcmc_kernel)

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -4,8 +4,10 @@ import pytest
 
 import pyro
 import pyro.distributions as dist
+from pyro.infer import config_enumerate
 from pyro.infer.mcmc import MCMC, HMC, NUTS
 import pyro.poutine as poutine
+from tests.common import assert_equal
 
 
 def assert_ok(mcmc_kernel):
@@ -67,3 +69,30 @@ def test_model_error_enum_dim_clash(kernel, kwargs):
 
     mcmc_kernel = kernel(gmm, max_iarange_nesting=0, **kwargs)
     assert_error(mcmc_kernel)
+
+
+@pytest.mark.parametrize("data, expected_log_prob", [
+    (torch.tensor([1.]), torch.tensor(-1.3434)),
+    (torch.tensor([1., 0., 0.]), torch.tensor(-4.1813))
+])
+def test_log_prob_computation(data, expected_log_prob):
+    @poutine.broadcast
+    def model(data):
+        p = pyro.sample("p", dist.Uniform(0., 1.))
+        y = pyro.sample("y", dist.Bernoulli(p))
+        q = 0.5 + 0.25 * y
+        with pyro.iarange("data", len(data)):
+            z = pyro.sample("z", dist.Bernoulli(q))
+            mean = 2 * z - 1
+            pyro.sample("obs", dist.Normal(mean, 1.), obs=data)
+
+    hmc_kernel = HMC(model, adapt_step_size=True, num_steps=3, max_iarange_nesting=1)
+    hmc_kernel._has_enumerable_sites = True
+    conditioned_model = poutine.enum(
+        config_enumerate(poutine.condition(model, {"p": torch.tensor(0.4)}),
+                         default="parallel"),
+        first_available_dim=1)
+    model_trace = poutine.trace(conditioned_model).get_trace(data)
+    assert_equal(hmc_kernel._compute_trace_log_prob(model_trace),
+                 expected_log_prob,
+                 prec=1e-3)

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -115,7 +115,7 @@ def test_log_prob_eval_iterates_in_correct_order():
     trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 4)
     trace_prob_evaluator.log_prob(model_trace)
     iarange_dims, enum_dims = [], []
-    for key in reversed(sorted(trace_prob_evaluator._log_probs.keys())):
+    for key in reversed(sorted(trace_prob_evaluator._log_probs.keys(), key=lambda x: (len(x), x))):
         iarange_dims.append(trace_prob_evaluator._iarange_dims[key])
         enum_dims.append(trace_prob_evaluator._enum_dims[key])
     assert iarange_dims == [[-4, -3], [-2], [-1], [0]]


### PR DESCRIPTION
Resolves #1128 via parallel enumeration.

 - If a model has discrete latents, they will be enumerated over in parallel. In such cases, we need to supply `max_iarange_nesting` as arg to HMC/NUTS constructor to reserve dims for parallel enumeration. Also in these cases, we do not allow for stray batch dims, i.e. batch dimensions need to be wrapped inside an `iarange`.
 - Tested on gmm and a latent bernoulli model. Also, added some cheap tests in `mcmc/test_valid_models.py` to assert error/ok behavior.