### PR TITLE
add vectorized test for BernoulliBeta

### DIFF
--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -295,6 +295,8 @@ class BernoulliBetaTests(TestCase):
     def test_elbo_nonreparameterized(self):
         self.do_elbo_test(False, 10000, Trace_ELBO())
 
+    # these "vectorized" tests are used to detect bugs similar to
+    # the one in https://github.com/pytorch/pytorch/issues/9521
     def test_elbo_reparameterized_vectorized(self):
         self.do_elbo_test(True, 5000, Trace_ELBO(num_particles=2, vectorize_particles=True,
                                                  max_iarange_nesting=1))

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -295,6 +295,14 @@ class BernoulliBetaTests(TestCase):
     def test_elbo_nonreparameterized(self):
         self.do_elbo_test(False, 10000, Trace_ELBO())
 
+    def test_elbo_reparameterized_vectorized(self):
+        self.do_elbo_test(True, 5000, Trace_ELBO(num_particles=2, vectorize_particles=True,
+                                                 max_iarange_nesting=1))
+
+    def test_elbo_nonreparameterized_vectorized(self):
+        self.do_elbo_test(False, 5000, Trace_ELBO(num_particles=2, vectorize_particles=True,
+                                                  max_iarange_nesting=1))
+
     def test_renyi_reparameterized(self):
         self.do_elbo_test(True, 5000, RenyiELBO(num_particles=2))
 

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -295,12 +295,12 @@ class BernoulliBetaTests(TestCase):
     def test_elbo_nonreparameterized(self):
         self.do_elbo_test(False, 10000, Trace_ELBO())
 
-    # these "vectorized" tests are used to detect bugs similar to
-    # the one in https://github.com/pytorch/pytorch/issues/9521
+    # this is used to detect bugs related to https://github.com/pytorch/pytorch/issues/9521
     def test_elbo_reparameterized_vectorized(self):
         self.do_elbo_test(True, 5000, Trace_ELBO(num_particles=2, vectorize_particles=True,
                                                  max_iarange_nesting=1))
 
+    # this is used to detect bugs related to https://github.com/pytorch/pytorch/issues/9521
     def test_elbo_nonreparameterized_vectorized(self):
         self.do_elbo_test(False, 5000, Trace_ELBO(num_particles=2, vectorize_particles=True,
                                                   max_iarange_nesting=1))


### PR DESCRIPTION
The bug https://github.com/pytorch/pytorch/issues/9521 in pytorch master makes the vectorized BernoulliBeta test fail. We want to add a test to detect that bug in future versions of both Pyro and PyTorch.