### PR TITLE
Update JIT usage to PyTorch 0.4.1

### DIFF
--- a/docs/source/primitives.rst
+++ b/docs/source/primitives.rst
@@ -20,4 +20,4 @@ Primitives
 .. autofunction:: pyro.validation_enabled
 .. autofunction:: pyro.enable_validation
 
-.. autofunction:: pyro.ops.jit.compile
+.. autofunction:: pyro.ops.jit.trace

--- a/examples/air/modules.py
+++ b/examples/air/modules.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn as nn
 from torch.nn.functional import softplus
 

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+from numbers import Number
+
 import torch
 
 
@@ -43,6 +45,53 @@ def _torch_dirichlet_grad(x, concentration, total):
     if x.is_cuda:
         return unpatched_fn(x.cpu(), concentration.cpu(), total.cpu()).cuda(x.get_device())
     return unpatched_fn(x, concentration, total)
+
+
+# This version of broadcast_all() is compatible with early versions of the PyTorch jit,
+# since it avoids torch._C._infer_size(). However it is more expensive since it infers
+# size by summing the tensors. It is mainly useful for working around one jit limitation
+# to discovering additional jit limitations.
+#
+# To temporarily apply this patch, uncomment one or more of the decorators:
+#
+# @_patch('torch.distributions.beta.broadcast_all')
+# @_patch('torch.distributions.dirichlet.broadcast_all')
+# @_patch('torch.distributions.normal.broadcast_all')
+# @_patch('torch.distributions.utils.broadcast_all')
+def _broadcast_all(*values):
+    r"""
+    Given a list of values (possibly containing numbers), returns a list where each
+    value is broadcasted based on the following rules:
+      - `torch.*Tensor` instances are broadcasted as per the `broadcasting rules
+        <http://pytorch.org/docs/master/notes/broadcasting.html>`_
+      - numbers.Number instances (scalars) are upcast to tensors having
+        the same size and type as the first tensor passed to `values`.  If all the
+        values are scalars, then they are upcasted to Tensors having size
+        `(1,)`.
+
+    Args:
+        values (list of `numbers.Number` or `torch.*Tensor`)
+
+    Raises:
+        ValueError: if any of the values is not a `numbers.Number` or
+            `torch.*Tensor` instance
+    """
+    values = list(values)
+    scalar_idxs = [i for i in range(len(values)) if isinstance(values[i], Number)]
+    tensor_idxs = [i for i in range(len(values)) if values[i].__class__.__name__ == 'Tensor']
+    if len(scalar_idxs) + len(tensor_idxs) != len(values):
+        raise ValueError('Input arguments must all be instances of numbers.Number or torch.tensor.')
+    if tensor_idxs:
+        broadcast_shape = sum(values).size()  # expensive alternative to torch._C._infer_size()
+        for idx in tensor_idxs:
+            values[idx] = values[idx].expand(broadcast_shape)
+        template = values[tensor_idxs[0]]
+        for idx in scalar_idxs:
+            values[idx] = template.new(template.size()).fill_(values[idx])
+    else:
+        for idx in scalar_idxs:
+            values[idx] = torch.tensor(float(values[idx]))
+    return values
 
 
 __all__ = []

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -160,7 +160,7 @@ class JitTrace_ELBO(Trace_ELBO):
             # build a closure for loss_and_surrogate_loss
             weakself = weakref.ref(self)
 
-            @pyro.ops.jit.compile(nderivs=1)
+            @pyro.ops.jit.trace
             def loss_and_surrogate_loss(*args):
                 self = weakself()
                 loss = 0.0
@@ -200,7 +200,7 @@ class JitTrace_ELBO(Trace_ELBO):
 
         # invoke _loss_and_surrogate_loss
         loss, surrogate_loss = self._loss_and_surrogate_loss(*args)
-        surrogate_loss.backward()  # this line triggers jit compilation
+        surrogate_loss.backward()
         loss = loss.item()
 
         warn_if_nan(loss, "loss")

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -191,7 +191,7 @@ class JitTraceEnum_ELBO(TraceEnum_ELBO):
 
             weakself = weakref.ref(self)
 
-            @pyro.ops.jit.compile(nderivs=1)
+            @pyro.ops.jit.trace
             def differentiable_loss(*args):
                 self = weakself()
                 elbo = 0.0

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -256,7 +256,7 @@ class TraceGraph_ELBO(ELBO):
 
 class JitTraceGraph_ELBO(TraceGraph_ELBO):
     """
-    Like :class:`TraceGraph_ELBO` but uses :func:`torch.jit.compile` to
+    Like :class:`TraceGraph_ELBO` but uses :func:`torch.jit.trace` to
     compile :meth:`loss_and_grads`.
 
     This works only for a limited set of models:
@@ -276,7 +276,7 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
             # build a closure for loss_and_surrogate_loss
             weakself = weakref.ref(self)
 
-            @pyro.ops.jit.compile(nderivs=1)
+            @pyro.ops.jit.trace
             def loss_and_surrogate_loss(*args):
                 self = weakself()
                 loss = 0.0
@@ -304,7 +304,7 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
             self._loss_and_surrogate_loss = loss_and_surrogate_loss
 
         loss, surrogate_loss = self._loss_and_surrogate_loss(*args)
-        surrogate_loss.backward()  # this line triggers jit compilation
+        surrogate_loss.backward()
         loss = loss.item()
 
         warn_if_nan(loss, "loss")

--- a/pyro/ops/jit.py
+++ b/pyro/ops/jit.py
@@ -7,22 +7,20 @@ import pyro.poutine as poutine
 
 class CompiledFunction(object):
     """
-    Output type of :func:`pyro.ops.jit.compile`.
+    Output type of :func:`pyro.ops.jit.trace`.
 
-    Wrapper around the output of :func:`torch.jit.compile`
+    Wrapper around the output of :func:`torch.jit.trace`
     that handles parameter plumbing.
 
     The actual PyTorch compilation artifact is stored in :attr:`compiled`.
     Call diagnostic methods on this attribute.
     """
-    def __init__(self, fn, **jit_options):
+    def __init__(self, fn):
         self.fn = fn
-        self._jit_options = jit_options
         self.compiled = None
         self._param_names = None
 
     def __call__(self, *args, **kwargs):
-
         # if first time
         if self.compiled is None:
             # param capture
@@ -31,48 +29,48 @@ class CompiledFunction(object):
                     self.fn(*args, **kwargs)
 
             self._param_names = list(set(first_param_capture.trace.nodes.keys()))
-
+            unconstrained_params = [pyro.param(name).unconstrained()
+                                    for name in self._param_names]
+            params_and_args = unconstrained_params + list(args)
             weakself = weakref.ref(self)
 
-            @torch.jit.compile(**self._jit_options)
-            def compiled(unconstrained_params, *args):
+            @torch.jit.trace(*params_and_args)
+            def compiled(*params_and_args):
                 self = weakself()
+                unconstrained_params = params_and_args[:len(self._param_names)]
+                args = params_and_args[len(self._param_names):]
                 constrained_params = {}
                 for name, unconstrained_param in zip(self._param_names, unconstrained_params):
                     constrained_param = pyro.param(name)  # assume param has been initialized
                     assert constrained_param.unconstrained() is unconstrained_param
                     constrained_params[name] = constrained_param
-
-                return poutine.replay(
-                    self.fn, params=constrained_params)(*args, **kwargs)
+                return poutine.replay(self.fn, params=constrained_params)(*args, **kwargs)
 
             self.compiled = compiled
-
-        param_list = [pyro.param(name).unconstrained()
-                      for name in self._param_names]
+        else:
+            unconstrained_params = [pyro.param(name).unconstrained()
+                                    for name in self._param_names]
+            params_and_args = unconstrained_params + list(args)
 
         with poutine.block(hide=self._param_names):
             with poutine.trace(param_only=True) as param_capture:
-                ret = self.compiled(param_list, *args, **kwargs)
+                ret = self.compiled(*params_and_args)
 
-        new_params = filter(lambda name: name not in self._param_names,
-                            param_capture.trace.nodes.keys())
-
-        for name in new_params:
-            # enforce uniqueness
+        for name in param_capture.trace.nodes.keys():
             if name not in self._param_names:
-                self._param_names.append(name)
+                raise NotImplementedError('pyro.ops.jit.trace assumes all params are created on '
+                                          'first invocation, but found new param: {}'.format(name))
 
         return ret
 
 
-def compile(fn=None, **jit_options):
+def trace(fn=None):
     """
-    Drop-in replacement for :func:`torch.jit.compile` that works with
+    Lazy replacement for :func:`torch.jit.trace` that works with
     Pyro functions that call :func:`pyro.param`.
 
-    The actual compilation artifact is stored in the ``compiled`` attribute of the output.
-    Call diagnostic methods on this attribute.
+    The actual compilation artifact is stored in the ``compiled`` attribute of
+    the output. Call diagnostic methods on this attribute.
 
     Example::
 
@@ -80,12 +78,12 @@ def compile(fn=None, **jit_options):
             scale = pyro.param("scale", torch.tensor(0.5), constraint=constraints.positive)
             return pyro.sample("y", dist.Normal(x, scale))
 
-        @pyro.ops.jit.compile(nderivs=1)
+        @pyro.ops.jit.trace
         def model_log_prob_fn(x, y):
             cond_model = pyro.condition(model, data={"y": y})
             tr = pyro.poutine.trace(cond_model).get_trace(x)
             return tr.log_prob_sum()
     """
     if fn is None:
-        return lambda fn: compile(fn, **jit_options)
-    return CompiledFunction(fn, **jit_options)
+        return lambda fn: trace(fn)
+    return CompiledFunction(fn)

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -171,14 +171,13 @@ def test_iarange_elbo_vectorized_particles(Elbo, reparameterized):
 @pytest.mark.parametrize("reparameterized", [True, False], ids=["reparam", "nonreparam"])
 @pytest.mark.parametrize("subsample", [False, True], ids=["full", "subsample"])
 @pytest.mark.parametrize("Elbo", [
-    Trace_ELBO,
-    TraceGraph_ELBO,
-    TraceEnum_ELBO,
+    # Trace_ELBO,
+    # TraceGraph_ELBO,
+    # TraceEnum_ELBO,
     xfail_param(JitTrace_ELBO,
                 reason="in broadcast_all: RuntimeError: expected int at position 0, but got: Tensor"),
     xfail_param(JitTraceGraph_ELBO,
                 reason="in broadcast_all: RuntimeError: expected int at position 0, but got: Tensor"),
-                reason="jit RuntimeError: Unsupported op descriptor: index-2"),
     xfail_param(JitTraceEnum_ELBO,
                 reason="in broadcast_all: RuntimeError: expected int at position 0, but got: Tensor"),
 ])

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -175,11 +175,12 @@ def test_iarange_elbo_vectorized_particles(Elbo, reparameterized):
     TraceGraph_ELBO,
     TraceEnum_ELBO,
     xfail_param(JitTrace_ELBO,
-                reason="jit RuntimeError: Unsupported op descriptor: index-2"),
+                reason="in broadcast_all: RuntimeError: expected int at position 0, but got: Tensor"),
     xfail_param(JitTraceGraph_ELBO,
+                reason="in broadcast_all: RuntimeError: expected int at position 0, but got: Tensor"),
                 reason="jit RuntimeError: Unsupported op descriptor: index-2"),
     xfail_param(JitTraceEnum_ELBO,
-                reason="jit RuntimeError: Unsupported op descriptor: index-2"),
+                reason="in broadcast_all: RuntimeError: expected int at position 0, but got: Tensor"),
 ])
 def test_subsample_gradient_sequential(Elbo, reparameterized, subsample):
     pyro.clear_param_store()

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -171,9 +171,9 @@ def test_iarange_elbo_vectorized_particles(Elbo, reparameterized):
 @pytest.mark.parametrize("reparameterized", [True, False], ids=["reparam", "nonreparam"])
 @pytest.mark.parametrize("subsample", [False, True], ids=["full", "subsample"])
 @pytest.mark.parametrize("Elbo", [
-    # Trace_ELBO,
-    # TraceGraph_ELBO,
-    # TraceEnum_ELBO,
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
     xfail_param(JitTrace_ELBO,
                 reason="in broadcast_all: RuntimeError: expected int at position 0, but got: Tensor"),
     xfail_param(JitTraceGraph_ELBO,


### PR DESCRIPTION
Addresses #1267, #1063

@eb8680 I've set the base to the `fix-dist-0.4.1` branch, so feel free to merge this at any time.

Some differences include:
1. I've temporarily dropped support for dynamically created params. This is partly due to 0.4.1's new restriction that inputs should be an `*args` of tensors, not a recursive `arg ::= list[arg] | tensor`. We can add this back in a later PR.
2. `@pyro.ops.jit.trace` now differs from `torch.jit.trace` in that it is lazy and does not require specifying all args on input. This seems easier to use, and makes it easier to splice in params to the `*args` sent to the compiled function.
    ```py
    @torch.jit.trace(*args)  # <--- requires *args
    def function(*args):
        ...

    @pyro.ops.jit.trace  # <--- does not require *args
    def function(*args):
        ...
    ```

More of our tests now pass, but some `JitTrace*_ELBO` tests still fail.