### PR TITLE
add regex search support for param store

### DIFF
--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -123,18 +123,16 @@ class ParamStoreDict(object):
 
         return param
 
-    def get_params(self, name, constraint=constraints.real):
+    def match(self, name):
         """
         Get all parameters that match regex. The parameter must exist.
 
         :param name: regular expression
         :type name: str
-        :param constraint: torch constraint
-        :type constraint: torch.distributions.constraints.Constraint
         :returns: dict with key param name and value torch Tensor
         """
         pattern = re.compile(name)
-        params_dict = {key: self.get_param(key, constraint=constraint) for key in self._params.keys()
+        params_dict = {key: self.get_param(key) for key in self._params.keys()
                        if pattern.match(key)}
         return params_dict
 

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import re
 import weakref
 
 import torch
@@ -84,6 +85,8 @@ class ParamStoreDict(object):
         :type name: str
         :param init_tensor: initial tensor
         :type init_tensor: torch.Tensor
+        :param constraint: torch constraint
+        :type constraint: torch.distributions.constraints.Constraint
         :returns: parameter
         :rtype: torch.Tensor
         """
@@ -119,6 +122,21 @@ class ParamStoreDict(object):
         param.unconstrained = weakref.ref(unconstrained_param)
 
         return param
+
+    def get_params(self, name, constraint=constraints.real):
+        """
+        Get all parameters that match regex. The parameter must exist.
+
+        :param name: regular expression
+        :type name: str
+        :param constraint: torch constraint
+        :type constraint: torch.distributions.constraints.Constraint
+        :returns: dict with key param name and value torch Tensor
+        """
+        pattern = re.compile(name)
+        params_dict = {key: self.get_param(key, constraint=constraint) for key in self._params.keys()
+                       if pattern.match(key)}
+        return params_dict
 
     def param_name(self, p):
         """


### PR DESCRIPTION
requested by @ae-foster 

**Example Usage:**
```python
for i in range(3):
  pyro.param('a_{}'.format(i), torch.ones(1))
  pyro.param('b_{}'.format(i), torch.ones(1))

pyro.get_param_store().match('a_[0-9]+')
# {'a_0': tensor([ 1.]),
#  'a_1': tensor([ 1.]),
#  'a_2': tensor([ 1.])}
```