### PR TITLE
ignores for code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "pyro/docutil.py"
+  - "pyro/logger.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
         - python: 2.7
           env: STAGE=examples
           script:
-              - pytest -vs --stage test_examples
+              - pytest -vs --cov=pyro --stage test_examples
               - grep -l smoke_test tutorial/source/*.ipynb | xargs grep -L 'smoke_test = False' \
                   | CI=1 xargs pytest -vx --nbval-lax --current-env
         - python: 3.5
@@ -72,7 +72,7 @@ jobs:
           script: pytest -vs --cov=pyro --stage unit --durations 20
         - python: 3.5
           env: STAGE=examples
-          script: pytest -vs --stage test_examples
+          script: pytest -vs --cov=pyro --stage test_examples
         - stage: integration test
           python: 2.7
           env: STAGE=integration_batch_1


### PR DESCRIPTION
increasing that code coverage. we're better than 89%

optimizers that are untested are used in examples. presumably theyd be covered if we ran coverage reports in test_examples. (verifying by running the CI, cant do it locally...)