### PR TITLE
Fix bug in TransformedDistribution.expand

### DIFF
--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -284,8 +284,7 @@ class StudentT(torch.distributions.StudentT, TorchDistributionMixin):
 
 class TransformedDistribution(torch.distributions.TransformedDistribution, TorchDistributionMixin):
     def expand(self, batch_shape):
-        base_dist = self.base_dist.expand(batch_shape)
-        return TransformedDistribution(base_dist, self.transforms)
+        return super(TransformedDistribution, self).expand(batch_shape)
 
 
 class Uniform(torch.distributions.Uniform, TorchDistributionMixin):

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -107,6 +107,8 @@ class TorchDistributionMixin(Distribution):
         :return: An expanded version of this distribution.
         :rtype: :class:`ReshapedDistribution`
         """
+        if not sample_shape:
+            return self
         return ReshapedDistribution(self, sample_shape=sample_shape)
 
     def reshape(self, sample_shape=None, extra_event_dims=None):

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -130,19 +130,16 @@ def test_distribution_validate_args(dist_class, args, validate_args):
 
 
 def check_sample_shapes(small, large):
-    if isinstance(small, dist.LogNormal) or (
-            isinstance(small, ReshapedDistribution) and
-            isinstance(small.base_dist, dist.LogNormal)):
+    dist_instance = small.base_dist if isinstance(small, ReshapedDistribution) \
+        else small
+    if isinstance(dist_instance, (dist.LogNormal, dist.LowRankMultivariateNormal, dist.VonMises)):
         # Ignore broadcasting bug in LogNormal:
         # https://github.com/pytorch/pytorch/pull/7269
         return
-    try:
-        x = small.sample()
-        assert_equal(small.log_prob(x).expand(large.batch_shape), large.log_prob(x))
-        x = large.sample()
-        assert_equal(small.log_prob(x), large.log_prob(x))
-    except NotImplementedError:
-        pass
+    x = small.sample()
+    assert_equal(small.log_prob(x).expand(large.batch_shape), large.log_prob(x))
+    x = large.sample()
+    assert_equal(small.log_prob(x), large.log_prob(x))
 
 
 @pytest.mark.parametrize('sample_shape', [(), (2,), (2, 3)])


### PR DESCRIPTION
All calls to pyro distribution's `.expand` should have the same type as the distribution class itself or `ReshapedDistribution`. This fixes a bug in TransformedDistribution so that this invariant is maintained. With this change `HalfCauchy.expand` should return either an instance of `HalfCauchy` or `ReshapedDistribution` so that calls to methods like `.log_prob` are delegated to `HalfCauchy` (and not `TransformedDistribution`), as expected.

Bug discovered by @fritzo in #1289.