### PR TITLE
Add differentiable_loss to Trace_ELBO

### DIFF
--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -103,12 +103,14 @@ class Trace_ELBO(ELBO):
         Computes the surrogate loss that can be differentiated with autograd
         to produce gradient estimates for the model and guide parameters
         """
+        loss = 0.
         surrogate_loss = 0.
         for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
             loss_particle, surrogate_loss_particle = self._differentiable_loss_particle(model_trace, guide_trace)
             surrogate_loss += surrogate_loss_particle / self.num_particles
+            loss += loss_particle / self.num_particles
         warn_if_nan(surrogate_loss, "loss")
-        return surrogate_loss
+        return loss + (surrogate_loss - surrogate_loss.detach())
 
     def loss_and_grads(self, model, guide, *args, **kwargs):
         """

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -70,6 +70,46 @@ class Trace_ELBO(ELBO):
         warn_if_nan(loss, "loss")
         return loss
 
+    def _differentiable_loss_particle(self, model_trace, guide_trace):
+        elbo_particle = 0
+        surrogate_elbo_particle = 0
+        log_r = None
+
+        # compute elbo and surrogate elbo
+        for name, site in model_trace.nodes.items():
+            if site["type"] == "sample":
+                elbo_particle = elbo_particle + torch_item(site["log_prob_sum"])
+                surrogate_elbo_particle = surrogate_elbo_particle + site["log_prob_sum"]
+
+        for name, site in guide_trace.nodes.items():
+            if site["type"] == "sample":
+                log_prob, score_function_term, entropy_term = site["score_parts"]
+
+                elbo_particle = elbo_particle - torch_item(site["log_prob_sum"])
+
+                if not is_identically_zero(entropy_term):
+                    surrogate_elbo_particle = surrogate_elbo_particle - entropy_term.sum()
+
+                if not is_identically_zero(score_function_term):
+                    if log_r is None:
+                        log_r = _compute_log_r(model_trace, guide_trace)
+                    site = log_r.sum_to(site["cond_indep_stack"])
+                    surrogate_elbo_particle = surrogate_elbo_particle + (site * score_function_term).sum()
+
+        return -elbo_particle, -surrogate_elbo_particle
+
+    def differentiable_loss(self, model, guide, *args, **kwargs):
+        """
+        Computes the surrogate loss that can be differentiated with autograd
+        to produce gradient estimates for the model and guide parameters
+        """
+        surrogate_loss = 0.
+        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+            loss_particle, surrogate_loss_particle = self._differentiable_loss_particle(model_trace, guide_trace)
+            surrogate_loss += surrogate_loss_particle / self.num_particles
+        warn_if_nan(surrogate_loss, "loss")
+        return surrogate_loss
+
     def loss_and_grads(self, model, guide, *args, **kwargs):
         """
         :returns: returns an estimate of the ELBO
@@ -78,46 +118,21 @@ class Trace_ELBO(ELBO):
         Computes the ELBO as well as the surrogate ELBO that is used to form the gradient estimator.
         Performs backward on the latter. Num_particle many samples are used to form the estimators.
         """
-        elbo = 0.0
+        loss = 0.0
         # grab a trace from the generator
         for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
-            elbo_particle = 0
-            surrogate_elbo_particle = 0
-            log_r = None
-
-            # compute elbo and surrogate elbo
-            for name, site in model_trace.nodes.items():
-                if site["type"] == "sample":
-                    elbo_particle = elbo_particle + torch_item(site["log_prob_sum"])
-                    surrogate_elbo_particle = surrogate_elbo_particle + site["log_prob_sum"]
-
-            for name, site in guide_trace.nodes.items():
-                if site["type"] == "sample":
-                    log_prob, score_function_term, entropy_term = site["score_parts"]
-
-                    elbo_particle = elbo_particle - torch_item(site["log_prob_sum"])
-
-                    if not is_identically_zero(entropy_term):
-                        surrogate_elbo_particle = surrogate_elbo_particle - entropy_term.sum()
-
-                    if not is_identically_zero(score_function_term):
-                        if log_r is None:
-                            log_r = _compute_log_r(model_trace, guide_trace)
-                        site = log_r.sum_to(site["cond_indep_stack"])
-                        surrogate_elbo_particle = surrogate_elbo_particle + (site * score_function_term).sum()
-
-            elbo += elbo_particle / self.num_particles
+            loss_particle, surrogate_loss_particle = self._differentiable_loss_particle(model_trace, guide_trace)
+            loss += loss_particle / self.num_particles
 
             # collect parameters to train from model and guide
             trainable_params = any(site["type"] == "param"
                                    for trace in (model_trace, guide_trace)
                                    for site in trace.nodes.values())
 
-            if trainable_params and getattr(surrogate_elbo_particle, 'requires_grad', False):
-                surrogate_loss_particle = -surrogate_elbo_particle / self.num_particles
+            if trainable_params and getattr(surrogate_loss_particle, 'requires_grad', False):
+                surrogate_loss_particle = surrogate_loss_particle / self.num_particles
                 surrogate_loss_particle.backward()
 
-        loss = -elbo
         warn_if_nan(loss, "loss")
         return loss
 

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -19,9 +19,13 @@ from tests.common import assert_equal, xfail_param
 logger = logging.getLogger(__name__)
 
 
+def DiffTrace_ELBO(*args, **kwargs):
+    return Trace_ELBO(*args, **kwargs).differentiable_loss
+
+
 @pytest.mark.parametrize("reparameterized", [True, False], ids=["reparam", "nonreparam"])
 @pytest.mark.parametrize("subsample", [False, True], ids=["full", "subsample"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [Trace_ELBO, DiffTrace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
 def test_subsample_gradient(Elbo, reparameterized, subsample):
     pyro.clear_param_store()
     data = torch.tensor([-0.5, 2.0])
@@ -67,7 +71,7 @@ def test_subsample_gradient(Elbo, reparameterized, subsample):
 
 
 @pytest.mark.parametrize("reparameterized", [True, False], ids=["reparam", "nonreparam"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [Trace_ELBO, DiffTrace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
 def test_iarange(Elbo, reparameterized):
     pyro.clear_param_store()
     data = torch.tensor([-0.5, 2.0])
@@ -115,7 +119,7 @@ def test_iarange(Elbo, reparameterized):
 
 
 @pytest.mark.parametrize("reparameterized", [True, False], ids=["reparam", "nonreparam"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [Trace_ELBO, DiffTrace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
 def test_iarange_elbo_vectorized_particles(Elbo, reparameterized):
     pyro.clear_param_store()
     data = torch.tensor([-0.5, 2.0])


### PR DESCRIPTION
This PR adds `differentiable_loss` to `infer.Trace_ELBO` as proposed in e.g. #1227 and done for `TraceEnum_ELBO` in #1243.  It is necessary for #1250 