### PR TITLE
Pin PyTorch version to 0.4.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'networkx>=2.0.0',
         'numpy>=1.7',
         'six>=1.10.0',
-        'torch>=0.4.0',
+        'torch==0.4.0',
     ],
     extras_require={
         'extras': EXTRAS_REQUIRE,


### PR DESCRIPTION
Addresses #1267 

Distributions like Bernoulli (probably others?) are broken in PyTorch 0.4.1. As @fritzo suggested, let us pin to PyTorch 0.4.0 until distributions are fixed upstream.

Related (upstream): https://github.com/pytorch/pytorch/issues/9521