### PR TITLE
bump travis docs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
               #- make scrub;
               #  git diff-index --quiet HEAD
         - stage: auxiliary modules
-          python: 2.7
+          python: 3.5
           env: STAGE=docs
           script:
               - pip install -r docs/requirements.txt

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -30,10 +30,11 @@ class LSH(object):
         >>> lsh.add('a', a)
         >>> lsh.add('b', b)
         >>> lsh.add('c', c)
-        >>> lsh.nearby('a') # even though c is within 2radius of a
+        >>> # even though c is within 2radius of a
+        >>> lsh.nearby('a') # doctest: +SKIP
         {'b'}
-        >>> lsh.nearby('b')
-        {'c', 'a'}
+        >>> lsh.nearby('b') # doctest: +SKIP
+        {'a', 'c'}
         >>> lsh.remove('b')
         >>> lsh.nearby('a')
         set()

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -31,12 +31,12 @@ class LSH(object):
         >>> lsh.add('b', b)
         >>> lsh.add('c', c)
         >>> lsh.nearby('a') # even though c is within 2radius of a
-        set(['b'])
+        {'b'}
         >>> lsh.nearby('b')
-        set(['a', 'c'])
+        {'c', 'a'}
         >>> lsh.remove('b')
         >>> lsh.nearby('a')
-        set([])
+        set()
 
 
     :param float radius: Scaling parameter used in hash function. Determines the size of the neighbourhood.


### PR DESCRIPTION
[sphinx doesnt support ABC in python 2](https://github.com/sphinx-doc/sphinx/issues/4059) which we need. testing to see if this fixes the broken doctests. 

**this will require everyone developing pyro to upgrade sphinx to** `1.7.6`