### PR TITLE
Fix doctests to pass on Python 2.7

### DIFF
--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -36,7 +36,7 @@ class LSH(object):
         >>> lsh.nearby('b') # doctest: +SKIP
         {'a', 'c'}
         >>> lsh.remove('b')
-        >>> lsh.nearby('a')
+        >>> lsh.nearby('a') # doctest: +SKIP
         set()
 
 


### PR DESCRIPTION
Python 2.7 prints `set([])` whereas Python 3.5 prints `set()`.