### PR TITLE
Rename Laplace approximation

### DIFF
--- a/docs/source/contrib.autoguide.rst
+++ b/docs/source/contrib.autoguide.rst
@@ -75,6 +75,14 @@ AutoIAFNormal
     :special-members: __call__
     :show-inheritance:
 
+AutoLaplaceApproximation
+-----------------------------
+.. autoclass:: pyro.contrib.autoguide.AutoLaplaceApproximation
+    :members:
+    :undoc-members:
+    :special-members: __call__
+    :show-inheritance:
+
 AutoDiscreteParallel
 --------------------
 .. autoclass:: pyro.contrib.autoguide.AutoDiscreteParallel

--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -41,10 +41,10 @@ __all__ = [
     'AutoDiscreteParallel',
     'AutoGuide',
     'AutoGuideList',
+    'AutoIAFNormal',
+    'AutoLaplaceApproximation',
     'AutoLowRankMultivariateNormal',
     'AutoMultivariateNormal',
-    'AutoIAFNormal',
-    'UnconstrainedLaplaceApproximation',
 ]
 
 
@@ -625,19 +625,20 @@ class AutoIAFNormal(AutoContinuous):
         return iaf_dist.independent(1)
 
 
-class UnconstrainedLaplaceApproximation(AutoContinuous):
+class AutoLaplaceApproximation(AutoContinuous):
     """
-    Unconstrained Laplace approximation (quadratic approximation) approximates
-    the posterior math:`log p(z | x)` by a multivariate normal distribution in
-    the unconstrained space. Under the hood, it uses Delta distributions to
+    Laplace approximation (quadratic approximation) approximates the posterior
+    math:`log p(z | x)` by a multivariate normal distribution in the
+    unconstrained space. Under the hood, it uses Delta distributions to
     construct a MAP guide over the entire (unconstrained) latent space. Its
     covariance is given by the inverse of the hessian of :math:`-\log p(x, z)`
     at the MAP point of `z`.
 
     Usage::
 
-        delta_guide = UnconstrainedLaplaceApproximation(model)
+        delta_guide = AutoLaplaceApproximation(model)
         svi = SVI(model, delta_guide, ...)
+        # ...then train the delta_guide...
         guide = delta_guide.laplace_approximation()
 
     By default the mean vector is initialized to zero. To change this default behavior

--- a/tests/contrib/autoguide/test_advi.py
+++ b/tests/contrib/autoguide/test_advi.py
@@ -8,9 +8,9 @@ from torch.distributions import constraints
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-from pyro.contrib.autoguide import (AutoCallable, AutoDelta, AutoDiagonalNormal, AutoDiscreteParallel,
-                                    AutoGuideList, AutoLowRankMultivariateNormal, AutoMultivariateNormal,
-                                    AutoIAFNormal, UnconstrainedLaplaceApproximation)
+from pyro.contrib.autoguide import (AutoCallable, AutoDelta, AutoDiagonalNormal, AutoDiscreteParallel, AutoGuideList,
+                                    AutoIAFNormal, AutoLaplaceApproximation, AutoLowRankMultivariateNormal,
+                                    AutoMultivariateNormal)
 from pyro.infer import SVI, Trace_ELBO, TraceEnum_ELBO, TraceGraph_ELBO
 from pyro.optim import Adam
 from tests.common import assert_equal
@@ -49,7 +49,7 @@ def test_scores(auto_class):
     AutoMultivariateNormal,
     AutoLowRankMultivariateNormal,
     AutoIAFNormal,
-    UnconstrainedLaplaceApproximation,
+    AutoLaplaceApproximation,
 ])
 def test_shapes(auto_class, Elbo):
 
@@ -72,7 +72,7 @@ def test_shapes(auto_class, Elbo):
     AutoMultivariateNormal,
     AutoLowRankMultivariateNormal,
     AutoIAFNormal,
-    UnconstrainedLaplaceApproximation,
+    AutoLaplaceApproximation,
 ])
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO])
 def test_irange_smoke(auto_class, Elbo):
@@ -122,7 +122,7 @@ def auto_guide_callable(model):
     AutoDiagonalNormal,
     AutoMultivariateNormal,
     AutoLowRankMultivariateNormal,
-    UnconstrainedLaplaceApproximation,
+    AutoLaplaceApproximation,
     auto_guide_list_x,
     auto_guide_callable,
 ])
@@ -139,7 +139,7 @@ def test_median(auto_class, Elbo):
     for _ in range(800):
         infer.step()
 
-    if auto_class is UnconstrainedLaplaceApproximation:
+    if auto_class is AutoLaplaceApproximation:
         guide = guide.laplace_approximation()
 
     median = guide.median()
@@ -155,7 +155,7 @@ def test_median(auto_class, Elbo):
     AutoDiagonalNormal,
     AutoMultivariateNormal,
     AutoLowRankMultivariateNormal,
-    UnconstrainedLaplaceApproximation,
+    AutoLaplaceApproximation,
 ])
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
 def test_quantiles(auto_class, Elbo):
@@ -170,7 +170,7 @@ def test_quantiles(auto_class, Elbo):
     for _ in range(100):
         infer.step()
 
-    if auto_class is UnconstrainedLaplaceApproximation:
+    if auto_class is AutoLaplaceApproximation:
         guide = guide.laplace_approximation()
 
     quantiles = guide.quantiles([0.1, 0.5, 0.9])
@@ -201,7 +201,7 @@ def test_quantiles(auto_class, Elbo):
     AutoMultivariateNormal,
     AutoLowRankMultivariateNormal,
     AutoIAFNormal,
-    UnconstrainedLaplaceApproximation,
+    AutoLaplaceApproximation,
 ])
 def test_discrete_parallel(continuous_class):
     K = 2
@@ -232,7 +232,7 @@ def test_discrete_parallel(continuous_class):
     AutoMultivariateNormal,
     AutoLowRankMultivariateNormal,
     AutoIAFNormal,
-    UnconstrainedLaplaceApproximation,
+    AutoLaplaceApproximation,
 ])
 def test_guide_list(auto_class):
 
@@ -251,7 +251,7 @@ def test_guide_list(auto_class):
     AutoDiagonalNormal,
     AutoMultivariateNormal,
     AutoLowRankMultivariateNormal,
-    UnconstrainedLaplaceApproximation,
+    AutoLaplaceApproximation,
 ])
 def test_callable(auto_class):
 
@@ -275,7 +275,7 @@ def test_callable(auto_class):
     AutoDiagonalNormal,
     AutoMultivariateNormal,
     AutoLowRankMultivariateNormal,
-    UnconstrainedLaplaceApproximation,
+    AutoLaplaceApproximation,
 ])
 def test_callable_return_dict(auto_class):
 

--- a/tests/contrib/autoguide/test_inference.py
+++ b/tests/contrib/autoguide/test_inference.py
@@ -10,8 +10,8 @@ from torch.distributions import biject_to, constraints
 import pyro
 import pyro.distributions as dist
 import pyro.optim as optim
-from pyro.contrib.autoguide import (AutoDelta, AutoDiagonalNormal, AutoLowRankMultivariateNormal,
-                                    AutoMultivariateNormal, UnconstrainedLaplaceApproximation)
+from pyro.contrib.autoguide import (AutoDelta, AutoDiagonalNormal, AutoLaplaceApproximation,
+                                    AutoLowRankMultivariateNormal, AutoMultivariateNormal)
 from pyro.infer import SVI, Trace_ELBO
 from tests.common import assert_equal
 from tests.integration_tests.test_conjugate_gaussian_models import GaussianChain
@@ -74,7 +74,7 @@ class AutoGaussianChain(GaussianChain):
 
 @pytest.mark.parametrize('auto_class', [AutoDiagonalNormal, AutoMultivariateNormal,
                                         AutoLowRankMultivariateNormal, AutoDelta,
-                                        UnconstrainedLaplaceApproximation])
+                                        AutoLaplaceApproximation])
 def test_auto_diagonal_gaussians(auto_class):
     n_steps = 3501 if auto_class == AutoDiagonalNormal else 6001
 
@@ -98,7 +98,7 @@ def test_auto_diagonal_gaussians(auto_class):
         loc = torch.tensor([latents["x"], latents["y"]])
         scale = guide.covariance().diag().sqrt()
     else:
-        if auto_class is UnconstrainedLaplaceApproximation:
+        if auto_class is AutoLaplaceApproximation:
             guide = guide.laplace_approximation()
 
         loc, scale = guide._loc_scale()
@@ -110,7 +110,7 @@ def test_auto_diagonal_gaussians(auto_class):
 
 
 @pytest.mark.parametrize('auto_class', [AutoDiagonalNormal, AutoMultivariateNormal,
-                                        AutoLowRankMultivariateNormal, UnconstrainedLaplaceApproximation])
+                                        AutoLowRankMultivariateNormal, AutoLaplaceApproximation])
 def test_auto_transform(auto_class):
     n_steps = 3500
 
@@ -128,7 +128,7 @@ def test_auto_transform(auto_class):
         loss = svi.step()
         assert np.isfinite(loss), loss
 
-    if auto_class is UnconstrainedLaplaceApproximation:
+    if auto_class is AutoLaplaceApproximation:
         guide = guide.laplace_approximation()
 
     loc, scale = guide._loc_scale()
@@ -139,7 +139,7 @@ def test_auto_transform(auto_class):
 
 
 @pytest.mark.parametrize('auto_class', [AutoDiagonalNormal, AutoMultivariateNormal,
-                                        AutoLowRankMultivariateNormal, UnconstrainedLaplaceApproximation])
+                                        AutoLowRankMultivariateNormal, AutoLaplaceApproximation])
 def test_auto_dirichlet(auto_class):
     num_steps = 2000
     prior = torch.tensor([0.5, 1.0, 1.5, 3.0])


### PR DESCRIPTION
1. Renames `UnconstrainedLaplaceApproximation` --> `AutoLaplaceApproximation`
2. Adds a docs section to docs/source/contrib.autoname.rst