### PR TITLE
Use expand=False while enumerating discrete sites in HMC

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -81,8 +81,10 @@ class HMC(TraceKernel):
                  max_iarange_nesting=float("inf")):
         # Wrap model in `poutine.enum` to enumerate over discrete latent sites.
         # No-op if model does not have any discrete latents.
-        self.model = poutine.enum(config_enumerate(model, default="parallel"),
+        self.model = poutine.enum(config_enumerate(model, default="parallel", expand=False),
                                   first_available_dim=max_iarange_nesting)
+        # broadcast sample sites inside iarange.
+        self.model = poutine.broadcast(self.model)
         self.step_size = step_size if step_size is not None else 1  # from Stan
         if trajectory_length is not None:
             self.trajectory_length = trajectory_length


### PR DESCRIPTION
Addresses #915 for HMC, using the work done in #1289. Since HMC on Pyro release does not support discrete sample sites or `iarange`, I am using `expand=False` and `poutine.broadcast` internally by default, since its not a breaking change. The HMM example is quite slow, and will make for a good test case for JIT.
