### PR TITLE
Use opt_einsum for message passing in SVI

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ cloudpickle>=0.3.1
 graphviz>=0.8
 networkx>=2.0.0
 observations>=0.1.4
+opt_einsum==2.1.2

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -25,13 +25,13 @@ def _compute_dice_elbo(model_trace, guide_trace):
                 for name, site in trace.nodes.items()
                 if site["type"] == "sample"}
 
-    costs = defaultdict(float)
+    costs = defaultdict(list)
     for name, site in model_trace.nodes.items():
         if site["type"] == "sample":
-            costs[ordering[name]] = costs[ordering[name]] + site["log_prob"]
+            costs[ordering[name]].append(site["log_prob"])
     for name, site in guide_trace.nodes.items():
         if site["type"] == "sample":
-            costs[ordering[name]] = costs[ordering[name]] - site["log_prob"]
+            costs[ordering[name]].append(-site["log_prob"])
 
     return Dice(guide_trace, ordering).compute_expectation(costs)
 

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -8,7 +8,7 @@ import torch
 from torch.distributions.utils import broadcast_all
 
 from pyro.distributions.util import is_identically_zero
-from pyro.ops._einsum import shared_intermediates
+from pyro.ops.einsum.deferred import shared_intermediates
 from pyro.ops.sumproduct import sumproduct
 from pyro.poutine.util import site_is_subsample
 
@@ -299,7 +299,7 @@ class Dice(object):
             for ordinal, cost_terms in costs.items():
                 factors = factors_table.get(ordinal, [])
                 for cost in cost_terms:
-                    prob = sumproduct(factors, cost.shape, backend='pyro.ops._einsum')
+                    prob = sumproduct(factors, cost.shape, backend='pyro.ops.einsum.deferred')
                     mask = prob > 0
                     if torch.is_tensor(mask) and not mask.all():
                         cost, prob, mask = broadcast_all(cost, prob, mask)

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -261,6 +261,7 @@ class Dice(object):
         return expected_cost
 
     def _opt_compute_expectation(self, costs):
+        # precompute exponentials to be shared across calls to sumproduct
         exp_table = {}
         factors_table = defaultdict(list)
         for ordinal in costs:
@@ -281,8 +282,7 @@ class Dice(object):
             for ordinal, cost_terms in costs.items():
                 factors = factors_table.get(ordinal, [])
                 for cost in cost_terms:
-                    prob = sumproduct(factors, cost.shape, optimize=True,
-                                      backend='pyro.ops._einsum')
+                    prob = sumproduct(factors, cost.shape, backend='pyro.ops._einsum')
                     mask = prob > 0
                     if torch.is_tensor(mask) and not mask.all():
                         cost, prob, mask = broadcast_all(cost, prob, mask)

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -250,27 +250,6 @@ class Dice(object):
             with shared_intermediates():
                 for ordinal, cost_terms in costs.items():
                     factors = factors_table[ordinal]
-
-                    # Version 0. (correct but exponential cost)
-                    # expected_cost = expected_cost + sumproduct(factors + [sum(cost_terms)])
-
-                    # Version 1. (wrong but cheap)
-                    # factors.append(sum(cost_terms))
-                    # expected_cost = expected_cost + sumproduct(factors)
-
-                    # Version 2. (correct but quadratic cost)
-                    # target_shape = broadcast_shape(*(c.shape for c in cost_terms))
-                    # for cost in cost_terms:
-                    #     cost = cost.expand(target_shape)
-                    #     expected_cost = expected_cost + sumproduct(factors + [cost])
-
-                    # Version 3. (best case linear cost, but does not share in practice)
-                    # for cost in cost_terms:
-                    #     part = sumproduct(factors + [cost], optimize=True,
-                    #                       backend='pyro.ops._einsum')
-                    #     expected_cost = expected_cost + part
-
-                    # Version 4.
                     for cost in cost_terms:
                         prob = sumproduct(factors, cost.shape, optimize=True,
                                           backend='pyro.ops._einsum')

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -270,6 +270,7 @@ class Dice(object):
                     exp_table[id(log_factor)] = factor
                     factors_table[ordinal].append(factor)
 
+        # deduplicate by shape to increase sharing
         costs = {ordinal: deduplicate_by_shape(group)
                  for ordinals, group in costs.items()}
         factors_table = {ordinal: deduplicate_by_shape(group, combine=lambda a, b: a * b)

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -5,6 +5,7 @@ import numbers
 from collections import defaultdict
 
 import torch
+from six.moves import reduce
 from torch.distributions.utils import broadcast_all
 
 from pyro.distributions.util import is_identically_zero

--- a/pyro/ops/_einsum.py
+++ b/pyro/ops/_einsum.py
@@ -1,0 +1,135 @@
+from __future__ import absolute_import, division, print_function
+
+import contextlib
+import numbers
+
+import opt_einsum
+
+CACHE = {}
+
+
+class Deferred(object):
+    def __init__(self, shape):
+        self.shape = shape
+        self._value = None
+
+    def __eq__(self, other):
+        return self is other
+
+    def eval(self):
+        if self._value is None:
+            self._eval()
+            assert self._value.shape == self.shape
+        return self._value
+
+
+class DeferredTensor(Deferred):
+    def __init__(self, tensor):
+        super(DeferredTensor, self).__init__(tensor.shape)
+        self._value = tensor
+
+
+class Transpose(Deferred):
+    def __init__(self, a, axes):
+        assert isinstance(a, Deferred)
+        self.a = a
+        self.axes = tuple(axes)
+        shape = tuple(a.shape[i] for i in axes)
+        super(Transpose, self).__init__(shape)
+
+    def _eval(self):
+        a = self.a.eval()
+        self._value = opt_einsum.backends.torch.transpose(a, self.axes)
+
+    def __hash__(self):
+        return hash((self.a, self.axes))
+
+
+def transpose(a, axes):
+    axes = tuple(axes)
+
+    key = 'transpose', a, axes
+    if key in CACHE:
+        return CACHE[key]
+
+    result = Transpose(a, axes)
+    CACHE[key] = result
+    return result
+
+
+class Tensordot(Deferred):
+    def __init__(self, x, y, axes):
+        assert isinstance(x, Deferred)
+        assert isinstance(y, Deferred)
+        self.x = x
+        self.y = y
+        self.axes = axes
+        x_shape = tuple(s for i, s in enumerate(x.shape) if i not in axes[0])
+        y_shape = tuple(s for i, s in enumerate(y.shape) if i not in axes[1])
+        shape = x_shape + y_shape
+        super(Tensordot, self).__init__(shape)
+
+    def _eval(self):
+        x = self.x.eval()
+        y = self.y.eval()
+        self._value = opt_einsum.backends.torch.tensordot(x, y, self.axes)
+
+    def __hash__(self):
+        return hash((self.x, self.y, self.axes))
+
+
+def tensordot(x, y, axes=2):
+    if isinstance(axes, numbers.Number):
+        axes = list(range(len(x.shape)))[len(x.shape) - axes:], list(range(len(y.shape)))[:axes]
+    axes = tuple(axes[0]), tuple(axes[1])
+
+    key = 'tensordot', x, y, axes
+    if key in CACHE:
+        return CACHE[key]
+
+    result = Tensordot(x, y, axes)
+    CACHE[key] = result
+    return result
+
+
+class Einsum(Deferred):
+    def __init__(self, equation, operands):
+        assert all(isinstance(d, Deferred) for d in operands)
+        self.equation = equation
+        self.operands = operands
+        inputs, output = equation.split('->')
+        inputs = inputs.split(',')
+        assert len(inputs) == len(operands)
+        sizes = {}
+        for names, tensor in zip(inputs, operands):
+            assert len(names) == len(tensor.shape)
+            for name, size in zip(names, tensor.shape):
+                sizes[name] = size
+        shape = tuple(sizes[name] for name in output)
+        super(Einsum, self).__init__(shape)
+
+    def _eval(self):
+        operands = [d.eval() for d in self.operands]
+        self._value = opt_einsum.backends.torch.einsum(self.equation, *operands)
+
+    def __hash__(self):
+        return hash((self.equation, self.operands))
+
+
+def einsum(equation, *operands):
+    operands = tuple(operands)
+
+    key = 'einsum', equation, operands
+    if key in CACHE:
+        return CACHE[key]
+
+    result = Einsum(equation, operands)
+    CACHE[key] = result
+    return result
+
+
+@contextlib.contextmanager
+def shared_intermediates():
+    CACHE.clear()
+    yield
+    CACHE.clear()

--- a/pyro/ops/_einsum.py
+++ b/pyro/ops/_einsum.py
@@ -9,7 +9,48 @@ import opt_einsum
 from pyro.distributions.torch_patch import _patch
 
 CACHE = OrderedDict()
+NEXT_SYMBOL = [0]
+LAST_CACHE_SIZE = [0]
 ALPHABET = 'abcdefghijklmnopqrstuvwxyz'
+
+
+@contextlib.contextmanager
+def shared_intermediates(debug=False):
+    CACHE.clear()
+    NEXT_SYMBOL[0] = 0
+    yield CACHE
+
+    if debug:
+        for i, value in enumerate(CACHE.values()):
+            if isinstance(value, DeferredTensor):
+                rhs = 'tensor{}'.format(tuple(value._value.shape))
+            elif isinstance(value, Transpose):
+                rhs = str(value)
+            elif isinstance(value, Tensordot):
+                rhs = '{} * {}'.format(value._x, value._y)
+            elif isinstance(value, Einsum):
+                rhs = ' * '.join(str(d) for d in value._operands)
+            dims = '?' if value._dims is None else value._dims
+            print('{: >4} {: <14}{: >8} {} = {}'.format(
+                i, type(value).__name__, dims, value, rhs))
+
+    LAST_CACHE_SIZE[0] = len(CACHE)
+    CACHE.clear()
+    NEXT_SYMBOL[0] = 0
+
+
+def contract(equation, *operands, **kwargs):
+    """
+    Like :func:`opt_einsum.contract` but adds debugging metadata.
+    """
+    # add debugging metadata
+    if kwargs.get('backend', 'torch') == 'pyro.ops._einsum':
+        inputs, output = equation.split('->')
+        inputs = inputs.split(',')
+        for dims, d in zip(inputs, operands):
+            d._dims = dims
+
+    return opt_einsum.contract(equation, *operands, **kwargs)
 
 
 def alpha_canonicalize(equation):
@@ -27,9 +68,14 @@ def alpha_canonicalize(equation):
 
 
 class Deferred(object):
-    def __init__(self, shape):
+    def __init__(self, shape, name):
         self.shape = shape
         self._value = None
+        self._name = name  # debugging info
+        self._dims = None  # debugging info set by contract()
+
+    def __str__(self):
+        return self._name
 
     def __eq__(self, other):
         return self is other
@@ -43,7 +89,9 @@ class Deferred(object):
 
 class DeferredTensor(Deferred):
     def __init__(self, tensor):
-        super(DeferredTensor, self).__init__(tensor.shape)
+        name = opt_einsum.get_symbol(NEXT_SYMBOL[0])
+        NEXT_SYMBOL[0] += 1
+        super(DeferredTensor, self).__init__(tensor.shape, name)
         self._value = tensor
 
     def __hash__(self):
@@ -72,17 +120,20 @@ def deferred_tensor(tensor):
 class Transpose(Deferred):
     def __init__(self, a, axes):
         assert isinstance(a, Deferred)
-        self.a = a
-        self.axes = tuple(axes)
+        self._a = a
+        self._axes = tuple(axes)
         shape = tuple(a.shape[i] for i in axes)
-        super(Transpose, self).__init__(shape)
+        name = a._name + "'"
+        super(Transpose, self).__init__(shape, name)
+        if a._dims is not None:
+            self._dims = ''.join(a._dims[i] for i in axes)
 
     def _eval(self):
-        a = self.a.eval()
-        self._value = opt_einsum.backends.torch.transpose(a, self.axes)
+        a = self._a.eval()
+        self._value = opt_einsum.backends.torch.transpose(a, self._axes)
 
     def __hash__(self):
-        return hash((self.a, self.axes))
+        return hash((self._a, self._axes))
 
 
 def transpose(a, axes):
@@ -101,26 +152,30 @@ class Tensordot(Deferred):
     def __init__(self, x, y, axes):
         assert isinstance(x, Deferred)
         assert isinstance(y, Deferred)
-        self.x = x
-        self.y = y
-        self.axes = axes
+        self._x = x
+        self._y = y
+        self._axes = axes
         x_shape = tuple(s for i, s in enumerate(x.shape) if i not in axes[0])
         y_shape = tuple(s for i, s in enumerate(y.shape) if i not in axes[1])
         shape = x_shape + y_shape
-        super(Tensordot, self).__init__(shape)
+        name = '({}{})'.format(x._name, y._name)
+        super(Tensordot, self).__init__(shape, name)
+        if x._dims is not None and y._dims is not None:
+            self._dims = ''.join([s for i, s in enumerate(x._dims) if i not in axes[0]] +
+                                 [s for i, s in enumerate(y._dims) if i not in axes[1]])
 
     def _eval(self):
-        x = self.x.eval()
-        y = self.y.eval()
+        x = self._x.eval()
+        y = self._y.eval()
 
         # This workaround can be deleted after this issue is fixed in release:
         # https://github.com/pytorch/pytorch/issues/7763
         x, y = x.clone(), y.clone()
 
-        self._value = opt_einsum.backends.torch.tensordot(x, y, self.axes)
+        self._value = opt_einsum.backends.torch.tensordot(x, y, self._axes)
 
     def __hash__(self):
-        return hash((self.x, self.y, self.axes))
+        return hash((self._x, self._y, self._axes))
 
 
 def tensordot(x, y, axes=2):
@@ -140,8 +195,8 @@ def tensordot(x, y, axes=2):
 class Einsum(Deferred):
     def __init__(self, equation, operands):
         assert all(isinstance(d, Deferred) for d in operands)
-        self.equation = equation
-        self.operands = tuple(operands)
+        self._equation = equation
+        self._operands = tuple(operands)
         inputs, output = equation.split('->')
         inputs = inputs.split(',')
         assert len(inputs) == len(operands)
@@ -151,19 +206,22 @@ class Einsum(Deferred):
             for name, size in zip(names, tensor.shape):
                 sizes[name] = size
         shape = tuple(sizes[name] for name in output)
-        super(Einsum, self).__init__(shape)
+        name = '({})'.format(''.join(str(d) for d in operands))
+        super(Einsum, self).__init__(shape, name)
+        if all(d._dims is not None for d in operands):
+            self._dims = output
 
     def _eval(self):
-        operands = [d.eval() for d in self.operands]
+        operands = [d.eval() for d in self._operands]
 
         # This workaround can be deleted after this issue is fixed in release:
         # https://github.com/pytorch/pytorch/issues/7763
         operands = [d.clone() for d in operands]
 
-        self._value = opt_einsum.backends.torch.einsum(self.equation, *operands)
+        self._value = opt_einsum.backends.torch.einsum(self._equation, *operands)
 
     def __hash__(self):
-        return hash((self.equation, self.operands))
+        return hash((self._equation, self._operands))
 
 
 def einsum(equation, *operands):
@@ -182,27 +240,6 @@ def einsum(equation, *operands):
     result = Einsum(equation, operands)
     CACHE[key] = result
     return result
-
-
-@contextlib.contextmanager
-def shared_intermediates(debug=False):
-    CACHE.clear()
-    yield CACHE
-
-    if debug:
-        names = {value: 'x{}'.format(i) for i, value in enumerate(CACHE.values())}
-        for value in CACHE.values():
-            if isinstance(value, DeferredTensor):
-                args = '...'
-            elif isinstance(value, Transpose):
-                args = '{}, {}'.format(names[value.a], value.axes)
-            elif isinstance(value, Tensordot):
-                args = '{}, {}, {}'.format(names[value.x], names[value.y], value.axes)
-            elif isinstance(value, Einsum):
-                args = '{}, {}'.format(value.equation, ', '.join(names[o] for o in value.operands))
-            print('{} = {}({})'.format(names[value], type(value).__name__, args))
-
-    CACHE.clear()
 
 
 # Work around torch.einsum's limitation to 26 letters

--- a/pyro/ops/_einsum.py
+++ b/pyro/ops/_einsum.py
@@ -187,7 +187,7 @@ def einsum(equation, *operands):
 @contextlib.contextmanager
 def shared_intermediates(debug=False):
     CACHE.clear()
-    yield
+    yield CACHE
 
     if debug:
         names = {value: 'x{}'.format(i) for i, value in enumerate(CACHE.values())}

--- a/pyro/ops/einsum/deferred.py
+++ b/pyro/ops/einsum/deferred.py
@@ -44,7 +44,7 @@ def contract(equation, *operands, **kwargs):
     Like :func:`opt_einsum.contract` but adds debugging metadata.
     """
     # add debugging metadata
-    if kwargs.get('backend', 'torch') == 'pyro.ops._einsum':
+    if kwargs.get('backend', 'torch') == 'pyro.ops.einsum.deferred':
         inputs, output = equation.split('->')
         inputs = inputs.split(',')
         for dims, d in zip(inputs, operands):

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import, division, print_function
+
+import math
+
+import torch
+
+# import opt_einsum as oe
+
+
+def sumproduct(factors, target_dims, optimize=False):
+    """
+    """
+    assert all(d < 0 for d in target_dims)
+
+    if not optimize:
+        product = factors[0]
+        for factor in factors[1:]:
+            product = product * factor
+
+        for dim, size in enumerate(product.shape):
+            if dim not in target_dims:
+                product = product.sum(dim, True)
+
+        target_ndims = 1-min(target_dims)
+        while len(product.shape) > target_ndims:
+            product = product.squeeze(0)
+        return product
+
+    raise NotImplementedError
+
+
+def sumlogsumexp(log_factors, target_shape, optimize=False):
+    """
+    """
+    # Handle trivial cases.
+    if not any(isinstance(t, torch.Tensor) for t in log_factors):
+        return math.exp(sum(log_factors))
+
+    # Naive algorithm.
+    if not optimize:
+        log_result = log_factors[0]
+        for log_factor in log_factors[1:]:
+            log_result = log_result + log_factor
+        result = log_result.exp()
+
+        while result.dim() > len(target_shape):
+            result = result.sum(0)
+        while result.dim() < len(target_shape):
+            result = result.unsqueeze(0)
+        for dim, (result_size, target_size) in enumerate(zip(result.shape, target_shape)):
+            if result_size > target_size:
+                result = result.sum(dim, True)
+
+        return result
+
+    raise NotImplementedError

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -7,41 +7,19 @@ import torch
 # import opt_einsum as oe
 
 
-def sumproduct(factors, target_dims, optimize=False):
-    """
-    """
-    assert all(d < 0 for d in target_dims)
-
-    if not optimize:
-        product = factors[0]
-        for factor in factors[1:]:
-            product = product * factor
-
-        for dim, size in enumerate(product.shape):
-            if dim not in target_dims:
-                product = product.sum(dim, True)
-
-        target_ndims = 1-min(target_dims)
-        while len(product.shape) > target_ndims:
-            product = product.squeeze(0)
-        return product
-
-    raise NotImplementedError
-
-
-def sumlogsumexp(log_factors, target_shape, optimize=False):
-    """
-    """
+def sumproduct(factors, target_shape, optimize=False):
     # Handle trivial cases.
-    if not any(isinstance(t, torch.Tensor) for t in log_factors):
-        return math.exp(sum(log_factors))
+    if not any(isinstance(t, torch.Tensor) for t in factors):
+        result = 1.
+        for factor in factors:
+            result *= factor
+        return result
 
     # Naive algorithm.
     if not optimize:
-        log_result = log_factors[0]
-        for log_factor in log_factors[1:]:
-            log_result = log_result + log_factor
-        result = log_result.exp()
+        result = factors[0]
+        for factor in factors[1:]:
+            result = result * factor
 
         while result.dim() > len(target_shape):
             result = result.sum(0)
@@ -53,4 +31,5 @@ def sumlogsumexp(log_factors, target_shape, optimize=False):
 
         return result
 
+    # Use opt-einsum.
     raise NotImplementedError

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -17,7 +17,7 @@ def _product(factors):
 
 
 def zip_align_right(xs, ys):
-    return reversed(zip(reversed(xs), reversed(ys)))
+    return reversed(list(zip(reversed(xs), reversed(ys))))
 
 
 def sumproduct(factors, target_shape=(), optimize=True, backend='torch'):

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
+from numbers import Number
+
 import opt_einsum
 import torch
 
 from pyro.distributions.util import broadcast_shape
+from pyro.ops._einsum import deferred_tensor
 
 
 def _product(factors):
@@ -17,18 +20,18 @@ def zip_align_right(xs, ys):
     return reversed(zip(reversed(xs), reversed(ys)))
 
 
-def sumproduct(factors, target_shape=(), optimize=True):
+def sumproduct(factors, target_shape=(), optimize=True, backend='torch'):
     # Handle numbers and trivial cases.
     numbers = []
     tensors = []
     for t in factors:
-        (tensors if isinstance(t, torch.Tensor) else numbers).append(t)
+        (numbers if isinstance(t, Number) else tensors).append(t)
     if not tensors:
         return _product(numbers)
     shape = broadcast_shape(*(t.shape for t in tensors))
     if numbers:
         number_part = _product(numbers)
-        tensor_part = sumproduct(tensors, target_shape, optimize=optimize)
+        tensor_part = sumproduct(tensors, target_shape, optimize=optimize, backend=backend)
         contracted_shape = shape[:len(shape) - len(target_shape)]
         replication_power = _product(contracted_shape)
         return tensor_part * number_part ** replication_power
@@ -43,13 +46,13 @@ def sumproduct(factors, target_shape=(), optimize=True):
         while smaller_shape and smaller_shape[0] == 1:
             smaller_shape = smaller_shape[1:]
         smaller_shape = tuple(smaller_shape)
-        result = sumproduct(factors, smaller_shape, optimize=optimize)
+        result = sumproduct(factors, smaller_shape, optimize=optimize, backend=backend)
         return result.expand(target_shape)
 
     if not optimize:
         return naive_sumproduct(tensors, target_shape)
     else:
-        return opt_sumproduct(tensors, target_shape)
+        return opt_sumproduct(tensors, target_shape, backend=backend)
 
 
 def naive_sumproduct(factors, target_shape):
@@ -70,11 +73,14 @@ def naive_sumproduct(factors, target_shape):
     return result
 
 
-def opt_sumproduct(factors, target_shape):
+def opt_sumproduct(factors, target_shape, backend='torch'):
     assert all(isinstance(t, torch.Tensor) for t in factors)
+    assert backend in ['torch', 'pyro.ops._einsum'], backend
+    if backend == 'pyro.ops._einsum':
+        factors = [deferred_tensor(t) for t in factors]
 
     num_symbols = len(target_shape)
-    num_symbols = max(num_symbols, max(t.dim() for t in factors))
+    num_symbols = max(num_symbols, max(len(t.shape) for t in factors))
     symbols = [opt_einsum.get_symbol(i) for i in range(num_symbols)]
     target_names = [name
                     for name, size in zip_align_right(symbols, target_shape)
@@ -88,14 +94,17 @@ def opt_sumproduct(factors, target_shape):
             name
             for name, size in zip_align_right(symbols, factor.shape)
             if size != 1])
-        packed_factors.append(factor.squeeze().clone())  # FIXME remove this clone
-        assert packed_factors[-1].dim() == len(packed_names[-1])
+        # packed_factors.append(factor.squeeze().clone())  # FIXME remove this clone
+        packed_factors.append(factor.squeeze())
+        assert len(packed_factors[-1].shape) == len(packed_names[-1])
 
     # Contract packed tensors.
     expr = '{}->{}'.format(','.join(''.join(names) for names in packed_names),
                            ''.join(target_names))
-    print('DEBUG {}'.format(expr))
-    packed_result = opt_einsum.contract(expr, *packed_factors, backend='torch')
+
+    packed_result = opt_einsum.contract(expr, *packed_factors, backend=backend)
+    if backend == 'pyro.ops._einsum':
+        packed_result = packed_result.eval()
 
     # Unpack result.
     result = packed_result

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -6,7 +6,7 @@ import opt_einsum
 import torch
 
 from pyro.distributions.util import broadcast_shape
-from pyro.ops._einsum import deferred_tensor
+from pyro.ops.einsum.deferred import deferred_tensor
 
 
 def _product(factors):
@@ -75,8 +75,8 @@ def naive_sumproduct(factors, target_shape):
 
 def opt_sumproduct(factors, target_shape, backend='torch'):
     assert all(isinstance(t, torch.Tensor) for t in factors)
-    assert backend in ['torch', 'pyro.ops._einsum'], backend
-    if backend == 'pyro.ops._einsum':
+    assert backend in ['torch', 'pyro.ops.einsum.deferred'], backend
+    if backend == 'pyro.ops.einsum.deferred':
         factors = [deferred_tensor(t) for t in factors]
 
     num_symbols = len(target_shape)
@@ -101,7 +101,7 @@ def opt_sumproduct(factors, target_shape, backend='torch'):
     expr = '{}->{}'.format(','.join(''.join(names) for names in packed_names),
                            ''.join(target_names))
     packed_result = opt_einsum.contract(expr, *packed_factors, backend=backend)
-    if backend == 'pyro.ops._einsum':
+    if backend == 'pyro.ops.einsum.deferred':
         packed_result = packed_result.eval()
 
     # Unpack result.

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -1,35 +1,89 @@
 from __future__ import absolute_import, division, print_function
 
-import math
-
+import opt_einsum
 import torch
 
-# import opt_einsum as oe
+from pyro.distributions.util import broadcast_shape
 
 
-def sumproduct(factors, target_shape, optimize=False):
-    # Handle trivial cases.
-    if not any(isinstance(t, torch.Tensor) for t in factors):
-        result = 1.
-        for factor in factors:
-            result *= factor
-        return result
+def _product(factors):
+    result = 1.
+    for factor in factors:
+        result = result * factor
+    return result
 
-    # Naive algorithm.
+
+def sumproduct(factors, target_shape, optimize=True):
+    # Handle numbers and trivial cases.
+    numbers = []
+    tensors = []
+    for t in factors:
+        (tensors if isinstance(t, torch.Tensor) else numbers).append(t)
+    if not tensors:
+        return _product(numbers)
+    if numbers:
+        number_part = _product(numbers)
+        tensor_part = sumproduct(tensors, target_shape, optimize=optimize)
+        shape = broadcast_shape(*(t.shape for t in tensors))
+        contracted_shape = shape[:len(shape) - len(target_shape)]
+        replication_power = _product(contracted_shape)
+        return tensor_part * number_part ** replication_power
+
     if not optimize:
-        result = factors[0]
-        for factor in factors[1:]:
-            result = result * factor
+        return naive_sumproduct(tensors, target_shape)
+    else:
+        return opt_sumproduct(tensors, target_shape)
 
-        while result.dim() > len(target_shape):
-            result = result.sum(0)
-        while result.dim() < len(target_shape):
-            result = result.unsqueeze(0)
-        for dim, (result_size, target_size) in enumerate(zip(result.shape, target_shape)):
-            if result_size > target_size:
-                result = result.sum(dim, True)
 
-        return result
+def naive_sumproduct(factors, target_shape):
+    assert all(isinstance(t, torch.Tensor) for t in factors)
 
-    # Use opt-einsum.
-    raise NotImplementedError
+    result = factors[0]
+    for factor in factors[1:]:
+        result = result * factor
+
+    while result.dim() > len(target_shape):
+        result = result.sum(0)
+    while result.dim() < len(target_shape):
+        result = result.unsqueeze(0)
+    for dim, (result_size, target_size) in enumerate(zip(result.shape, target_shape)):
+        if result_size > target_size:
+            result = result.sum(dim, True)
+
+    return result
+
+
+def opt_sumproduct(factors, target_shape):
+    assert all(isinstance(t, torch.Tensor) for t in factors)
+
+    num_symbols = len(target_shape)
+    num_symbols = max(num_symbols, max(t.dim() for t in factors))
+    symbols = [opt_einsum.get_symbol(i) for i in range(num_symbols)]
+    rev_symbols = list(reversed(symbols))
+    target_names = [name
+                    for name, size in zip(rev_symbols, reversed(target_shape))
+                    if size != 1]
+
+    # Construct low-dimensional tensors with symbolic names.
+    packed_names = []
+    packed_factors = []
+    for factor in factors:
+        packed_names.append([
+            name
+            for name, size in zip(rev_symbols, reversed(factor.shape))
+            if size != 1])
+        packed_factors.append(factor.squeeze().clone())  # FIXME remove this clone
+        assert packed_factors[-1].dim() == len(packed_names[-1])
+
+    # Contract packed tensors.
+    expr = '{}->{}'.format(','.join(''.join(names) for names in packed_names),
+                           ''.join(target_names))
+    packed_result = opt_einsum.contract(expr, *packed_factors, backend='torch')
+
+    # Unpack result.
+    result = packed_result
+    for dim in range(-1, -1 - len(target_shape), -1):
+        if target_shape[dim] == 1:
+            result = result.unsqueeze(dim)
+    assert result.shape == target_shape
+    return result

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -94,6 +94,7 @@ def opt_sumproduct(factors, target_shape):
     # Contract packed tensors.
     expr = '{}->{}'.format(','.join(''.join(names) for names in packed_names),
                            ''.join(target_names))
+    print('DEBUG {}'.format(expr))
     packed_result = opt_einsum.contract(expr, *packed_factors, backend='torch')
 
     # Unpack result.

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         'graphviz>=0.8',
         'networkx>=2.0.0',
         'numpy>=1.7',
+        'opt_einsum==2.1.2',
         'six>=1.10.0',
         'torch==0.4.0',
     ],

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -973,6 +973,7 @@ def test_elbo_hmm_in_model(enumerate1, num_steps, expand):
     ("parallel", 3, False),
     ("parallel", 10, False),
     ("parallel", 20, False),
+    ("parallel", 22, False),
     pytest.param("parallel", 30, False, marks=pytest.mark.skip(reason="extremely expensive")),
 ])
 def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):
@@ -1024,6 +1025,10 @@ def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):
         20: {
             "transition_probs": [[3.70781687, -3.70781687], [3.70781687, -3.70781687]],
             "emission_probs": [[7.5, -7.5], [2.5, -2.5]],
+        },
+        22: {
+            "transition_probs": [[4.11979618, -4.11979618], [4.11979618, -4.11979618]],
+            "emission_probs": [[8.25, -8.25], [2.75, -2.75]],
         },
     }
 

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -11,7 +11,7 @@ from torch.distributions import constraints, kl_divergence
 
 import pyro
 import pyro.distributions as dist
-import pyro.ops._einsum
+import pyro.ops.einsum.deferred
 import pyro.optim
 import pyro.poutine as poutine
 from pyro.distributions.testing.rejection_gamma import ShapeAugmentedGamma
@@ -1085,7 +1085,7 @@ def test_elbo_hmm_in_guide_growth():
         start_time = timeit.default_timer()
         elbo.loss_and_grads(model, guide, data)
         times.append(timeit.default_timer() - start_time)
-        costs.append(pyro.ops._einsum.LAST_CACHE_SIZE[0])
+        costs.append(pyro.ops.einsum.deferred.LAST_CACHE_SIZE[0])
     print('Growth:')
     print('sizes = {}'.format(repr(sizes)))
     print('costs = {}'.format(repr(costs)))

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -1037,12 +1037,11 @@ def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):
         },
     }
 
+    if num_steps not in expected_grads:
+        return
     for name, value in pyro.get_param_store().named_parameters():
         actual = value.grad
-        try:
-            expected = torch.tensor(expected_grads[num_steps][name])
-        except KeyError:
-            continue
+        expected = torch.tensor(expected_grads[num_steps][name])
         assert_equal(actual, expected, msg=''.join([
             '\nexpected {}.grad = {}'.format(name, expected.cpu().numpy()),
             '\n  actual {}.grad = {}'.format(name, actual.detach().cpu().numpy()),

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -250,9 +250,9 @@ def test_svi_step_guide_uses_grad(enumerate1):
     def model():
         scale = pyro.param("scale")
         loc = pyro.sample("loc", dist.Normal(0., 10.))
+        pyro.sample("b", dist.Bernoulli(0.5))
         with pyro.iarange("data", len(data)):
             pyro.sample("obs", dist.Normal(loc, scale), obs=data)
-        pyro.sample("b", dist.Bernoulli(0.5))
 
     @config_enumerate(default=enumerate1)
     def guide():

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -973,7 +973,7 @@ def test_elbo_hmm_in_model(enumerate1, num_steps, expand):
     ("parallel", 3, False),
     ("parallel", 10, False),
     ("parallel", 20, False),
-    ("parallel", 22, False),
+    # ("parallel", 22, False),
     pytest.param("parallel", 30, False, marks=pytest.mark.skip(reason="extremely expensive")),
 ])
 def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -973,8 +973,7 @@ def test_elbo_hmm_in_model(enumerate1, num_steps, expand):
     ("parallel", 3, False),
     ("parallel", 10, False),
     ("parallel", 20, False),
-    # ("parallel", 22, False),
-    pytest.param("parallel", 30, False, marks=pytest.mark.skip(reason="extremely expensive")),
+    ("parallel", 30, False),
 ])
 def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):
     pyro.clear_param_store()
@@ -1029,6 +1028,10 @@ def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):
         22: {
             "transition_probs": [[4.11979618, -4.11979618], [4.11979618, -4.11979618]],
             "emission_probs": [[8.25, -8.25], [2.75, -2.75]],
+        },
+        30: {
+            "transition_probs": [[5.76771452, -5.76771452], [5.76771452, -5.76771452]],
+            "emission_probs": [[11.25, -11.25], [3.75, -3.75]],
         },
     }
 

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -974,6 +974,8 @@ def test_elbo_hmm_in_model(enumerate1, num_steps, expand):
     ("parallel", 10, False),
     ("parallel", 20, False),
     ("parallel", 30, False),
+    ("parallel", 40, False),
+    ("parallel", 50, False),
 ])
 def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):
     pyro.clear_param_store()
@@ -1037,7 +1039,10 @@ def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):
 
     for name, value in pyro.get_param_store().named_parameters():
         actual = value.grad
-        expected = torch.tensor(expected_grads[num_steps][name])
+        try:
+            expected = torch.tensor(expected_grads[num_steps][name])
+        except KeyError:
+            continue
         assert_equal(actual, expected, msg=''.join([
             '\nexpected {}.grad = {}'.format(name, expected.cpu().numpy()),
             '\n  actual {}.grad = {}'.format(name, actual.detach().cpu().numpy()),

--- a/tests/ops/einsum/conftest.py
+++ b/tests/ops/einsum/conftest.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if item.nodeid.startswith("tests/ops/einsum"):
+            if "stage" not in item.keywords:
+                item.add_marker(pytest.mark.stage("unit"))
+            if "init" not in item.keywords:
+                item.add_marker(pytest.mark.init(rng_seed=123))

--- a/tests/ops/einsum/test_deferred.py
+++ b/tests/ops/einsum/test_deferred.py
@@ -4,7 +4,7 @@ import opt_einsum
 import pytest
 import torch
 
-from pyro.ops._einsum import Deferred, contract, deferred_tensor, shared_intermediates
+from pyro.ops.einsum.deferred import Deferred, contract, deferred_tensor, shared_intermediates
 from tests.common import assert_equal
 
 
@@ -22,7 +22,7 @@ def test_deferred_backend():
         x_ = deferred_tensor(x)
         y_ = deferred_tensor(y)
         z_ = deferred_tensor(z)
-        actual_ = contract(expr, w_, x_, y_, z_, backend='pyro.ops._einsum')
+        actual_ = contract(expr, w_, x_, y_, z_, backend='pyro.ops.einsum.deferred')
 
     assert isinstance(actual_, Deferred)
     actual = actual_.eval()
@@ -40,7 +40,7 @@ def test_complete_sharing():
         x_ = deferred_tensor(x)
         y_ = deferred_tensor(y)
         z_ = deferred_tensor(z)
-        contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops._einsum')
+        contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops.einsum.deferred')
         expected = len(cache)
 
     print('-' * 40)
@@ -49,8 +49,8 @@ def test_complete_sharing():
         x_ = deferred_tensor(x)
         y_ = deferred_tensor(y)
         z_ = deferred_tensor(z)
-        contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops._einsum')
-        contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops._einsum')
+        contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops.einsum.deferred')
+        contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops.einsum.deferred')
         actual = len(cache)
 
     print('-' * 40)
@@ -72,13 +72,13 @@ def test_partial_sharing():
         x_ = deferred_tensor(x)
         y_ = deferred_tensor(y)
         z1_ = deferred_tensor(z1)
-        contract('ab,bc,cd->', x_, y_, z1_, backend='pyro.ops._einsum')
+        contract('ab,bc,cd->', x_, y_, z1_, backend='pyro.ops.einsum.deferred')
         num_exprs_nosharing += len(cache) - 3  # ignore deferred_tensor
     with shared_intermediates() as cache:
         x_ = deferred_tensor(x)
         y_ = deferred_tensor(y)
         z2_ = deferred_tensor(z1)
-        contract('ab,bc,cd->', x_, y_, z2_, backend='pyro.ops._einsum')
+        contract('ab,bc,cd->', x_, y_, z2_, backend='pyro.ops.einsum.deferred')
         num_exprs_nosharing += len(cache) - 3  # ignore deferred_tensor
 
     print('-' * 40)
@@ -88,8 +88,8 @@ def test_partial_sharing():
         y_ = deferred_tensor(y)
         z1_ = deferred_tensor(z1)
         z2_ = deferred_tensor(z2)
-        contract('ab,bc,cd->', x_, y_, z1_, backend='pyro.ops._einsum')
-        contract('ab,bc,cd->', x_, y_, z2_, backend='pyro.ops._einsum')
+        contract('ab,bc,cd->', x_, y_, z1_, backend='pyro.ops.einsum.deferred')
+        contract('ab,bc,cd->', x_, y_, z2_, backend='pyro.ops.einsum.deferred')
         num_exprs_sharing = len(cache) - 4  # ignore deferred_tensor
 
     print('-' * 40)
@@ -118,7 +118,7 @@ def test_chain(size):
             xs_ = [deferred_tensor(x) for x in xs]
             path_info = opt_einsum.contract_path(equation, *xs_)
             print(path_info[1])
-            contract(equation, *xs_, backend='pyro.ops._einsum')
+            contract(equation, *xs_, backend='pyro.ops.einsum.deferred')
         print('-' * 40)
 
 
@@ -137,7 +137,7 @@ def test_chain_2(size):
             xs_ = [deferred_tensor(x) for x in xs]
             path_info = opt_einsum.contract_path(equation, *xs_)
             print(path_info[1])
-            contract(equation, *xs_, backend='pyro.ops._einsum')
+            contract(equation, *xs_, backend='pyro.ops.einsum.deferred')
         print('-' * 40)
 
 
@@ -155,7 +155,7 @@ def test_chain_2_growth():
                 target = alphabet[i:i+2]
                 equation = '{}->{}'.format(inputs, target)
                 xs_ = [deferred_tensor(x) for x in xs]
-                contract(equation, *xs_, backend='pyro.ops._einsum')
+                contract(equation, *xs_, backend='pyro.ops.einsum.deferred')
             costs.append(compute_cost(cache))
 
     print('sizes = {}'.format(repr(sizes)))
@@ -177,7 +177,7 @@ def test_chain_sharing(size):
             target = alphabet[i]
             equation = '{}->{}'.format(inputs, target)
             xs_ = [deferred_tensor(x) for x in xs]
-            contract(equation, *xs_, backend='pyro.ops._einsum')
+            contract(equation, *xs_, backend='pyro.ops.einsum.deferred')
             num_exprs_nosharing += compute_cost(cache)
 
     with shared_intermediates() as cache:
@@ -188,7 +188,7 @@ def test_chain_sharing(size):
             xs_ = [deferred_tensor(x) for x in xs]
             path_info = opt_einsum.contract_path(equation, *xs_)
             print(path_info[1])
-            contract(equation, *xs_, backend='pyro.ops._einsum')
+            contract(equation, *xs_, backend='pyro.ops.einsum.deferred')
         num_exprs_sharing = compute_cost(cache)
 
     print('-' * 40)

--- a/tests/ops/test_einsum.py
+++ b/tests/ops/test_einsum.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import opt_einsum
 import torch
 
-import pyro.ops._einsum
 from pyro.ops._einsum import Deferred, deferred_tensor, shared_intermediates
 from tests.common import assert_equal
 
@@ -36,22 +35,22 @@ def test_complete_sharing():
 
     print('-' * 40)
     print('Without sharing:')
-    with shared_intermediates():
+    with shared_intermediates() as cache:
         x_ = deferred_tensor(x)
         y_ = deferred_tensor(y)
         z_ = deferred_tensor(z)
         opt_einsum.contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops._einsum')
-        expected = len(pyro.ops._einsum.CACHE)
+        expected = len(cache)
 
     print('-' * 40)
     print('With sharing:')
-    with shared_intermediates():
+    with shared_intermediates() as cache:
         x_ = deferred_tensor(x)
         y_ = deferred_tensor(y)
         z_ = deferred_tensor(z)
         opt_einsum.contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops._einsum')
         opt_einsum.contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops._einsum')
-        actual = len(pyro.ops._einsum.CACHE)
+        actual = len(cache)
 
     print('-' * 40)
     print('Without sharing: {} expressions'.format(expected))
@@ -68,29 +67,29 @@ def test_partial_sharing():
     print('-' * 40)
     print('Without sharing:')
     num_exprs_nosharing = 0
-    with shared_intermediates():
+    with shared_intermediates() as cache:
         x_ = deferred_tensor(x)
         y_ = deferred_tensor(y)
         z1_ = deferred_tensor(z1)
         opt_einsum.contract('ab,bc,cd->', x_, y_, z1_, backend='pyro.ops._einsum')
-        num_exprs_nosharing += len(pyro.ops._einsum.CACHE) - 3  # ignore deferred_tensor
-    with shared_intermediates():
+        num_exprs_nosharing += len(cache) - 3  # ignore deferred_tensor
+    with shared_intermediates() as cache:
         x_ = deferred_tensor(x)
         y_ = deferred_tensor(y)
         z2_ = deferred_tensor(z1)
         opt_einsum.contract('ab,bc,cd->', x_, y_, z2_, backend='pyro.ops._einsum')
-        num_exprs_nosharing += len(pyro.ops._einsum.CACHE) - 3  # ignore deferred_tensor
+        num_exprs_nosharing += len(cache) - 3  # ignore deferred_tensor
 
     print('-' * 40)
     print('With sharing:')
-    with shared_intermediates():
+    with shared_intermediates() as cache:
         x_ = deferred_tensor(x)
         y_ = deferred_tensor(y)
         z1_ = deferred_tensor(z1)
         z2_ = deferred_tensor(z2)
         opt_einsum.contract('ab,bc,cd->', x_, y_, z1_, backend='pyro.ops._einsum')
         opt_einsum.contract('ab,bc,cd->', x_, y_, z2_, backend='pyro.ops._einsum')
-        num_exprs_sharing = len(pyro.ops._einsum.CACHE) - 4  # ignore deferred_tensor
+        num_exprs_sharing = len(cache) - 4  # ignore deferred_tensor
 
     print('-' * 40)
     print('Without sharing: {} expressions'.format(num_exprs_nosharing))

--- a/tests/ops/test_einsum.py
+++ b/tests/ops/test_einsum.py
@@ -29,7 +29,37 @@ def test_deferred_backend():
     assert_equal(actual, expected)
 
 
-def test_sharing():
+def test_complete_sharing():
+    x = torch.randn(5, 4)
+    y = torch.randn(4, 3)
+    z = torch.randn(3, 2)
+
+    print('-' * 40)
+    print('Without sharing:')
+    with shared_intermediates():
+        x_ = deferred_tensor(x)
+        y_ = deferred_tensor(y)
+        z_ = deferred_tensor(z)
+        opt_einsum.contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops._einsum')
+        expected = len(pyro.ops._einsum.CACHE)
+
+    print('-' * 40)
+    print('With sharing:')
+    with shared_intermediates():
+        x_ = deferred_tensor(x)
+        y_ = deferred_tensor(y)
+        z_ = deferred_tensor(z)
+        opt_einsum.contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops._einsum')
+        opt_einsum.contract('ab,bc,cd->', x_, y_, z_, backend='pyro.ops._einsum')
+        actual = len(pyro.ops._einsum.CACHE)
+
+    print('-' * 40)
+    print('Without sharing: {} expressions'.format(expected))
+    print('With sharing: {} expressions'.format(actual))
+    assert actual == expected
+
+
+def test_partial_sharing():
     x = torch.randn(5, 4)
     y = torch.randn(4, 3)
     z1 = torch.randn(3, 2)

--- a/tests/ops/test_einsum.py
+++ b/tests/ops/test_einsum.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import, division, print_function
 import opt_einsum
 import torch
 
-from pyro.ops._einsum import Deferred, DeferredTensor, shared_intermediates
+import pyro.ops._einsum
+from pyro.ops._einsum import Deferred, deferred_tensor, shared_intermediates
 from tests.common import assert_equal
 
 
@@ -17,12 +18,51 @@ def test_deferred_backend():
     expected = opt_einsum.contract(expr, w, x, y, z, backend='torch')
 
     with shared_intermediates():
-        w_ = DeferredTensor(w)
-        x_ = DeferredTensor(x)
-        y_ = DeferredTensor(y)
-        z_ = DeferredTensor(z)
+        w_ = deferred_tensor(w)
+        x_ = deferred_tensor(x)
+        y_ = deferred_tensor(y)
+        z_ = deferred_tensor(z)
         actual_ = opt_einsum.contract(expr, w_, x_, y_, z_, backend='pyro.ops._einsum')
 
     assert isinstance(actual_, Deferred)
     actual = actual_.eval()
     assert_equal(actual, expected)
+
+
+def test_sharing():
+    x = torch.randn(5, 4)
+    y = torch.randn(4, 3)
+    z1 = torch.randn(3, 2)
+    z2 = torch.randn(3, 2)
+
+    print('-' * 40)
+    print('Without sharing:')
+    num_exprs_nosharing = 0
+    with shared_intermediates():
+        x_ = deferred_tensor(x)
+        y_ = deferred_tensor(y)
+        z1_ = deferred_tensor(z1)
+        opt_einsum.contract('ab,bc,cd->', x_, y_, z1_, backend='pyro.ops._einsum')
+        num_exprs_nosharing += len(pyro.ops._einsum.CACHE) - 3  # ignore deferred_tensor
+    with shared_intermediates():
+        x_ = deferred_tensor(x)
+        y_ = deferred_tensor(y)
+        z2_ = deferred_tensor(z1)
+        opt_einsum.contract('ab,bc,cd->', x_, y_, z2_, backend='pyro.ops._einsum')
+        num_exprs_nosharing += len(pyro.ops._einsum.CACHE) - 3  # ignore deferred_tensor
+
+    print('-' * 40)
+    print('With sharing:')
+    with shared_intermediates():
+        x_ = deferred_tensor(x)
+        y_ = deferred_tensor(y)
+        z1_ = deferred_tensor(z1)
+        z2_ = deferred_tensor(z2)
+        opt_einsum.contract('ab,bc,cd->', x_, y_, z1_, backend='pyro.ops._einsum')
+        opt_einsum.contract('ab,bc,cd->', x_, y_, z2_, backend='pyro.ops._einsum')
+        num_exprs_sharing = len(pyro.ops._einsum.CACHE) - 4  # ignore deferred_tensor
+
+    print('-' * 40)
+    print('Without sharing: {} expressions'.format(num_exprs_nosharing))
+    print('With sharing: {} expressions'.format(num_exprs_sharing))
+    assert num_exprs_nosharing > num_exprs_sharing

--- a/tests/ops/test_einsum.py
+++ b/tests/ops/test_einsum.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import, division, print_function
+
+import opt_einsum
+import torch
+
+from pyro.ops._einsum import Deferred, DeferredTensor, shared_intermediates
+from tests.common import assert_equal
+
+
+def test_deferred_backend():
+    w = torch.randn(2, 3, 4)
+    x = torch.randn(3, 4, 5)
+    y = torch.randn(4, 5, 6)
+    z = torch.randn(5, 6, 7)
+    expr = 'abc,bcd,cde,def->af'
+
+    expected = opt_einsum.contract(expr, w, x, y, z, backend='torch')
+
+    with shared_intermediates():
+        w_ = DeferredTensor(w)
+        x_ = DeferredTensor(x)
+        y_ = DeferredTensor(y)
+        z_ = DeferredTensor(z)
+        actual_ = opt_einsum.contract(expr, w_, x_, y_, z_, backend='pyro.ops._einsum')
+
+    assert isinstance(actual_, Deferred)
+    actual = actual_.eval()
+    assert_equal(actual, expected)

--- a/tests/ops/test_einsum.py
+++ b/tests/ops/test_einsum.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import opt_einsum
+import pytest
 import torch
 
 from pyro.ops._einsum import Deferred, deferred_tensor, shared_intermediates
@@ -90,6 +91,44 @@ def test_partial_sharing():
         opt_einsum.contract('ab,bc,cd->', x_, y_, z1_, backend='pyro.ops._einsum')
         opt_einsum.contract('ab,bc,cd->', x_, y_, z2_, backend='pyro.ops._einsum')
         num_exprs_sharing = len(cache) - 4  # ignore deferred_tensor
+
+    print('-' * 40)
+    print('Without sharing: {} expressions'.format(num_exprs_nosharing))
+    print('With sharing: {} expressions'.format(num_exprs_sharing))
+    assert num_exprs_nosharing > num_exprs_sharing
+
+
+def compute_cost(cache):
+    return sum(1 for v in cache.values()
+               if type(v).__name__ in ('Einsum', 'Tensordot'))
+
+
+@pytest.mark.parametrize('size', [3, 4, 5])
+def test_chain_sharing(size):
+    xs = [torch.randn(2, 2) for _ in range(size)]
+    alphabet = ''.join(opt_einsum.get_symbol(i) for i in range(size + 1))
+    names = [alphabet[i:i+2] for i in range(size)]
+    inputs = ','.join(names)
+
+    num_exprs_nosharing = 0
+    for i in range(size + 1):
+        with shared_intermediates() as cache:
+            target = alphabet[i]
+            equation = '{}->{}'.format(inputs, target)
+            xs_ = [deferred_tensor(x) for x in xs]
+            opt_einsum.contract(equation, *xs_, backend='pyro.ops._einsum')
+            num_exprs_nosharing += compute_cost(cache)
+
+    with shared_intermediates() as cache:
+        print(inputs)
+        for i in range(size + 1):
+            target = alphabet[i]
+            equation = '{}->{}'.format(inputs, target)
+            xs_ = [deferred_tensor(x) for x in xs]
+            path_info = opt_einsum.contract_path(equation, *xs_)
+            print(path_info[1])
+            opt_einsum.contract(equation, *xs_, backend='pyro.ops._einsum')
+        num_exprs_sharing = compute_cost(cache)
 
     print('-' * 40)
     print('Without sharing: {} expressions'.format(num_exprs_nosharing))

--- a/tests/ops/test_sumproduct.py
+++ b/tests/ops/test_sumproduct.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from pyro.ops.sumproduct import zip_align_right
+
+
+@pytest.mark.parametrize('xs,ys,expected', [
+    (['a', 'b'], [6, 5], [('a', 6), ('b', 5)]),
+    (['b'], [6, 5], [('b', 5)]),
+    (['a', 'b'], [5], [('b', 5)]),
+])
+def test_zip_align_right(xs, ys, expected):
+    actual = list(zip_align_right(xs, ys))
+    assert actual == expected


### PR DESCRIPTION
Adresses #915 
Pair coded with @eb8680 

This uses the [opt_einsum](https://github.com/dgasmith/opt_einsum) package to implement a cheap batched `sumproduct()` operation which is then used in `TraceEnum_ELBO` to perform message passing. This allows us to marginalize out discrete latent variables. E.g. for HMMs, this allows linear-time inference (per SVI step).

Currently this implementation does not handle `iarange` and falls back to naive inference for models with `iarange`.

## Tested

- [x] added tests for `pyro.ops._einsum` module
- [x] added new tests for `TraceEnum_ELBO`
- [x] enabled larger HMM test cases