### PR TITLE
Fix AutoRegNN when default tensor type is CUDA

### DIFF
--- a/pyro/nn/auto_reg_nn.py
+++ b/pyro/nn/auto_reg_nn.py
@@ -18,7 +18,7 @@ def sample_mask_indices(input_dim, hidden_dim, simple=True):
     :param simple: True to space fractional indices by rounding to nearest int, false round randomly
     :type simple: bool
     """
-    indices = torch.linspace(1, input_dim, steps=hidden_dim)
+    indices = torch.linspace(1, input_dim, steps=hidden_dim, device='cpu').to(torch.Tensor().device)
     if simple:
         # Simple procedure tries to space fractional indices evenly by rounding to nearest int
         return torch.round(indices)
@@ -140,7 +140,7 @@ class AutoRegressiveNN(nn.Module):
 
         if permutation is None:
             # By default set a random permutation of variables, which is important for performance with multiple steps
-            self.permutation = torch.randperm(input_dim)
+            self.permutation = torch.randperm(input_dim, device='cpu').to(torch.Tensor().device)
         else:
             # The permutation is chosen by the user
             self.permutation = permutation.type(dtype=torch.int64)

--- a/tests/distributions/test_iaf.py
+++ b/tests/distributions/test_iaf.py
@@ -150,7 +150,7 @@ class AutoRegressiveNNTests(TestCase):
                         # NOTE: the hidden dimension must be greater than the input_dim for the
                         # masks to be well-defined!
                         hidden_dim = input_dim * 5
-                        permutation = torch.randperm(input_dim)
+                        permutation = torch.randperm(input_dim, device='cpu')
                         self._test_masks(
                             input_dim,
                             observed_dim,


### PR DESCRIPTION
Minor fixes to `AutoRegNN` so that it works when the default tensor type is CUDA. The problem comes because certain functions like `randperm` and `linspace` do not have CUDA implementations. For the most part, this won't matter since we explicitly lift the module to CUDA using `module.cuda()` but these fixes are needed to make sure that this does not break our CUDA tests.