### PR TITLE
Refactor test_examples.py to allow xfailing examples

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -14,57 +14,50 @@ pytestmark = pytest.mark.stage('test_examples')
 
 
 CPU_EXAMPLES = [
-    ['air/main.py', '--num-steps=1'],
-    ['baseball.py', '--num-samples=200', '--warmup-steps=100'],
-    ['bayesian_regression.py', '--num-epochs=1'],
-    ['contrib/autoname/scoping_mixture.py', '--num-epochs=1'],
-    ['contrib/autoname/mixture.py', '--num-epochs=1'],
-    ['contrib/autoname/tree_data.py', '--num-epochs=1'],
-    ['contrib/gp/sv-dkl.py', '--epochs=1', '--num-inducing=4'],
-    ['contrib/oed/ab_test.py', '--num-vi-steps=1000', '--num-acquisitions=2'],
-    ['dmm/dmm.py', '--num-epochs=1'],
-    ['dmm/dmm.py', '--num-epochs=1', '--num-iafs=1'],
-    ['eight_schools/mcmc.py', '--num-samples=500', '--warmup-steps=100'],
-    ['eight_schools/svi.py', '--num-epochs=1'],
-    ['inclined_plane.py', '--num-samples=1'],
-    ['rsa/generics.py', '--num-samples=10'],
-    ['rsa/hyperbole.py', '--price=10000'],
-    ['rsa/schelling.py', '--num-samples=10'],
-    ['rsa/schelling_false.py', '--num-samples=10'],
-    ['rsa/semantic_parsing.py', '--num-samples=10'],
-    ['sparse_gamma_def.py', '--num-epochs=1'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1', '--aux-loss'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=parallel'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=sequential'],
-    ['vae/vae.py', '--num-epochs=1'],
-    ['vae/vae_comparison.py', '--num-epochs=1'],
+    'air/main.py --num-steps=1',
+    'baseball.py --num-samples=200 --warmup-steps=100',
+    'bayesian_regression.py --num-epochs=1',
+    'contrib/autoname/scoping_mixture.py --num-epochs=1',
+    'contrib/autoname/mixture.py --num-epochs=1',
+    'contrib/autoname/tree_data.py --num-epochs=1',
+    'contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4',
+    'contrib/oed/ab_test.py --num-vi-steps=1000 --num-acquisitions=2',
+    'dmm/dmm.py --num-epochs=1',
+    'dmm/dmm.py --num-epochs=1 --num-iafs=1',
+    'eight_schools/mcmc.py --num-samples=500 --warmup-steps=100',
+    'eight_schools/svi.py --num-epochs=1',
+    'inclined_plane.py --num-samples=1',
+    'rsa/generics.py --num-samples=10',
+    'rsa/hyperbole.py --price=10000',
+    'rsa/schelling.py --num-samples=10',
+    'rsa/schelling_false.py --num-samples=10',
+    'rsa/semantic_parsing.py --num-samples=10',
+    'sparse_gamma_def.py --num-epochs=1',
+    'vae/ss_vae_M2.py --num-epochs=1',
+    'vae/ss_vae_M2.py --num-epochs=1 --aux-loss',
+    'vae/ss_vae_M2.py --num-epochs=1 --enum-discrete=parallel',
+    'vae/ss_vae_M2.py --num-epochs=1 --enum-discrete=sequential',
+    'vae/vae.py --num-epochs=1',
+    'vae/vae_comparison.py --num-epochs=1',
 ]
 
 CUDA_EXAMPLES = [
-    ['air/main.py', '--num-steps=1', '--cuda'],
-    ['bayesian_regression.py', '--num-epochs=1', '--cuda'],
-    ['contrib/gp/sv-dkl.py', '--epochs=1', '--num-inducing=4', '--cuda'],
-    ['dmm/dmm.py', '--num-epochs=1', '--cuda'],
-    ['dmm/dmm.py', '--num-epochs=1', '--num-iafs=1', '--cuda'],
-    ['vae/vae.py', '--num-epochs=1', '--cuda'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1', '--cuda'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1', '--aux-loss', '--cuda'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=parallel', '--cuda'],
-    ['vae/ss_vae_M2.py', '--num-epochs=1', '--enum-discrete=sequential', '--cuda'],
+    'air/main.py --num-steps=1 --cuda',
+    'bayesian_regression.py --num-epochs=1 --cuda',
+    'contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --cuda',
+    'dmm/dmm.py --num-epochs=1 --cuda',
+    'dmm/dmm.py --num-epochs=1 --num-iafs=1 --cuda',
+    'vae/vae.py --num-epochs=1 --cuda',
+    'vae/ss_vae_M2.py --num-epochs=1 --cuda',
+    'vae/ss_vae_M2.py --num-epochs=1 --aux-loss --cuda',
+    'vae/ss_vae_M2.py --num-epochs=1 --enum-discrete=parallel --cuda',
+    'vae/ss_vae_M2.py --num-epochs=1 --enum-discrete=sequential --cuda',
 ]
-
-CPU_EXAMPLES = [(example[0], example[1:]) for example in sorted(CPU_EXAMPLES)]
-CUDA_EXAMPLES = [(example[0], example[1:]) for example in sorted(CUDA_EXAMPLES)]
-
-
-def make_ids(examples):
-    return ['{} {}'.format(example, ' '.join(args)) for example, args in examples]
 
 
 def test_coverage():
-    cpu_tests = set([name for name, _ in CPU_EXAMPLES])
-    cuda_tests = set([name for name, _ in CUDA_EXAMPLES])
+    cpu_tests = set((e if isinstance(e, str) else e.values[0]).split()[0] for e in CPU_EXAMPLES)
+    cuda_tests = set((e if isinstance(e, str) else e.values[0]).split()[0] for e in CUDA_EXAMPLES)
     for root, dirs, files in os.walk(EXAMPLES_DIR):
         for basename in files:
             if not basename.endswith('.py'):
@@ -80,16 +73,20 @@ def test_coverage():
                     pytest.fail('Example: {} not covered by CUDA_TESTS.'.format(example))
 
 
-@pytest.mark.parametrize('example,args', CPU_EXAMPLES, ids=make_ids(CPU_EXAMPLES))
-def test_cpu(example, args):
-    logger.info('Running:\npython examples/{} {}'.format(example, ' '.join(args)))
-    example = os.path.join(EXAMPLES_DIR, example)
-    check_call([sys.executable, example] + args)
+@pytest.mark.parametrize('example', CPU_EXAMPLES)
+def test_cpu(example):
+    logger.info('Running:\npython examples/{}'.format(example))
+    example = example.split()
+    filename, args = example[0], example[1:]
+    filename = os.path.join(EXAMPLES_DIR, filename)
+    check_call([sys.executable, filename] + args)
 
 
 @requires_cuda
-@pytest.mark.parametrize('example,args', CUDA_EXAMPLES, ids=make_ids(CUDA_EXAMPLES))
-def test_cuda(example, args):
-    logger.info('Running:\npython examples/{} {}'.format(example, ' '.join(args)))
-    example = os.path.join(EXAMPLES_DIR, example)
-    check_call([sys.executable, example] + args)
+@pytest.mark.parametrize('example', CUDA_EXAMPLES)
+def test_cuda(example):
+    logger.info('Running:\npython examples/{}'.format(example))
+    example = example.split()
+    filename, args = example[0], example[1:]
+    filename = os.path.join(EXAMPLES_DIR, filename)
+    check_call([sys.executable, filename] + args)


### PR DESCRIPTION
This simplifies test_examples.py to make it compatible with per-parameter xfail markers.

## Tested

- added `xfail_param` annotations [in a branch](https://github.com/uber/pyro/blob/fc9a4a7/tests/test_examples.py#L42) and ran locally.