### PR TITLE
make TorchDistributionsMixin.independent() return dist.Independent

### DIFF
--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -125,12 +125,23 @@ class Gumbel(torch.distributions.Gumbel, TorchDistributionMixin):
 
 
 class Independent(torch.distributions.Independent, TorchDistributionMixin):
+    @constraints.dependent_property
+    def support(self):
+        return IndependentConstraint(self.base_dist.support, self.reinterpreted_batch_ndims)
+
+    @property
+    def _validate_args(self):
+        return self.base_dist._validate_args
+
+    @_validate_args.setter
+    def _validate_args(self, value):
+        self.base_dist._validate_args = value
+
     def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         validate_args = self.__dict__.get('_validate_args')
-        extra_shape = self.base_dist.event_shape[:self.reinterpreted_batch_ndims]
-        base_dist = self.base_dist.expand(batch_shape + extra_shape)
-        return Independent(base_dist, self.reinterpreted_batch_ndims, validate_args=validate_args)
+        base_dist = self.base_dist.expand(batch_shape + self.event_shape)
+        return type(self)(base_dist, self.reinterpreted_batch_ndims, validate_args=validate_args)
 
 
 class Laplace(torch.distributions.Laplace, TorchDistributionMixin):

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -140,7 +140,9 @@ class Independent(torch.distributions.Independent, TorchDistributionMixin):
     def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
         validate_args = self.__dict__.get('_validate_args')
-        base_dist = self.base_dist.expand(batch_shape + self.event_shape)
+        base_shape = self.base_dist.batch_shape
+        reinterpreted_shape = base_shape[len(base_shape) - self.reinterpreted_batch_ndims:]
+        base_dist = self.base_dist.expand(batch_shape + reinterpreted_shape)
         return type(self)(base_dist, self.reinterpreted_batch_ndims, validate_args=validate_args)
 
 

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -139,7 +139,6 @@ class Independent(torch.distributions.Independent, TorchDistributionMixin):
 
     def expand(self, batch_shape):
         batch_shape = torch.Size(batch_shape)
-        validate_args = self.__dict__.get('_validate_args')
         base_shape = self.base_dist.batch_shape
         reinterpreted_shape = base_shape[len(base_shape) - self.reinterpreted_batch_ndims:]
         base_dist = self.base_dist.expand(batch_shape + reinterpreted_shape)

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -143,7 +143,7 @@ class Independent(torch.distributions.Independent, TorchDistributionMixin):
         base_shape = self.base_dist.batch_shape
         reinterpreted_shape = base_shape[len(base_shape) - self.reinterpreted_batch_ndims:]
         base_dist = self.base_dist.expand(batch_shape + reinterpreted_shape)
-        return type(self)(base_dist, self.reinterpreted_batch_ndims, validate_args=validate_args)
+        return type(self)(base_dist, self.reinterpreted_batch_ndims)
 
 
 class Laplace(torch.distributions.Laplace, TorchDistributionMixin):

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -5,7 +5,7 @@ import numbers
 import torch
 from torch.distributions import biject_to, constraints, transform_to
 
-import pyro.distributions
+import pyro.distributions.torch
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.score_parts import ScoreParts
 from pyro.distributions.util import broadcast_shape, sum_rightmost

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -5,6 +5,7 @@ import numbers
 import torch
 from torch.distributions import biject_to, constraints, transform_to
 
+import pyro.distributions
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.score_parts import ScoreParts
 from pyro.distributions.util import broadcast_shape, sum_rightmost
@@ -142,12 +143,11 @@ class TorchDistributionMixin(Distribution):
         :param int reinterpreted_batch_ndims: The number of batch dimensions
             to reinterpret as event dimensions.
         :return: A reshaped version of this distribution.
-        :rtype: :class:`ReshapedDistribution`
+        :rtype: :class:`pyro.distributions.torch.Independent`
         """
         if reinterpreted_batch_ndims is None:
             reinterpreted_batch_ndims = len(self.batch_shape)
-        # TODO return pyro.distributions.torch.Independent(self, reinterpreted_batch_ndims)
-        return ReshapedDistribution(self, reinterpreted_batch_ndims=reinterpreted_batch_ndims)
+        return pyro.distributions.torch.Independent(self, reinterpreted_batch_ndims)
 
     def mask(self, mask):
         """

--- a/tests/distributions/test_independent.py
+++ b/tests/distributions/test_independent.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+import torch
+from torch.distributions.utils import _sum_rightmost
+
+import pyro.distributions as dist
+from pyro.util import torch_isnan
+from tests.common import assert_equal
+
+
+@pytest.mark.parametrize('sample_shape', [(), (6,), (4, 2)])
+@pytest.mark.parametrize('batch_shape', [(), (7,), (5, 3), (5, 3, 2)])
+@pytest.mark.parametrize('reinterpreted_batch_ndims', [0, 1, 2, 3])
+@pytest.mark.parametrize('base_dist',
+                         [dist.Normal(1., 2.), dist.Exponential(2.),
+                          dist.MultivariateNormal(torch.zeros(2), torch.eye(2))],
+                         ids=['normal', 'exponential', 'mvn'])
+def test_independent(base_dist, sample_shape, batch_shape, reinterpreted_batch_ndims):
+    if batch_shape:
+        base_dist = base_dist.expand_by(batch_shape)
+    if reinterpreted_batch_ndims > len(base_dist.batch_shape):
+        with pytest.raises(ValueError):
+            d = dist.Independent(base_dist, reinterpreted_batch_ndims)
+    else:
+        d = dist.Independent(base_dist, reinterpreted_batch_ndims)
+        assert d.batch_shape == batch_shape[:len(batch_shape) - reinterpreted_batch_ndims]
+        assert d.event_shape == batch_shape[len(batch_shape) - reinterpreted_batch_ndims:] + base_dist.event_shape
+
+        assert d.sample().shape == batch_shape + base_dist.event_shape
+        assert d.mean.shape == batch_shape + base_dist.event_shape
+        assert d.variance.shape == batch_shape + base_dist.event_shape
+        x = d.sample(sample_shape)
+        assert x.shape == sample_shape + d.batch_shape + d.event_shape
+
+        log_prob = d.log_prob(x)
+        assert log_prob.shape == sample_shape + batch_shape[:len(batch_shape) - reinterpreted_batch_ndims]
+        assert not torch_isnan(log_prob)
+        log_prob_0 = base_dist.log_prob(x)
+        assert_equal(log_prob, _sum_rightmost(log_prob_0, reinterpreted_batch_ndims))
+
+
+@pytest.mark.parametrize('event_shape', [(), (2,), (2, 3)])
+@pytest.mark.parametrize('batch_shape', [(), (3,), (5, 3)])
+@pytest.mark.parametrize('sample_shape', [(), (2,), (4, 2)])
+def test_expand(sample_shape, batch_shape, event_shape):
+    ones_shape = torch.Size((1,) * len(batch_shape))
+    zero = torch.zeros(ones_shape + event_shape)
+    d0 = dist.Uniform(zero - 2, zero + 1).independent(len(event_shape))
+
+    assert d0.sample().shape == ones_shape + event_shape
+    assert d0.mean.shape == ones_shape + event_shape
+    assert d0.variance.shape == ones_shape + event_shape
+    assert d0.sample(sample_shape).shape == sample_shape + ones_shape + event_shape
+
+    assert d0.expand(sample_shape + batch_shape).batch_shape == sample_shape + batch_shape
+    assert d0.expand(sample_shape + batch_shape).sample().shape == sample_shape + batch_shape + event_shape
+    assert d0.expand(sample_shape + batch_shape).mean.shape == sample_shape + batch_shape + event_shape
+    assert d0.expand(sample_shape + batch_shape).variance.shape == sample_shape + batch_shape + event_shape

--- a/tests/distributions/test_independent.py
+++ b/tests/distributions/test_independent.py
@@ -60,12 +60,12 @@ def test_expand(sample_shape, batch_shape, event_shape):
 
     base_dist = dist.MultivariateNormal(torch.zeros(2).expand(*(event_shape + (2,))),
                                         torch.eye(2).expand(*(event_shape + (2, 2))))
-    if len(event_shape) >= len(base_dist.batch_shape):
+    if len(event_shape) > len(base_dist.batch_shape):
         with pytest.raises(ValueError):
-            base_dist.independent(len(event_shape) + 1).expand(batch_shape)
+            base_dist.independent(len(event_shape)).expand(batch_shape)
     else:
-            expanded = base_dist.independent(len(event_shape) + 1).expand(batch_shape)
+            expanded = base_dist.independent(len(event_shape)).expand(batch_shape)
             assert expanded.batch_shape == batch_shape
-            assert expanded.event_shape == (base_dist.batch_shape[:len(base_dist.batch_shape) -
-                                                                  expanded.reinterpreted_batch_ndims] +
+            assert expanded.event_shape == (base_dist.batch_shape[len(base_dist.batch_shape) -
+                                                                  expanded.reinterpreted_batch_ndims:] +
                                             base_dist.event_shape)


### PR DESCRIPTION
- `TorchDistributionsMixin.independent()` now returns `dist.Independent`
- fix bug in `Independent.expand`
- add tests that would have caught the bug.