### PR TITLE
 Added flag to allow loading of CUDA-trained parameters to CPU.

### DIFF
--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -165,23 +165,23 @@ class ParamStoreDict(object):
         Save parameters to disk
 
         :param filename: file name to save to
-        :type name: str
+        :type filename: str
         """
         with open(filename, "wb") as output_file:
             torch.save(self.get_state(), output_file)
 
-    def load(self, filename, load_to_cpu=False):
+    def load(self, filename, map_location=None):
         """
         Loads parameters from disk
 
         :param filename: file name to load from
-        :type name: str
-        :param load_to_cpu: flag to load CUDA-trained parameters to CPU
-        :type name: bool
+        :type filename: str
+        :param map_location: specifies how to remap storage locations
+        :type map_location: function, torch.device, string or a dict
         """
         with open(filename, "rb") as input_file:
             if load_to_cpu:
-                state = torch.load(input_file, map_location=lambda storage, loc: storage)
+                state = torch.load(input_file, map_location)
             else:
                 state = torch.load(input_file)
         self.set_state(state)

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -176,6 +176,8 @@ class ParamStoreDict(object):
 
         :param filename: file name to load from
         :type name: str
+        :param load_to_cpu: flag to load CUDA-trained parameters to CPU
+        :type name: bool
         """
         with open(filename, "rb") as input_file:
             if load_to_cpu:

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -170,7 +170,7 @@ class ParamStoreDict(object):
         with open(filename, "wb") as output_file:
             torch.save(self.get_state(), output_file)
 
-    def load(self, filename):
+    def load(self, filename, load_to_cpu=False):
         """
         Loads parameters from disk
 
@@ -178,7 +178,10 @@ class ParamStoreDict(object):
         :type name: str
         """
         with open(filename, "rb") as input_file:
-            state = torch.load(input_file)
+            if load_to_cpu:
+                state = torch.load(input_file, map_location=lambda storage, loc: storage)
+            else:
+                state = torch.load(input_file)
         self.set_state(state)
 
 

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -180,10 +180,7 @@ class ParamStoreDict(object):
         :type map_location: function, torch.device, string or a dict
         """
         with open(filename, "rb") as input_file:
-            if load_to_cpu:
-                state = torch.load(input_file, map_location)
-            else:
-                state = torch.load(input_file)
+            state = torch.load(input_file, map_location)
         self.set_state(state)
 
 


### PR DESCRIPTION
After training a model on a GPU cluster, I found myself needing to load the Pyro parameter store on a non-CUDA-enabled device. This quick patch adds a flag to make that possible using this method:
https://discuss.pytorch.org/t/on-a-cpu-device-how-to-load-checkpoint-saved-on-gpu-device/349/4