### PR TITLE
Use torch.logsumexp when available

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -11,7 +11,7 @@ import torch
 import pyro
 import pyro.poutine as poutine
 from pyro.distributions import Binomial, HalfCauchy, Normal, Uniform
-from pyro.distributions.util import log_sum_exp
+from pyro.distributions.util import logsumexp
 from pyro.infer import EmpiricalMarginal
 from pyro.infer.abstract_infer import TracePredictive
 from pyro.infer.mcmc import MCMC, NUTS
@@ -208,7 +208,7 @@ def evaluate_log_predictive_density(model, model_trace_posterior, baseball_datas
         trace_log_pdf.append(tr.log_prob_sum())
     # Use LogSumExp trick to evaluate $log(1/num_samples \sum_i p(new_data | \theta^{i})) $,
     # where $\theta^{i}$ are parameter samples from the model's posterior.
-    posterior_pred_density = log_sum_exp(torch.stack(trace_log_pdf), dim=-1) - math.log(len(trace_log_pdf))
+    posterior_pred_density = logsumexp(torch.stack(trace_log_pdf), dim=-1) - math.log(len(trace_log_pdf))
     logging.info("\nLog posterior predictive density")
     logging.info("---------------------------------")
     logging.info("{:.4f}\n".format(posterior_pred_density))

--- a/examples/rsa/search_inference.py
+++ b/examples/rsa/search_inference.py
@@ -84,13 +84,13 @@ class HashingMarginal(dist.Distribution):
                 value_hash = hash(value)
             if value_hash in logits:
                 # Value has already been seen.
-                logits[value_hash] = dist.util.log_sum_exp(torch.stack([logits[value_hash], logit]), dim=-1)
+                logits[value_hash] = dist.util.logsumexp(torch.stack([logits[value_hash], logit]), dim=-1)
             else:
                 logits[value_hash] = logit
                 values_map[value_hash] = value
 
         logits = torch.stack(list(logits.values())).contiguous().view(-1)
-        logits = logits - dist.util.log_sum_exp(logits, dim=-1)
+        logits = logits - dist.util.logsumexp(logits, dim=-1)
         d = dist.Categorical(logits=logits)
         return d, values_map
 

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -8,7 +8,7 @@ from torch.distributions import constraints
 
 from pyro.distributions.torch import Categorical
 from pyro.distributions.torch_distribution import TorchDistribution
-from pyro.distributions.util import copy_docs_from, log_sum_exp
+from pyro.distributions.util import copy_docs_from, logsumexp
 
 
 @copy_docs_from(TorchDistribution)
@@ -127,7 +127,7 @@ class Empirical(TorchDistribution):
             return self._log_weights.new_zeros(torch.Size()).log()
         idxs = torch.arange(self.sample_size)[selection_mask.min(dim=-1)[0]]
         log_probs = self._categorical.log_prob(idxs)
-        return log_sum_exp(log_probs, dim=-1)
+        return logsumexp(log_probs, dim=-1)
 
     def _weighted_mean(self, value, dim=0):
         weights = self._log_weights

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -188,16 +188,19 @@ def torch_sign(value):
     return torch.sign(value)
 
 
-def log_sum_exp(tensor, dim=-1):
-    """
-    Numerically stable implementation for the `LogSumExp` operation. The
-    summing is done along the dimension specified by ``dim``.
+try:
+    from torch import logsumexp  # for pytorch 0.4.1 and later
+except ImportError:
+    def logsumexp(tensor, dim=-1):
+        """
+        Numerically stable implementation for the `LogSumExp` operation. The
+        summing is done along the dimension specified by ``dim``.
 
-    :param torch.Tensor tensor: Input tensor.
-    :param dim: Dimension to be summed out.
-    """
-    max_val = tensor.max(dim)[0]
-    return max_val + (tensor - max_val.unsqueeze(dim)).exp().sum(dim=dim).log()
+        :param torch.Tensor tensor: Input tensor.
+        :param dim: Dimension to be summed out.
+        """
+        max_val = tensor.max(dim)[0]
+        return max_val + (tensor - max_val.unsqueeze(dim)).exp().sum(dim=dim).log()
 
 
 def enable_validation(is_validate):

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -203,6 +203,9 @@ except ImportError:
         return max_val + (tensor - max_val.unsqueeze(dim)).exp().sum(dim=dim).log()
 
 
+log_sum_exp = logsumexp  # DEPRECATED
+
+
 def enable_validation(is_validate):
     global _VALIDATION_ENABLED
     _VALIDATION_ENABLED = is_validate

--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -4,7 +4,7 @@ import math
 
 import torch
 
-from pyro.distributions.util import is_identically_zero, log_sum_exp
+from pyro.distributions.util import is_identically_zero, logsumexp
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import get_importance_trace
 from pyro.infer.util import is_validation_enabled, torch_item
@@ -114,7 +114,7 @@ class RenyiELBO(ELBO):
             elbo_particles = torch.tensor(elbo_particles)  # no need to use .new*() here
 
         log_weights = (1. - self.alpha) * elbo_particles
-        log_mean_weight = log_sum_exp(log_weights, dim=0) - math.log(self.num_particles)
+        log_mean_weight = logsumexp(log_weights, dim=0) - math.log(self.num_particles)
         elbo = log_mean_weight.sum().item() / (1. - self.alpha)
 
         loss = -elbo
@@ -196,7 +196,7 @@ class RenyiELBO(ELBO):
             surrogate_elbo_particles = torch.stack(surrogate_elbo_particles)
 
         log_weights = (1. - self.alpha) * elbo_particles
-        log_mean_weight = log_sum_exp(log_weights, dim=0) - math.log(self.num_particles)
+        log_mean_weight = logsumexp(log_weights, dim=0) - math.log(self.num_particles)
         elbo = log_mean_weight.sum().item() / (1. - self.alpha)
 
         # collect parameters to train from model and guide

--- a/tests/distributions/test_mask.py
+++ b/tests/distributions/test_mask.py
@@ -11,7 +11,7 @@ from tests.common import assert_equal
 def checker_mask(shape):
     mask = tensor(0.)
     for size in shape:
-        mask = mask.unsqueeze(-1) + torch.arange(size)
+        mask = mask.unsqueeze(-1) + torch.arange(float(size))
     return mask.fmod(2)
 
 


### PR DESCRIPTION
Addresses #1267 

This replaces our internal `pyro.distributions.util.log_sum_exp` with `torch.logsumexp` when available, i.e. after pytorch 0.4.1. The old implementation is kept as a fallback, and I've kept a `log_sum_exp` alias to avoid breaking internal applications.