### PR TITLE
Implement logsumexp backend for opt_einsum

### DIFF
--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -1,0 +1,84 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+
+from opt_einsum.parser import einsum_symbols_base
+
+
+def transpose(a, axes):
+    return a.permute(*axes)
+
+
+def einsum(equation, *operands):
+    """
+    Log-sum-exp implementation of einsum.
+    """
+    inputs, output = equation.split('->')
+    inputs = inputs.split(',')
+
+    shifts = []
+    exp_operands = []
+    for dims, operand in zip(inputs, operands):
+        shift = operand
+        for i, dim in enumerate(dims):
+            if dim not in output:
+                shift = shift.max(i, keepdim=True)[0]
+        exp_operands.append((operand - shift).exp())
+
+        # permute shift to match output
+        shift = shift.squeeze()
+        dims = [dim for dim in dims if dim in output]
+        dims = [dim for dim in output if dim not in dims] + dims
+        shift = shift.reshape((1,) * (len(output) - len(shift.shape)) + shift.shape)
+        if dims:
+            shift = shift.permute(*(dims.index(dim) for dim in output))
+        shifts.append(shift)
+
+    result = torch.einsum(equation, exp_operands).log()
+    return sum(shifts + [result])
+
+
+# Copyright (c) 2014 Daniel Smith
+# This function is copied and adapted from:
+# https://github.com/dgasmith/opt_einsum/blob/a6dd686/opt_einsum/backends/torch.py
+def tensordot(x, y, axes=2):
+    xnd = x.ndimension()
+    ynd = y.ndimension()
+
+    # convert int argument to (list[int], list[int])
+    if isinstance(axes, int):
+        axes = range(xnd - axes, xnd), range(axes)
+
+    # convert (int, int) to (list[int], list[int])
+    if isinstance(axes[0], int):
+        axes = (axes[0],), axes[1]
+    if isinstance(axes[1], int):
+        axes = axes[0], (axes[1],)
+
+    # initialize empty indices
+    x_ix = [None] * xnd
+    y_ix = [None] * ynd
+    out_ix = []
+
+    # fill in repeated indices
+    available_ix = iter(einsum_symbols_base)
+    for ax1, ax2 in zip(*axes):
+        repeat = next(available_ix)
+        x_ix[ax1] = repeat
+        y_ix[ax2] = repeat
+
+    # fill in the rest, and maintain output order
+    for i in range(xnd):
+        if x_ix[i] is None:
+            leave = next(available_ix)
+            x_ix[i] = leave
+            out_ix.append(leave)
+    for i in range(ynd):
+        if y_ix[i] is None:
+            leave = next(available_ix)
+            y_ix[i] = leave
+            out_ix.append(leave)
+
+    # form full string and contract!
+    einsum_str = "{},{}->{}".format(*map("".join, (x_ix, y_ix, out_ix)))
+    return einsum(einsum_str, x, y)


### PR DESCRIPTION
Addresses #915 
Pair coded with @eb8680 

This implements a logsumexp backend for `opt_einsum.contract()` and `sumproduct()`. To use this for logsumexp contraction, set the appropriate backend:
```py
log_factors = [...]
log_result = sumproduct(log_factors, backend='pyro.ops.einsum.torch_log')
```
To share comptation among multiple calls, you can combine this with the deferred backend
```py
from pyro.ops.einsum.deferred import deferred_tensor, shared_intermediates

log_factors1 = [...]
log_factors2 = [...]
with shared_intermediates():
    log_factors1_ = [deferred_tensor(t) for t in log_factors1]
    log_factors2_ = [deferred_tensor(t) for t in log_factors2]
    results_ = [sumproduct(log_factors1_ + [t], backend='pyro.ops.einsum.deferred')
                for t in log_factors2_]
results = [t.eval(backend='pyro.ops.einsum.torch_log') for t in results_]
```

## Tested

- added tests against naive implementation