### PR TITLE
Use JIT traced potential energy computation in HMC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ test-cuda: lint FORCE
 test-jit: FORCE
 	@echo See jit.log
 	pytest -v -n auto --tb=short --runxfail tests/infer/test_jit.py tests/test_examples.py::test_jit | tee jit.log
+	pytest -v -n auto --tb=short --runxfail tests/infer/mcmc/test_hmc.py tests/infer/mcmc/test_nuts.py \
+		-k JIT=True | tee -a jit.log
 
 clean: FORCE
 	git clean -dfx -e pyro-egg.info

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -270,7 +270,7 @@ if __name__ == "__main__":
     parser.add_argument("-n", "--num-samples", nargs="?", default=1200, type=int)
     parser.add_argument("--warmup-steps", nargs='?', default=300, type=int)
     parser.add_argument("--rng_seed", nargs='?', default=0, type=int)
-    parser.add_argument('--jit', action='store_true', default=True,
+    parser.add_argument('--jit', action='store_true', default=False,
                         help='use PyTorch jit')
     args = parser.parse_args()
     main(args)

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -218,7 +218,7 @@ def main(args):
     baseball_dataset = pd.read_csv(DATA_URL, "\t")
     train, _, player_names = train_test_split(baseball_dataset)
     at_bats, hits = train[:, 0], train[:, 1]
-    nuts_kernel = NUTS(conditioned_model, adapt_step_size=True)
+    nuts_kernel = NUTS(conditioned_model, adapt_step_size=True, jit_compile=args.jit)
     logging.info("Original Dataset:")
     logging.info(baseball_dataset)
 
@@ -270,5 +270,7 @@ if __name__ == "__main__":
     parser.add_argument("-n", "--num-samples", nargs="?", default=1200, type=int)
     parser.add_argument("--warmup-steps", nargs='?', default=300, type=int)
     parser.add_argument("--rng_seed", nargs='?', default=0, type=int)
+    parser.add_argument('--jit', action='store_true', default=True,
+                        help='use PyTorch jit')
     args = parser.parse_args()
     main(args)

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
                         help='number of MCMC samples (default: 1000)')
     parser.add_argument('--warmup-steps', type=int, default=1000,
                         help='number of MCMC samples for warmup (default: 1000)')
-    parser.add_argument('--jit', action='store_true', default=True)
+    parser.add_argument('--jit', action='store_true', default=False)
     args = parser.parse_args()
 
     main(args)

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -34,7 +34,7 @@ def conditioned_model(model, sigma, y):
 
 
 def main(args):
-    nuts_kernel = NUTS(conditioned_model, adapt_step_size=True)
+    nuts_kernel = NUTS(conditioned_model, adapt_step_size=True, jit_compile=args.jit)
     posterior = MCMC(nuts_kernel, num_samples=args.num_samples, warmup_steps=args.warmup_steps)\
         .run(model, data.sigma, data.y)
     marginal_mu_tau = EmpiricalMarginal(posterior, sites=["mu", "tau"])\
@@ -54,6 +54,7 @@ if __name__ == '__main__':
                         help='number of MCMC samples (default: 1000)')
     parser.add_argument('--warmup-steps', type=int, default=1000,
                         help='number of MCMC samples for warmup (default: 1000)')
+    parser.add_argument('--jit', action='store_true', default=True)
     args = parser.parse_args()
 
     main(args)

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -50,6 +50,9 @@ class HMC(TraceKernel):
     :param int max_iarange_nesting: Optional bound on max number of nested
         :func:`pyro.iarange` contexts. This is required if model contains
         discrete sample sites that can be enumerated over in parallel.
+    :param bool jit_compile: Optional parameter denoting whether to use
+        the PyTorch JIT to trace the log density computation, and use this
+        optimized executable trace in the integrator.
 
     Example:
 
@@ -78,7 +81,8 @@ class HMC(TraceKernel):
                  num_steps=None,
                  adapt_step_size=False,
                  transforms=None,
-                 max_iarange_nesting=float("inf")):
+                 max_iarange_nesting=float("inf"),
+                 jit_compile=False):
         # Wrap model in `poutine.enum` to enumerate over discrete latent sites.
         # No-op if model does not have any discrete latents.
         self.model = poutine.enum(config_enumerate(model, default="parallel"),
@@ -92,6 +96,7 @@ class HMC(TraceKernel):
             self.trajectory_length = 2 * math.pi  # from Stan
         self.num_steps = max(1, int(self.trajectory_length / self.step_size))
         self.adapt_step_size = adapt_step_size
+        self._jit_compile = jit_compile
         self._target_accept_prob = 0.8  # from Stan
 
         self.transforms = {} if transforms is None else transforms
@@ -121,6 +126,8 @@ class HMC(TraceKernel):
         return 0.5 * sum(x.pow(2).sum() for x in r.values())
 
     def _potential_energy(self, z):
+        if self._jit_compile:
+            return self._potential_energy_jit(z)
         # Since the model is specified in the constrained space, transform the
         # unconstrained R.V.s `z` to the constrained space.
         z_constrained = z.copy()
@@ -133,6 +140,32 @@ class HMC(TraceKernel):
             potential_energy += transform.log_abs_det_jacobian(z_constrained[name], z[name]).sum()
         return potential_energy
 
+    def _potential_energy_jit(self, z):
+        names, vals = zip(*sorted(z.items()))
+        if self._compiled_potential_fn:
+            return self._compiled_potential_fn(*vals)
+
+        @torch.jit.trace(*vals, optimize=True)
+        def wrapped(*zi):
+            print("called")
+            z_constrained = list(zi)
+            for i, name in enumerate(names):
+                if name in self.transforms:
+                    transform = self.transforms[name]
+                    z_constrained[i] = transform.inv(z_constrained[i])
+            z_constrained = dict(zip(names, z_constrained))
+            trace = self._get_trace(z_constrained)
+            potential_energy = -self._compute_trace_log_prob(trace)
+            # adjust by the jacobian for this transformation.
+            for i, name in enumerate(names):
+                if name in self.transforms:
+                    transform = self.transforms[name]
+                    potential_energy += transform.log_abs_det_jacobian(z_constrained[name], zi[i]).sum()
+            return potential_energy
+
+        self._compiled_potential_fn = wrapped
+        return self._compiled_potential_fn(*vals)
+
     def _energy(self, z, r):
         return self._kinetic_energy(r) + self._potential_energy(z)
 
@@ -141,6 +174,7 @@ class HMC(TraceKernel):
         self._accept_cnt = 0
         self._r_dist = OrderedDict()
         self._args = None
+        self._compiled_potential_fn = None
         self._kwargs = None
         self._prototype_trace = None
         self._adapt_phase = False

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -147,8 +147,8 @@ class HMC(TraceKernel):
 
         @torch.jit.trace(*vals, optimize=True)
         def wrapped(*zi):
-            print("called")
             z_constrained = list(zi)
+            # transform to constrained space.
             for i, name in enumerate(names):
                 if name in self.transforms:
                     transform = self.transforms[name]

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -138,7 +138,7 @@ class NUTS(HMC):
         else:
             diverging = (sliced_energy >= self._max_sliced_energy)
             delta_energy = energy_new - energy_current
-            accept_prob = (-delta_energy).exp().clamp(max=1)
+            accept_prob = (-delta_energy).exp().clamp(max=1.0)
         return _TreeInfo(z_new, r_new, z_grads, z_new, r_new, z_grads,
                          z_new, tree_size, False, diverging, accept_prob, 1)
 

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -56,6 +56,9 @@ class NUTS(HMC):
     :param int max_iarange_nesting: Optional bound on max number of nested
         :func:`pyro.iarange` contexts. This is required if model contains
         discrete sample sites that can be enumerated over in parallel.
+    :param bool jit_compile: Optional parameter denoting whether to use
+        the PyTorch JIT to trace the log density computation, and use this
+        optimized executable trace in the integrator.
 
     Example:
 
@@ -82,12 +85,14 @@ class NUTS(HMC):
                  step_size=None,
                  adapt_step_size=False,
                  transforms=None,
-                 max_iarange_nesting=float("inf")):
+                 max_iarange_nesting=float("inf"),
+                 jit_compile=False):
         super(NUTS, self).__init__(model,
                                    step_size,
                                    adapt_step_size=adapt_step_size,
                                    transforms=transforms,
-                                   max_iarange_nesting=max_iarange_nesting)
+                                   max_iarange_nesting=max_iarange_nesting,
+                                   jit_compile=jit_compile)
 
         self._max_tree_depth = 10  # from Stan
         # There are three conditions to stop doubling process:

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -289,7 +289,8 @@ def test_gamma_normal_with_dual_averaging(jit):
     assert_equal(posterior.mean, true_std, prec=0.05)
 
 
-@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+@pytest.mark.parametrize("jit", [False, mark_jit(True,
+                                                 marks=[pytest.mark.skip("FIXME: Slow on JIT.")])])
 def test_gaussian_mixture_model(jit):
     K, N = 3, 1000
 
@@ -315,8 +316,7 @@ def test_gaussian_mixture_model(jit):
     assert_equal(posterior[1], true_cluster_means, prec=0.2)
 
 
-@pytest.mark.parametrize("jit", [False, mark_jit(True,
-                                                 marks=[pytest.mark.skip("FIXME: Slow on JIT.")])])
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
 def test_bernoulli_latent_model(jit):
     @poutine.broadcast
     def model(data):

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -18,6 +18,16 @@ from tests.common import assert_equal
 logger = logging.getLogger(__name__)
 
 
+def mark_jit(*args, markers=[]):
+    jit_markers = markers + [
+        pytest.mark.skipif(torch.__version__ <= "0.4.1",
+                           reason="https://github.com/pytorch/pytorch/issues/10041#issuecomment-409057228"),
+        pytest.mark.skipif('CI' in os.environ,
+                           reason='slow test')
+    ]
+    return pytest.param(*args, marks=jit_markers)
+
+
 class GaussianChain(object):
 
     def __init__(self, dim, chain_len, num_obs):
@@ -154,7 +164,8 @@ def test_hmc_conjugate_gaussian(fixture,
         assert_equal(rmse(latent_std, expected_std).item(), 0.0, prec=std_tol)
 
 
-def test_logistic_regression():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_logistic_regression(jit):
     dim = 3
     data = torch.randn(2000, dim)
     true_coefs = torch.arange(1., dim + 1.)
@@ -166,13 +177,14 @@ def test_logistic_regression():
         y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
         return y
 
-    hmc_kernel = HMC(model, step_size=0.0855, num_steps=4)
+    hmc_kernel = HMC(model, step_size=0.0855, num_steps=4, jit_compile=jit)
     mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
     beta_posterior = EmpiricalMarginal(mcmc_run, sites='beta')
     assert_equal(rmse(true_coefs, beta_posterior.mean).item(), 0.0, prec=0.1)
 
 
-def test_beta_bernoulli():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_beta_bernoulli(jit):
     def model(data):
         alpha = torch.tensor([1.1, 1.1])
         beta = torch.tensor([1.1, 1.1])
@@ -182,13 +194,14 @@ def test_beta_bernoulli():
 
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
-    hmc_kernel = HMC(model, step_size=0.02, num_steps=3)
+    hmc_kernel = HMC(model, step_size=0.02, num_steps=3, jit_compile=jit)
     mcmc_run = MCMC(hmc_kernel, num_samples=800, warmup_steps=500).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='p_latent')
     assert_equal(posterior.mean, true_probs, prec=0.05)
 
 
-def test_gamma_normal():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_gamma_normal(jit):
     def model(data):
         rate = torch.tensor([1.0, 1.0])
         concentration = torch.tensor([1.0, 1.0])
@@ -198,13 +211,14 @@ def test_gamma_normal():
 
     true_std = torch.tensor([0.5, 2])
     data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
-    hmc_kernel = HMC(model, step_size=0.01, num_steps=3)
+    hmc_kernel = HMC(model, step_size=0.01, num_steps=3, jit_compile=jit)
     mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='p_latent')
     assert_equal(posterior.mean, true_std, prec=0.05)
 
 
-def test_dirichlet_categorical():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_dirichlet_categorical(jit):
     def model(data):
         concentration = torch.tensor([1.0, 1.0, 1.0])
         p_latent = pyro.sample('p_latent', dist.Dirichlet(concentration))
@@ -213,13 +227,14 @@ def test_dirichlet_categorical():
 
     true_probs = torch.tensor([0.1, 0.6, 0.3])
     data = dist.Categorical(true_probs).sample(sample_shape=(torch.Size((2000,))))
-    hmc_kernel = HMC(model, step_size=0.01, num_steps=3)
+    hmc_kernel = HMC(model, step_size=0.01, num_steps=3, jit_compile=jit)
     mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='p_latent')
     assert_equal(posterior.mean, true_probs, prec=0.02)
 
 
-def test_logistic_regression_with_dual_averaging():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_logistic_regression_with_dual_averaging(jit):
     dim = 3
     data = torch.randn(2000, dim)
     true_coefs = torch.arange(1., dim + 1.)
@@ -231,13 +246,14 @@ def test_logistic_regression_with_dual_averaging():
         y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
         return y
 
-    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True)
+    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True, jit_compile=jit)
     mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='beta')
     assert_equal(rmse(posterior.mean, true_coefs).item(), 0.0, prec=0.1)
 
 
-def test_beta_bernoulli_with_dual_averaging():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_beta_bernoulli_with_dual_averaging(jit):
     def model(data):
         alpha = torch.tensor([1.1, 1.1])
         beta = torch.tensor([1.1, 1.1])
@@ -254,7 +270,8 @@ def test_beta_bernoulli_with_dual_averaging():
     assert_equal(posterior.mean, true_probs, prec=0.05)
 
 
-def test_gamma_normal_with_dual_averaging():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_gamma_normal_with_dual_averaging(jit):
     def model(data):
         rate = torch.tensor([1.0, 1.0])
         concentration = torch.tensor([1.0, 1.0])
@@ -264,13 +281,14 @@ def test_gamma_normal_with_dual_averaging():
 
     true_std = torch.tensor([0.5, 2])
     data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
-    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True)
+    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True, jit_compile=jit)
     mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='p_latent')
     assert_equal(posterior.mean, true_std, prec=0.05)
 
 
-def test_gaussian_mixture_model():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_gaussian_mixture_model(jit):
     K, N = 3, 1000
 
     @poutine.broadcast
@@ -287,14 +305,17 @@ def test_gaussian_mixture_model():
     true_mix_proportions = torch.tensor([0.1, 0.3, 0.6])
     cluster_assignments = dist.Categorical(true_mix_proportions).sample(torch.Size((N,)))
     data = dist.Normal(true_cluster_means[cluster_assignments], 1.0).sample()
-    hmc_kernel = HMC(gmm, trajectory_length=1, adapt_step_size=True, max_iarange_nesting=1)
+    hmc_kernel = HMC(gmm, trajectory_length=1, adapt_step_size=True,
+                     max_iarange_nesting=1, jit_compile=jit)
     mcmc_run = MCMC(hmc_kernel, num_samples=600, warmup_steps=200).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites=["phi", "cluster_means"]).mean.sort()[0]
     assert_equal(posterior[0], true_mix_proportions, prec=0.05)
     assert_equal(posterior[1], true_cluster_means, prec=0.2)
 
 
-def test_bernoulli_latent_model():
+@pytest.mark.parametrize("jit", [False, mark_jit(True,
+                                                 markers=[pytest.mark.skip("Extremely slow.")])])
+def test_bernoulli_latent_model(jit):
     @poutine.broadcast
     def model(data):
         y_prob = pyro.sample("y_prob", dist.Beta(1.0, 1.0))
@@ -309,7 +330,8 @@ def test_bernoulli_latent_model():
     y = dist.Bernoulli(y_prob).sample(torch.Size((N,)))
     z = dist.Bernoulli(0.65 * y + 0.1).sample()
     data = dist.Normal(2. * z, 1.0).sample()
-    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True, max_iarange_nesting=1)
+    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True,
+                     max_iarange_nesting=1, jit_compile=jit)
     mcmc_run = MCMC(hmc_kernel, num_samples=600, warmup_steps=200).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites="y_prob").mean
     assert_equal(posterior, y_prob, prec=0.05)

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -18,14 +18,16 @@ from tests.common import assert_equal
 logger = logging.getLogger(__name__)
 
 
-def mark_jit(*args, markers=[]):
-    jit_markers = markers + [
+def mark_jit(*args, **kwargs):
+    jit_markers = kwargs.pop("marks", [])
+    jit_markers += [
         pytest.mark.skipif(torch.__version__ <= "0.4.1",
                            reason="https://github.com/pytorch/pytorch/issues/10041#issuecomment-409057228"),
         pytest.mark.skipif('CI' in os.environ,
                            reason='slow test')
     ]
-    return pytest.param(*args, marks=jit_markers)
+    kwargs["marks"] = jit_markers
+    return pytest.param(*args, **kwargs)
 
 
 class GaussianChain(object):
@@ -314,7 +316,7 @@ def test_gaussian_mixture_model(jit):
 
 
 @pytest.mark.parametrize("jit", [False, mark_jit(True,
-                                                 markers=[pytest.mark.skip("Extremely slow.")])])
+                                                 marks=[pytest.mark.skip("FIXME: Slow on JIT.")])])
 def test_bernoulli_latent_model(jit):
     @poutine.broadcast
     def model(data):

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -18,6 +18,17 @@ from .test_hmc import TEST_CASES, TEST_IDS, T, rmse
 
 logger = logging.getLogger(__name__)
 
+
+def mark_jit(*args, markers=[]):
+    jit_markers = markers + [
+        pytest.mark.skipif(torch.__version__ <= "0.4.1",
+                           reason="https://github.com/pytorch/pytorch/issues/10041#issuecomment-409057228"),
+        pytest.mark.skipif('CI' in os.environ,
+                           reason='slow test')
+    ]
+    return pytest.param(*args, marks=jit_markers)
+
+
 T2 = T(*TEST_CASES[2].values)._replace(num_samples=800, warmup_steps=200)
 TEST_CASES[2] = pytest.param(*T2, marks=pytest.mark.skipif(
     'CI' in os.environ and os.environ['CI'] == 'true', reason='Slow test - skip on CI'))
@@ -68,7 +79,8 @@ def test_nuts_conjugate_gaussian(fixture,
         assert_equal(rmse(latent_std, expected_std).item(), 0.0, prec=std_tol)
 
 
-def test_logistic_regression():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_logistic_regression(jit):
     dim = 3
     data = torch.randn(2000, dim)
     true_coefs = torch.arange(1., dim + 1.)
@@ -80,13 +92,14 @@ def test_logistic_regression():
         y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
         return y
 
-    nuts_kernel = NUTS(model, step_size=0.0855)
+    nuts_kernel = NUTS(model, step_size=0.0855, jit_compile=jit)
     mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='beta')
     assert_equal(rmse(true_coefs, posterior.mean).item(), 0.0, prec=0.1)
 
 
-def test_beta_bernoulli():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_beta_bernoulli(jit):
     def model(data):
         alpha = torch.tensor([1.1, 1.1])
         beta = torch.tensor([1.1, 1.1])
@@ -96,13 +109,14 @@ def test_beta_bernoulli():
 
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
-    nuts_kernel = NUTS(model, step_size=0.02)
+    nuts_kernel = NUTS(model, step_size=0.02, jit_compile=jit)
     mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='p_latent')
     assert_equal(posterior.mean, true_probs, prec=0.02)
 
 
-def test_gamma_normal():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_gamma_normal(jit):
     def model(data):
         rate = torch.tensor([1.0, 1.0])
         concentration = torch.tensor([1.0, 1.0])
@@ -112,13 +126,14 @@ def test_gamma_normal():
 
     true_std = torch.tensor([0.5, 2])
     data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
-    nuts_kernel = NUTS(model, step_size=0.01)
+    nuts_kernel = NUTS(model, step_size=0.01, jit_compile=jit)
     mcmc_run = MCMC(nuts_kernel, num_samples=200, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='p_latent')
     assert_equal(posterior.mean, true_std, prec=0.05)
 
 
-def test_logistic_regression_with_dual_averaging():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_logistic_regression_with_dual_averaging(jit):
     dim = 3
     data = torch.randn(2000, dim)
     true_coefs = torch.arange(1., dim + 1.)
@@ -130,13 +145,14 @@ def test_logistic_regression_with_dual_averaging():
         y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
         return y
 
-    nuts_kernel = NUTS(model, adapt_step_size=True)
+    nuts_kernel = NUTS(model, adapt_step_size=True, jit_compile=jit)
     mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='beta')
     assert_equal(rmse(true_coefs, posterior.mean).item(), 0.0, prec=0.1)
 
 
-def test_beta_bernoulli_with_dual_averaging():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_beta_bernoulli_with_dual_averaging(jit):
     def model(data):
         alpha = torch.tensor([1.1, 1.1])
         beta = torch.tensor([1.1, 1.1])
@@ -152,7 +168,8 @@ def test_beta_bernoulli_with_dual_averaging():
     assert_equal(posterior.mean, true_probs, prec=0.03)
 
 
-def test_dirichlet_categorical():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_dirichlet_categorical(jit):
     def model(data):
         concentration = torch.tensor([1.0, 1.0, 1.0])
         p_latent = pyro.sample('p_latent', dist.Dirichlet(concentration))
@@ -161,13 +178,14 @@ def test_dirichlet_categorical():
 
     true_probs = torch.tensor([0.1, 0.6, 0.3])
     data = dist.Categorical(true_probs).sample(sample_shape=(torch.Size((2000,))))
-    nuts_kernel = NUTS(model, adapt_step_size=True)
+    nuts_kernel = NUTS(model, adapt_step_size=True, jit_compile=jit)
     mcmc_run = MCMC(nuts_kernel, num_samples=200, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites='p_latent')
     assert_equal(posterior.mean, true_probs, prec=0.02)
 
 
-def test_gamma_beta():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_gamma_beta(jit):
     def model(data):
         alpha_prior = pyro.sample('alpha', dist.Gamma(concentration=1., rate=1.))
         beta_prior = pyro.sample('beta', dist.Gamma(concentration=1., rate=1.))
@@ -176,13 +194,14 @@ def test_gamma_beta():
     true_alpha = torch.tensor(5.)
     true_beta = torch.tensor(1.)
     data = dist.Beta(concentration1=true_alpha, concentration0=true_beta).sample(torch.Size((5000,)))
-    nuts_kernel = NUTS(model, adapt_step_size=True)
+    nuts_kernel = NUTS(model, adapt_step_size=True, jit_compile=jit)
     mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=200).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites=['alpha', 'beta'])
     assert_equal(posterior.mean, torch.stack([true_alpha, true_beta]), prec=0.05)
 
 
-def test_gaussian_mixture_model():
+@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+def test_gaussian_mixture_model(jit):
     K, N = 3, 1000
 
     @poutine.broadcast
@@ -199,14 +218,16 @@ def test_gaussian_mixture_model():
     true_mix_proportions = torch.tensor([0.1, 0.3, 0.6])
     cluster_assignments = dist.Categorical(true_mix_proportions).sample(torch.Size((N,)))
     data = dist.Normal(true_cluster_means[cluster_assignments], 1.0).sample()
-    nuts_kernel = NUTS(gmm, adapt_step_size=True, max_iarange_nesting=1)
+    nuts_kernel = NUTS(gmm, adapt_step_size=True, max_iarange_nesting=1, jit_compile=jit)
     mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=200).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites=["phi", "cluster_means"]).mean.sort()[0]
     assert_equal(posterior[0], true_mix_proportions, prec=0.05)
     assert_equal(posterior[1], true_cluster_means, prec=0.2)
 
 
-def test_bernoulli_latent_model():
+@pytest.mark.parametrize("jit", [False, mark_jit(True,
+                                                 markers=[pytest.mark.skip("Extremely slow.")])])
+def test_bernoulli_latent_model(jit):
     @poutine.broadcast
     def model(data):
         y_prob = pyro.sample("y_prob", dist.Beta(1., 1.))
@@ -220,7 +241,7 @@ def test_bernoulli_latent_model():
     y = dist.Bernoulli(y_prob).sample(torch.Size((N,)))
     z = dist.Bernoulli(0.65 * y + 0.1).sample()
     data = dist.Normal(2. * z, 1.0).sample()
-    nuts_kernel = NUTS(model, adapt_step_size=True, max_iarange_nesting=1)
+    nuts_kernel = NUTS(model, adapt_step_size=True, max_iarange_nesting=1, jit_compile=jit)
     mcmc_run = MCMC(nuts_kernel, num_samples=600, warmup_steps=200).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites="y_prob").mean
     assert_equal(posterior, y_prob, prec=0.05)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -202,7 +202,8 @@ def test_gamma_beta(jit):
     assert_equal(posterior.mean, torch.stack([true_alpha, true_beta]), prec=0.05)
 
 
-@pytest.mark.parametrize("jit", [False, mark_jit(True)])
+@pytest.mark.parametrize("jit", [False, mark_jit(True,
+                                                 marks=[pytest.mark.skip("FIXME: Slow on JIT.")])])
 def test_gaussian_mixture_model(jit):
     K, N = 3, 1000
 
@@ -227,8 +228,8 @@ def test_gaussian_mixture_model(jit):
     assert_equal(posterior[1], true_cluster_means, prec=0.2)
 
 
-@pytest.mark.parametrize("jit", [False, mark_jit(True,
-                                                 marks=[pytest.mark.skip("FIXME: Slow on JIT.")])])
+@pytest.mark.parametrize("jit", [False, mark_jit(True, marks=[
+    pytest.mark.xfail(reason="FIXME: log not implemented for 'CPULongType'")])])
 def test_bernoulli_latent_model(jit):
     @poutine.broadcast
     def model(data):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -62,11 +62,13 @@ def xfail_jit(*args):
 
 JIT_EXAMPLES = [
     xfail_jit('air/main.py --num-steps=1 --jit'),
+    xfail_jit('baseball.py --num-samples=200 --warmup-steps=100 --jit'),
     xfail_jit('bayesian_regression.py --num-epochs=1 --jit'),  # this works on PyTorch master
     xfail_jit('contrib/autoname/mixture.py --num-epochs=1 --jit'),
     xfail_jit('contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --jit'),
     xfail_jit('dmm/dmm.py --num-epochs=1 --jit'),
     xfail_jit('dmm/dmm.py --num-epochs=1 --num-iafs=1 --jit'),
+    xfail_jit('eight_schools/mcmc.py --num-samples=500 --warmup-steps=100 --jit'),
     xfail_jit('eight_schools/svi.py --num-epochs=1 --jit'),
     xfail_jit('vae/ss_vae_M2.py --num-epochs=1 --aux-loss --jit'),
     xfail_jit('vae/ss_vae_M2.py --num-epochs=1 --enum-discrete=parallel --jit'),


### PR DESCRIPTION
Addresses #1063. 

This allows for tracing the Potential Energy computation inside HMC, and using this optimized trace for subsequent model executions in the integrator and for computing the energy outside the integrator. 

The output from this function is then differentiated to compute the gradient terms in the integrator. To JIT the integrator internals would require us to JIT the gradient computation using `@torch.jit.script` and wrapping up the integrator steps inside a `@torch.jit.trace`. However, `@torch.jit.script` has many more limitations which makes this infeasible. Just wrapping the PE computation offers a reduction of 10%-30% (more on certain examples) in the runtime.

Most tests pass on PyTorch master, except marked otherwise. Both the examples currently fail.