### PR TITLE
Separate models from examples/tests; benchmarking script

### DIFF
--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -29,7 +29,7 @@ information from actually performing the experiment.
 For details of the implementation of average posterior entropy estimation, see
 the docs for :func:`pyro.contrib.oed.eig.vi_ape`.
 
-We recommend the technical report from Long Ouyang et al [3] as an introduction
+We recommend the technical report from Long Ouyang et al [2] as an introduction
 to optimal experiment design within probabilistic programs.
 
 [1] ["Bayesian Regression"](http://pyro.ai/examples/bayesian_regression.html)

--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -2,10 +2,8 @@ import argparse
 from functools import partial
 import torch
 from torch.distributions import constraints
-import numpy as np
 
 import pyro
-import pyro.distributions as dist
 from pyro import optim
 from pyro.infer import TraceEnum_ELBO
 from pyro.contrib.oed.eig import vi_ape
@@ -46,7 +44,7 @@ p = 2    # number of features
 prior_sds = torch.tensor([10., 2.5])
 
 # Model and guide using known obs_sd
-model = partial(bayesian_linear_model, w_mean=torch.tensor(0.), 
+model = partial(bayesian_linear_model, w_mean=torch.tensor(0.),
                 w_sqrtlambda=1/prior_sds, obs_sd=torch.tensor(1.))
 guide = partial(normal_inv_gamma_guide, obs_sd=torch.tensor(1.))
 
@@ -66,6 +64,7 @@ def estimated_ape(ns, num_vi_steps):
         is_parameters={"num_samples": 1}
     )
     return est_ape
+
 
 def true_ape(ns):
     """Analytic APE"""

--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -58,7 +58,7 @@ def estimated_ape(ns, num_vi_steps):
         observation_labels="y",
         vi_parameters={
             "guide": guide,
-            "optim": optim.Adam({"lr": 0.0025}),
+            "optim": optim.Adam({"lr": 0.05}),
             "loss": TraceEnum_ELBO(strict_enumeration_warning=False).differentiable_loss,
             "num_steps": num_vi_steps},
         is_parameters={"num_samples": 1}

--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -1,4 +1,5 @@
 import argparse
+from functools import partial
 import torch
 from torch.distributions import constraints
 import numpy as np
@@ -11,6 +12,10 @@ from pyro.contrib.oed.eig import vi_ape
 import pyro.contrib.gp as gp
 
 from gp_bayes_opt import GPBayesOptimizer
+from models.bayes_linear import (
+    bayesian_linear_model, normal_inv_gamma_guide, group_assignment_matrix,
+    analytic_posterior_entropy
+)
 
 """
 Example builds on the Bayesian regression tutorial [1]. It demonstrates how
@@ -37,78 +42,40 @@ to optimal experiment design within probabilistic programs.
 
 # Set up regression model dimensions
 N = 100  # number of participants
-p_treatments = 2  # number of treatment groups
-p = p_treatments  # number of features
-prior_stdevs = torch.tensor([10., 2.5])
+p = 2    # number of features
+prior_sds = torch.tensor([10., 2.5])
 
-softplus = torch.nn.functional.softplus
-
-
-def model(design):
-    # Allow batching of designs
-    loc_shape = list(design.shape)
-    loc_shape[-2] = 1
-    loc = torch.zeros(loc_shape)
-    scale = prior_stdevs
-    # Place a normal prior on the regression coefficient
-    # w is 1 x p: hence use .independent(2)
-    w_prior = dist.Normal(loc, scale).independent(2)
-    w = pyro.sample('w', w_prior).transpose(-1, -2)
-
-    # Run the regressor forward conditioned on inputs
-    prediction_mean = torch.matmul(design, w).squeeze(-1)
-    # y is an n-vector: hence use .independent(1)
-    pyro.sample("y", dist.Normal(prediction_mean, 1).independent(1))
+# Model and guide using known obs_sd
+model = partial(bayesian_linear_model, w_mean=torch.tensor(0.), 
+                w_sqrtlambda=1/prior_sds, obs_sd=torch.tensor(1.))
+guide = partial(normal_inv_gamma_guide, obs_sd=torch.tensor(1.))
 
 
-def guide(design):
-    # Guide defines a Gaussian family for `w`
-    # The true posterior for `w` is within this family
-    # In this case, variational inference will be exact
-    loc_shape = list(design.shape)
-    loc_shape[-2] = 1
-    # define our variational parameters
-    w_loc = torch.zeros(loc_shape)
-    # note that we initialize our scales to be pretty narrow
-    w_sig = -3*torch.ones(loc_shape)
-    # register learnable params in the param store
-    mw_param = pyro.param("guide_mean_weight", w_loc)
-    sw_param = softplus(pyro.param("guide_scale_weight", w_sig))
-    # guide distributions for w
-    w_dist = dist.Normal(mw_param, sw_param).independent(2)
-    pyro.sample('w', w_dist)
+def estimated_ape(ns, num_vi_steps):
+    designs = [group_assignment_matrix(torch.tensor([n1, N-n1])) for n1 in ns]
+    X = torch.stack(designs)
+    est_ape = vi_ape(
+        model,
+        X,
+        observation_labels="y",
+        vi_parameters={
+            "guide": guide,
+            "optim": optim.Adam({"lr": 0.0025}),
+            "loss": TraceEnum_ELBO(strict_enumeration_warning=False).differentiable_loss,
+            "num_steps": num_vi_steps},
+        is_parameters={"num_samples": 1}
+    )
+    return est_ape
 
-
-def design_to_matrix(design):
-    """Converts a one-dimensional tensor listing group sizes into a
-    two-dimensional binary tensor of indicator variables.
-
-    :return: A :math:`n \times p` binary matrix where :math:`p` is
-        the length of `design` and :math:`n` is its sum. There are
-        :math:`n_i` ones in the :math:`i`th column.
-    :rtype: torch.tensor
-
-    """
-    n, p = int(torch.sum(design)), int(design.size()[0])
-    X = torch.zeros(n, p)
-    t = 0
-    for col, i in enumerate(design):
-        i = int(i)
-        if i > 0:
-            X[t:t+i, col] = 1.
-        t += i
-    if t < n:
-        X[t:, -1] = 1.
-    return X
-
-
-def analytic_posterior_entropy(prior_cov, x):
-    # Use some kernel trick magic
-    SigmaXX = prior_cov.mm(x.t().mm(x))
-    posterior_cov = prior_cov - torch.inverse(
-        SigmaXX + torch.eye(p)).mm(SigmaXX.mm(prior_cov))
-    y = 0.5*torch.logdet(2*np.pi*np.e*posterior_cov)
-    return y
+def true_ape(ns):
+    """Analytic APE"""
+    true_ape = []
+    prior_cov = torch.diag(prior_sds**2)
+    designs = [group_assignment_matrix(torch.tensor([n1, N-n1])) for n1 in ns]
+    for i in range(len(ns)):
+        x = designs[i]
+        true_ape.append(analytic_posterior_entropy(prior_cov, x, torch.tensor(1.)))
+    return torch.tensor(true_ape)
 
 
 def main(num_vi_steps, num_acquisitions, num_bo_steps):
@@ -116,35 +83,12 @@ def main(num_vi_steps, num_acquisitions, num_bo_steps):
     pyro.set_rng_seed(42)
     pyro.clear_param_store()
 
-    def estimated_ape(ns):
-        designs = [design_to_matrix(torch.tensor([n1, N-n1])) for n1 in ns]
-        X = torch.stack(designs)
-        est_ape = vi_ape(
-            model,
-            X,
-            observation_labels="y",
-            vi_parameters={
-                "guide": guide,
-                "optim": optim.Adam({"lr": 0.0025}),
-                "loss": TraceEnum_ELBO(strict_enumeration_warning=False).differentiable_loss,
-                "num_steps": num_vi_steps},
-            is_parameters={"num_samples": 1}
-        )
-        return est_ape
+    est_ape = partial(estimated_ape, num_vi_steps=num_vi_steps)
+    est_ape.__doc__ = "Estimated APE by VI"
 
-    def true_ape(ns):
-        true_ape = []
-        prior_cov = torch.diag(prior_stdevs**2)
-        designs = [design_to_matrix(torch.tensor([n1, N-n1])) for n1 in ns]
-        for i in range(len(ns)):
-            x = designs[i]
-            true_ape.append(analytic_posterior_entropy(prior_cov, x))
-        return torch.tensor(true_ape)
-
-    for f in [true_ape, estimated_ape]:
+    for f in [true_ape, est_ape]:
         X = torch.tensor([25., 75.])
         y = f(X)
-        pyro.clear_param_store()
         gpmodel = gp.models.GPRegression(
             X, y, gp.kernels.Matern52(input_dim=1, lengthscale=torch.tensor(5.)),
             noise=torch.tensor(0.1), jitter=1e-6)
@@ -152,8 +96,10 @@ def main(num_vi_steps, num_acquisitions, num_bo_steps):
         gpbo = GPBayesOptimizer(constraints.interval(0, 100), gpmodel,
                                 num_acquisitions=num_acquisitions)
         for i in range(num_bo_steps):
+            pyro.clear_param_store()
             result = gpbo.get_step(f, None)
 
+        print(f.__doc__)
         print(result)
 
 

--- a/examples/contrib/oed/eig_estimation_benchmarking.py
+++ b/examples/contrib/oed/eig_estimation_benchmarking.py
@@ -48,7 +48,8 @@ def lm_true_ape(X_lm, sqrtlambda, obs_sd):
 
 
 @pytest.mark.parametrize("arglist",
-    [[(X_lm, vi_for_lm, torch.tensor([.1, .4]), None, torch.tensor(10.), torch.tensor(10.), 5000, 10)],
+    [# Warning: do not do this, not a mean-field guide!
+     #[(X_lm, vi_for_lm, torch.tensor([.1, .4]), None, torch.tensor(10.), torch.tensor(10.), 5000, 10)],
      [(X_lm, lm_true_ape, torch.tensor([.1, .4]), torch.tensor(1.)),
       (X_lm, vi_for_lm, torch.tensor([.1, .4]), torch.tensor(1.), None, None, 5000, 1)],
      [(X_lm, lm_true_ape, torch.tensor([.1, 10.]), torch.tensor(1.)),

--- a/examples/contrib/oed/eig_estimation_benchmarking.py
+++ b/examples/contrib/oed/eig_estimation_benchmarking.py
@@ -1,0 +1,78 @@
+import argparse
+from functools import partial
+import torch
+from torch.distributions import constraints
+
+import pyro
+from pyro import optim
+from pyro.infer import TraceEnum_ELBO
+from pyro.contrib.oed.eig import vi_ape
+
+from models.bayes_linear import (
+    bayesian_linear_model, normal_inv_gamma_guide, group_assignment_matrix,
+    analytic_posterior_entropy
+)
+
+# Set up regression model dimensions
+N = 100  # number of participants
+p = 2    # number of features
+prior_sds = torch.tensor([10., 2.5])
+
+# Model and guide using known obs_sd
+model = partial(bayesian_linear_model, w_mean=torch.tensor(0.),
+                w_sqrtlambda=1/prior_sds, obs_sd=torch.tensor(1.))
+guide = partial(normal_inv_gamma_guide, obs_sd=torch.tensor(1.))
+
+
+def estimated_ape(ns, model, guide, num_vi_steps):
+    designs = [group_assignment_matrix(torch.tensor([n1, N-n1])) for n1 in ns]
+    X = torch.stack(designs)
+    est_ape = vi_ape(
+        model,
+        X,
+        observation_labels="y",
+        vi_parameters={
+            "guide": guide,
+            "optim": optim.Adam({"lr": 0.0025}),
+            "loss": TraceEnum_ELBO(strict_enumeration_warning=False).differentiable_loss,
+            "num_steps": num_vi_steps},
+        is_parameters={"num_samples": 1}
+    )
+    return est_ape
+
+
+def true_ape(ns, model, guide):
+    """Analytic APE"""
+    true_ape = []
+    prior_cov = torch.diag(prior_sds**2)
+    designs = [group_assignment_matrix(torch.tensor([n1, N-n1])) for n1 in ns]
+    for i in range(len(ns)):
+        x = designs[i]
+        true_ape.append(analytic_posterior_entropy(prior_cov, x, torch.tensor(1.)))
+    return torch.tensor(true_ape)
+
+
+def main(num_vi_steps, num_acquisitions, num_bo_steps):
+
+    pyro.set_rng_seed(42)
+    pyro.clear_param_store()
+
+    est_ape = partial(estimated_ape, num_vi_steps=num_vi_steps)
+    est_ape.__doc__ = "Estimated APE by VI"
+
+    # todo timer
+    for f in [true_ape, est_ape]:
+        X = torch.tensor(range(0, N, 5))
+        y = f(X)
+        print(y)
+        print(timer)
+
+
+if __name__ == "__main__":
+    # todo change
+    parser = argparse.ArgumentParser(description="A/B test experiment design using VI")
+    parser.add_argument("-n", "--num-vi-steps", nargs="?", default=5000, type=int)
+    parser.add_argument('--num-acquisitions', nargs="?", default=10, type=int)
+    parser.add_argument('--num-bo-steps', nargs="?", default=6, type=int)
+    args = parser.parse_args()
+    main(args.num_vi_steps, args.num_acquisitions, args.num_bo_steps)

--- a/examples/contrib/oed/gp_bayes_opt.py
+++ b/examples/contrib/oed/gp_bayes_opt.py
@@ -99,7 +99,7 @@ class GPBayesOptimizer(pyro.optim.multi.MultiOptimizer):
         :param int num_acquisitions: the number of points to generate
         :param dict opt_params: additional parameters for optimization
             routines
-        :return: a tensor of points to evaluate `self.f` at
+        :return: a tensor of points to evaluate `loss` at
         :rtype: torch.Tensor
         """
 

--- a/examples/contrib/oed/models/bayes_linear.py
+++ b/examples/contrib/oed/models/bayes_linear.py
@@ -1,0 +1,130 @@
+import argparse
+import warnings
+import torch
+from torch.nn.functional import softplus
+from torch.distributions import constraints
+import numpy as np
+
+import pyro
+import pyro.distributions as dist
+from pyro import optim
+from pyro.infer import TraceEnum_ELBO
+from pyro.contrib.oed.eig import vi_ape
+import pyro.contrib.gp as gp
+
+
+def bayesian_linear_model(design, w_mean, w_sqrtlambda, obs_sd=None, 
+                          alpha_0=None, beta_0=None):
+    """A Bayesian linear model.
+
+    If `obs_sd` is passed, the regression coefficient `w` is samples from
+    a Gaussian with mean `w_mean` and sds `obs_sd / w_sqrtlambda`. 
+    These tensors may be scalar or `p`-dimensional vectors. 
+    `X` is then sampled from a Gaussian with mean `Xw` and sd `obs_sd`.
+
+    If `obs_sd=None`, the observation variance is sampled from an inverse
+    Gamma distribution with parameters `alpha_0` and `beta_0`.
+    Then `w` is sampled from a Gaussian with mean `w_mean` and sds given by
+    `obs_sd / w_sqrtlambda` (cf. `lambda` in the NIG family).
+    Finally, `X` is Gaussian with mean `Xw` and sd `sigma`.
+    """
+    if obs_sd is None:
+        # First, sample tau (observation precision)
+        tau_shape = design.shape[:-2]
+        # Global variable
+        tau_prior = dist.Gamma(alpha=alpha_0.expand(tau_shape), 
+                               beta=beta_0.expand(tau_shape))
+        tau = pyro.sample("tau", tau_prior)
+        obs_sd = 1./torch.sqrt(tau)
+
+    elif alpha_0 is not None or beta_0 is not None:
+        warnings.warn("Values of `alpha_0` and `beta_0` unused becased"
+                      "`obs_sd` was specified already.")
+
+    # Allow batching of designs
+    # design is batch x n x p
+    loc_shape = list(design.shape)
+    loc_shape[-2] = 1
+    # loc is batch x 1 x p
+    loc = w_mean.expand(loc_shape)
+    # Place a normal prior on the regression coefficient
+    w_prior = dist.Normal(loc, obs_sd / w_sqrtlambda).independent(2)
+    w = pyro.sample('w', w_prior).transpose(-1, -2)
+
+    # Run the regressor forward conditioned on inputs
+    prediction_mean = torch.matmul(design, w).squeeze(-1)
+    # y is an n-vector: hence use .independent(1)
+    pyro.sample("y", dist.Normal(prediction_mean, obs_sd).independent(1))
+
+
+def normal_inv_gamma_guide(design, obs_sd):
+    """Normal inverse Gamma family guide.
+
+    If `obs_sd` is known, this is a two-parameter family with separate parameters
+    for each batch. `w` is sampled from a Gaussian with mean `mw_param` and
+    sd `obs_sd / lambda_param` and the two parameters `mw_param` and `lambda_param`
+    are learned.
+
+    If `obs_sd=None`, this is a four-parameter family. The observation precision 
+    `tau` is sampled from a Gamma distribution with parameters `alpha`, `beta` 
+    (separate for each batch). We let `obs_sd = 1./torch.sqrt(tau)` and then
+    proceed as above.
+    """
+    if obs_sd is None:
+        # First, sample tau (observation precision)
+        tau_shape = design.shape[:-2]
+        alpha = softplus(pyro.param("invsoftplus_alpha", torch.zeros(tau_shape)))
+        beta = softplus(pyro.param("invsoftplus_beta", torch.zeros(tau_shape)))
+        # Global variable
+        tau_prior = dist.Gamma(alpha=alpha, beta=beta)
+        tau = pyro.sample("tau", tau_prior)
+        obs_sd = 1./torch.sqrt(tau)
+
+    loc_shape = list(design.shape)
+    loc_shape[-2] = 1
+
+    # Set up mu and lambda
+    mw_param = pyro.param("guide_mean", torch.zeros(loc_shape))
+    sqrtlambda_param = softplus(pyro.param("guide_sqrtlambda", 
+                                           3.*torch.ones(loc_shape)))
+    # guide distributions for w
+    w_dist = dist.Normal(mw_param, obs_sd / sqrtlambda_param).independent(2)
+    pyro.sample('w', w_dist)
+
+
+def group_assignment_matrix(design):
+    """Converts a one-dimensional tensor listing group sizes into a
+    two-dimensional binary tensor of indicator variables.
+
+    :return: A :math:`n \times p` binary matrix where :math:`p` is
+        the length of `design` and :math:`n` is its sum. There are
+        :math:`n_i` ones in the :math:`i`th column.
+    :rtype: torch.tensor
+
+    """
+    n, p = int(torch.sum(design)), int(design.size()[0])
+    X = torch.zeros(n, p)
+    t = 0
+    for col, i in enumerate(design):
+        i = int(i)
+        if i > 0:
+            X[t:t+i, col] = 1.
+        t += i
+    if t < n:
+        X[t:, -1] = 1.
+    return X
+
+
+def analytic_posterior_entropy(prior_cov, x, obs_sd):
+    """
+    Given a prior covariance matrix and a design matrix `x`, 
+    returns the entropy of the posterior under a Bayesian
+    linear regression model with design `x` and observation
+    noise `obs_sd`.
+    """
+    # Use some kernel trick magic
+    p = prior_cov.shape[-1]
+    SigmaXX = prior_cov.mm(x.t().mm(x))
+    posterior_cov = prior_cov - torch.inverse(
+        SigmaXX + (obs_sd**2)*torch.eye(p)).mm(SigmaXX.mm(prior_cov))
+    return 0.5*torch.logdet(2*np.pi*np.e*posterior_cov)


### PR DESCRIPTION
This PR does several things:
 - allow unknown covariance in linear models and introduce the normal inverse gamma guide family for inference
 - reorganize the code to separate models from examples
 - add a benchmarking script - right now comparing VI against exact answers only