### PR TITLE
add coverage config file

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,8 @@
 ignore:
   - "pyro/docutil.py"
   - "pyro/logger.py"
+
+coverage:
+  range: 60..95
+  round: nearest
+  precision: 2

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [report]
 exclude_lines =
     pragma: no cover
-    def backward  # these are run via Pytorch
+    def backward
     raise AssertionError
     raise NotImplementedError
     raise ValueError

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    def backward  # these are run via Pytorch
+    raise AssertionError
+    raise NotImplementedError
+    raise ValueError
+    except NotImplementedError
+    except ImportError
+    except KeyError
+    except TypeError
+    warnings\.warn.*
+    warn_if.*
+    if __name__ == .__main__.:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,32 +60,32 @@ jobs:
         - stage: unit test
           python: 2.7
           env: STAGE=unit
-          script: pytest -vs --cov=pyro --stage unit --durations 20
+          script: pytest -vs --cov=pyro --cov-config .coveragerc --stage unit --durations 20
         - python: 2.7
           env: STAGE=examples
           script:
-              - pytest -vs --cov=pyro --stage test_examples
+              - pytest -vs --cov=pyro --cov-config .coveragerc --stage test_examples
               - grep -l smoke_test tutorial/source/*.ipynb | xargs grep -L 'smoke_test = False' \
                   | CI=1 xargs pytest -vx --nbval-lax --current-env
         - python: 3.5
           env: STAGE=unit
-          script: pytest -vs --cov=pyro --stage unit --durations 20
+          script: pytest -vs --cov=pyro --cov-config .coveragerc --stage unit --durations 20
         - python: 3.5
           env: STAGE=examples
-          script: pytest -vs --cov=pyro --stage test_examples
+          script: pytest -vs --cov=pyro --cov-config .coveragerc --stage test_examples
         - stage: integration test
           python: 2.7
           env: STAGE=integration_batch_1
-          script: pytest -vs --cov=pyro --stage integration_batch_1 --durations 10
+          script: pytest -vs --cov=pyro --cov-config .coveragerc --stage integration_batch_1 --durations 10
         - python: 2.7
           env: STAGE=integration_batch_2
-          script: pytest -vs --cov=pyro --stage integration_batch_2 --durations 10
+          script: pytest -vs --cov=pyro --cov-config .coveragerc --stage integration_batch_2 --durations 10
         - python: 3.5
           env: STAGE=integration_batch_1
-          script: pytest -vs --cov=pyro --stage integration_batch_1 --durations 10
+          script: pytest -vs --cov=pyro --cov-config .coveragerc --stage integration_batch_1 --durations 10
         - python: 3.5
           env: STAGE=integration_batch_2
-          script: pytest -vs --cov=pyro --stage integration_batch_2 --durations 10
+          script: pytest -vs --cov=pyro --cov-config .coveragerc --stage integration_batch_2 --durations 10
 
 after_success:
           - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
generating accurate coverage reports. all the ignores are:
- warnings
- errors (this is standard in pytest-cov config files)
- backward implementations (this is tested but the control flow goes to pytorch then back to pyro, which cant be checked by static analysis)
- main methods (we actually test this, though copied from the pytest-cov example config)

testing on CI