### PR TITLE
Implement MaskedMixture distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -99,6 +99,13 @@ LowRankMultivariateNormal
     :undoc-members:
     :show-inheritance:
 
+MaskedMixture
+-------------
+.. autoclass:: pyro.distributions.MaskedMixture
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 MixtureOfDiagNormalsSharedCovariance
 ------------------------------------
 .. autoclass:: pyro.distributions.MixtureOfDiagNormalsSharedCovariance

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -1,26 +1,27 @@
 from __future__ import absolute_import, division, print_function
 
 import pyro.distributions.torch_patch  # noqa F403
+from pyro.distributions.avf_mvn import AVFMultivariateNormal
 from pyro.distributions.binomial import Binomial
 from pyro.distributions.delta import Delta
+from pyro.distributions.diag_normal_mixture_shared_cov import MixtureOfDiagNormalsSharedCovariance
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.empirical import Empirical
+from pyro.distributions.gaussian_scale_mixture import GaussianScaleMixture
 from pyro.distributions.half_cauchy import HalfCauchy
 from pyro.distributions.iaf import InverseAutoregressiveFlow
 from pyro.distributions.lowrank_mvn import LowRankMultivariateNormal
+from pyro.distributions.mixture import MaskedMixture
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
-from pyro.distributions.avf_mvn import AVFMultivariateNormal
 from pyro.distributions.rejector import Rejector
-from pyro.distributions.torch import __all__ as torch_dists
+from pyro.distributions.relaxed_straight_through import (RelaxedBernoulliStraightThrough,
+                                                         RelaxedOneHotCategoricalStraightThrough)
 from pyro.distributions.torch import *  # noqa F403
+from pyro.distributions.torch import __all__ as torch_dists
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.util import enable_validation, is_validation_enabled, validation_enabled
 from pyro.distributions.von_mises import VonMises
 from pyro.distributions.von_mises_3d import VonMises3D
-from pyro.distributions.relaxed_straight_through import RelaxedOneHotCategoricalStraightThrough
-from pyro.distributions.diag_normal_mixture_shared_cov import MixtureOfDiagNormalsSharedCovariance
-from pyro.distributions.gaussian_scale_mixture import GaussianScaleMixture
-from pyro.distributions.relaxed_straight_through import RelaxedBernoulliStraightThrough
 
 __all__ = [
     "enable_validation",
@@ -35,6 +36,7 @@ __all__ = [
     "HalfCauchy",
     "InverseAutoregressiveFlow",
     "LowRankMultivariateNormal",
+    "MaskedMixture",
     "MixtureOfDiagNormalsSharedCovariance",
     "OMTMultivariateNormal",
     "Rejector",

--- a/pyro/distributions/lowrank_mvn.py
+++ b/pyro/distributions/lowrank_mvn.py
@@ -6,7 +6,7 @@ import torch
 from torch.distributions import constraints
 from torch.distributions.utils import lazy_property
 
-from pyro.distributions.torch_distribution import TorchDistribution
+from pyro.distributions.torch_distribution import IndependentConstraint, TorchDistribution
 
 
 def _matrix_triangular_solve_compat(b, A, upper=True):
@@ -45,7 +45,7 @@ class LowRankMultivariateNormal(TorchDistribution):
     arg_constraints = {"loc": constraints.real,
                        "covariance_matrix_D_term": constraints.positive,
                        "scale_tril": constraints.lower_triangular}
-    support = constraints.real
+    support = IndependentConstraint(constraints.real, 1)
     has_rsample = True
 
     def __init__(self, loc, W_term, D_term, trace_term=None):

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -46,10 +46,6 @@ class MaskedMixture(TorchDistribution):
         with pyro.iarange("data", len(data)):
             pyro.sample("obs", MaskedMixture(mask, dist1, dist2), obs=data)
 
-    Note that :ivar:`support` is set to ``component0.support`` due to lack of
-    programmatic ability to union constraints. To correctly set support of an
-    instance, simply overwrite its :ivar:`support` attribute.
-
     :param torch.Tensor mask: A byte tensor toggling between ``component0``
         and ``component1``.
     :param pyro.distributions.TorchDistribution component0: a distribution

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -1,0 +1,93 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+from torch.distributions.utils import lazy_property
+
+from pyro.distributions.torch_distribution import TorchDistribution
+
+
+class MaskedMixture(TorchDistribution):
+    """
+    A masked deterministic mixture of two distributions.
+
+    This is useful when the mask is sampled from another distribution,
+    possibly correlated across the batch. Often the mask can be
+    marginalized out via enumeration.
+
+    Example::
+
+        change_point = pyro.sample("change_point",
+                                   dist.Categorical(torch.ones(len(data) + 1)),
+                                   infer={'enumerate': 'parallel'})
+        mask = torch.arange(len(data), dtype=torch.long) >= changepoint
+        with pyro.iarange("data", len(data)):
+            pyro.sample("obs", MaskedMixture(mask, dist1, dist2), obs=data)
+
+    Note that :ivar:`support` is set to ``component0.support`` due to lack of
+    programmatic ability to union constraints. To correctly set support of an
+    instance, simply overwrite its :ivar:`support` attribute.
+
+    :param torch.Tensor mask: A byte tensor toggling between ``component0``
+        and ``component1``.
+    :param pyro.distributions.TorchDistribution component0: a distribution
+    :param pyro.distributions.TorchDistribution component1: a distribution
+    """
+    def __init__(self, mask, component0, component1):
+        if component0.batch_shape != mask.shape:
+            raise ValueError('component0 does not match mask shape: {} vs {}'.format(
+                             component0.batch_shape, mask.shape))
+        if component1.batch_shape != mask.shape:
+            raise ValueError('component1 does not match mask shape: {} vs {}'
+                             .format(component1.batch_shape, mask.shape))
+        if component0.event_shape != component1.event_shape:
+            raise ValueError('components event_shape disagree: {} vs {}'
+                             .format(component0.event_shape, component1.event_shape))
+        self.mask = mask
+        self.component0 = component0
+        self.component1 = component1
+        self.support = component0.support  # best guess; may be incorrect
+        super(MaskedMixture, self).__init__(component0.batch_shape, component0.event_shape)
+
+    @property
+    def has_rsample(self):
+        return self.component0.has_rsample and self.component1.has_rsample
+
+    def expand(self, batch_shape):
+        try:
+            return super(MaskedMixture, self).expand(batch_shape)
+        except NotImplementedError:
+            mask = self.mask.expand(batch_shape)
+            components0 = self.components0.expand(batch_shape)
+            components1 = self.components1.expand(batch_shape)
+            result = type(self)(mask, components0, components1)
+            result.support = self.support
+            return result
+
+    def sample(self, sample_shape=torch.Size()):
+        mask = self.mask.expand(sample_shape + self.batch_shape) if sample_shape else self.mask
+        result = self.component0.sample(sample_shape)
+        result[mask] = self.component1.sample(sample_shape)[mask]
+        return result
+
+    def rsample(self, sample_shape=torch.Size()):
+        mask = self.mask.expand(sample_shape + self.batch_shape) if sample_shape else self.mask
+        result = self.component0.rsample(sample_shape)
+        result[mask] = self.component1.rsample(sample_shape)[mask]
+        return result
+
+    def log_prob(self, value):
+        result = self.component0.log_prob(value)
+        result[self.mask] = self.component1.log_prob(value)[self.mask]
+        return result
+
+    @lazy_property
+    def mean(self):
+        result = self.component0.mean.clone()
+        result[self.mask] = self.component1.mean[self.mask]
+        return result
+
+    @lazy_property
+    def variance(self):
+        result = self.component0.variance.clone()
+        result[self.mask] = self.component1.variance[self.mask]
+        return result

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -50,7 +50,9 @@ class MaskedMixture(TorchDistribution):
     :param torch.Tensor mask: A byte tensor toggling between ``component0``
         and ``component1``.
     :param pyro.distributions.TorchDistribution component0: a distribution
+        for batch elements ``mask == 0``.
     :param pyro.distributions.TorchDistribution component1: a distribution
+        for batch elements ``mask == 1``.
     """
     arg_constraints = {}  # nothing can be constrained
 

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -16,7 +16,8 @@ class MaskedConstraint(constraints.Constraint):
     :param torch.constraints.Constraint constraint0: constraint that holds
         wherever ``mask == 0``
     :param torch.constraints.Constraint constraint1: constraint that holds
-        wherever ``mask == 1`` """
+        wherever ``mask == 1``
+    """
     def __init__(self, mask, constraint0, constraint1):
         self.mask = mask
         self.constraint0 = constraint0

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -55,6 +55,8 @@ class MaskedMixture(TorchDistribution):
     arg_constraints = {}  # nothing can be constrained
 
     def __init__(self, mask, component0, component1, validate_args=None):
+        if not torch.is_tensor(mask) or mask.dtype != torch.uint8:
+            raise ValueError('Expected mask to be a ByteTensor but got {}'.format(type(mask)))
         if component0.event_shape != component1.event_shape:
             raise ValueError('components event_shape disagree: {} vs {}'
                              .format(component0.event_shape, component1.event_shape))

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 import torch
+from torch.distributions import constraints
 
-from pyro.distributions.torch_distribution import TorchDistributionMixin
+from pyro.distributions.torch_distribution import IndependentConstraint, TorchDistributionMixin
 
 
 class Bernoulli(torch.distributions.Bernoulli, TorchDistributionMixin):
@@ -170,6 +171,8 @@ class Multinomial(torch.distributions.Multinomial, TorchDistributionMixin):
 
 
 class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributionMixin):
+    support = IndependentConstraint(constraints.real, 1)  # TODO move upstream
+
     def expand(self, batch_shape):
         try:
             return super(MultivariateNormal, self).expand(batch_shape)

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -227,6 +227,16 @@ class TorchDistribution(torch.distributions.Distribution, TorchDistributionMixin
 
 # TODO move this upstream to torch.distributions
 class IndependentConstraint(constraints.Constraint):
+    """
+    Wraps a constraint by aggregating over ``reinterpreted_batch_ndims``-many
+    dims in :meth:`check`, so that an event is valid only if all its
+    independent entries are valid.
+
+    :param torch.distributions.constraints.Constraint base_constraint: A base
+        constraint whose entries are incidentally indepenent.
+    :param int reinterpreted_batch_ndims: The number of extra event dimensions that will
+        be considered dependent.
+    """
     def __init__(self, base_constraint, reinterpreted_batch_ndims):
         self.base_constraint = base_constraint
         self.reinterpreted_batch_ndims = reinterpreted_batch_ndims

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import numbers
 
 import torch
-from torch.distributions import constraints
+from torch.distributions import biject_to, constraints, transform_to
 
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.score_parts import ScoreParts
@@ -225,6 +225,23 @@ class TorchDistribution(torch.distributions.Distribution, TorchDistributionMixin
     pass
 
 
+# TODO move this upstream to torch.distributions
+class IndependentConstraint(constraints.Constraint):
+    def __init__(self, base_constraint, reinterpreted_batch_ndims):
+        self.base_constraint = base_constraint
+        self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
+
+    def check(self, value):
+        result = self.base_constraint.check(value)
+        result = result.reshape(result.shape[:result.dim() - self.reinterpreted_batch_ndims] + (-1,))
+        result = result.min(-1)[0]
+        return result
+
+
+biject_to.register(IndependentConstraint, lambda c: biject_to(c.base_constraint))
+transform_to.register(IndependentConstraint, lambda c: transform_to(c.base_constraint))
+
+
 class ReshapedDistribution(TorchDistribution):
     """
     Reshapes a distribution by adding ``sample_shape`` to its total shape
@@ -300,7 +317,15 @@ class ReshapedDistribution(TorchDistribution):
 
     @constraints.dependent_property
     def support(self):
-        return self.base_dist.support
+        return IndependentConstraint(self.base_dist.support, self.reinterpreted_batch_ndims)
+
+    @property
+    def _validate_args(self):
+        return self.base_dist._validate_args
+
+    @_validate_args.setter
+    def _validate_args(self, value):
+        self.base_dist._validate_args = value
 
     def sample(self, sample_shape=torch.Size()):
         return self.base_dist.sample(sample_shape + self.sample_shape)

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+import torch
+
+import pyro.distributions as dist
+from pyro.util import torch_isnan
+from tests.common import assert_equal
+
+
+@pytest.mark.parametrize('sample_shape', [(), (6,), (4, 2)])
+@pytest.mark.parametrize('batch_shape', [(), (7,), (5, 3)])
+@pytest.mark.parametrize('component1',
+                         [dist.Normal(1., 2.), dist.Exponential(2.)],
+                         ids=['normal', 'exponential'])
+@pytest.mark.parametrize('component0',
+                         [dist.Normal(1., 2.), dist.Exponential(2.)],
+                         ids=['normal', 'exponential'])
+def test_masked_mixture(component0, component1, sample_shape, batch_shape):
+    if batch_shape:
+        component0 = component0.expand_by(batch_shape)
+        component1 = component1.expand_by(batch_shape)
+    mask = torch.empty(batch_shape, dtype=torch.uint8).bernoulli_(0.5)
+    d = dist.MaskedMixture(mask, component0, component1)
+
+    assert d.sample().shape == batch_shape
+    assert d.mean.shape == batch_shape
+    assert d.variance.shape == batch_shape
+    x = d.sample(sample_shape)
+    assert x.shape == sample_shape + batch_shape
+
+    log_prob = d.log_prob(x)
+    assert log_prob.shape == sample_shape + batch_shape
+    assert not torch_isnan(log_prob)
+    log_prob_0 = component0.log_prob(x)
+    log_prob_1 = component1.log_prob(x)
+    mask = mask.expand(sample_shape + batch_shape)
+    assert_equal(log_prob[mask], log_prob_1[mask])
+    assert_equal(log_prob[~mask], log_prob_0[~mask])
+
+
+@pytest.mark.parametrize('event_shape', [(), (2,), (2, 3)])
+@pytest.mark.parametrize('batch_shape', [(), (3,), (5, 3)])
+@pytest.mark.parametrize('sample_shape', [(), (2,), (4, 2)])
+def test_expand(sample_shape, batch_shape, event_shape):
+    ones_shape = torch.Size((1,) * len(batch_shape))
+    mask = torch.ByteTensor(ones_shape).bernoulli_(0.5)
+    zero = torch.zeros(ones_shape + event_shape)
+    d0 = dist.Uniform(zero - 2, zero + 1).independent(len(event_shape))
+    d1 = dist.Uniform(zero - 1, zero + 2).independent(len(event_shape))
+    d = dist.MaskedMixture(mask, d0, d1)
+
+    assert d.sample().shape == ones_shape + event_shape
+    assert d.mean.shape == ones_shape + event_shape
+    assert d.variance.shape == ones_shape + event_shape
+    assert d.sample(sample_shape).shape == sample_shape + ones_shape + event_shape
+
+    assert d.expand(sample_shape + batch_shape).batch_shape == sample_shape + batch_shape
+    assert d.expand(sample_shape + batch_shape).sample().shape == sample_shape + batch_shape + event_shape
+    assert d.expand(sample_shape + batch_shape).mean.shape == sample_shape + batch_shape + event_shape
+    assert d.expand(sample_shape + batch_shape).variance.shape == sample_shape + batch_shape + event_shape


### PR DESCRIPTION
This implements a `MaskedMixture` distribution that can replace many of our uses of pairs of `poutine.scale` in models with element-wise dependencies. See docs and `test_em.py` for example usage.

About 90% of the logic is for broadcasting and validation, including two new constraints: `IndependentConstraint` and `MaskedConstraint`.

## Questions for reviewers

1. Which orientation is more intuitive?
    - `MaskedMixture(mask, if_zero, if_one)` is currently implemented. This is nice in that it is similar to a future `IndexedMixture(index, [case_0, case_1, ..., case_n])` where index is a `LongTensor`.
    - `MaskedMixture(cond, if_true, if_false)` is closer to `tf.Cond`
2. Should this be named something else like `Interleaved` or `CondDistribution` or other?

## Tested

- unit tests
- refactored `test_em.py` to use this distribution rather than `poutine.scale`

This PR was originally suggested by @eb8680