### PR TITLE
Add support for iarange in einsum-based Dice

### DIFF
--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -2,13 +2,14 @@ from __future__ import absolute_import, division, print_function
 
 import math
 import numbers
+import operator
 from collections import defaultdict
 
 import torch
 from six.moves import reduce
 from torch.distributions.utils import broadcast_all
 
-from pyro.distributions.util import broadcast_shape, is_identically_zero
+from pyro.distributions.util import is_identically_zero
 from pyro.ops.einsum.deferred import shared_intermediates
 from pyro.ops.sumproduct import sumproduct
 from pyro.poutine.util import site_is_subsample
@@ -129,20 +130,11 @@ class MultiFrameTensor(dict):
             '({}, ...)'.format(frames) for frames in self]))
 
 
-def deduplicate_by_shape(tensors, combine=lambda a, b: a + b):
+def deduplicate_by_shape(tensors, combine=operator.add):
     grouped = defaultdict(list)
     for tensor in tensors:
         grouped[getattr(tensor, 'shape', None)].append(tensor)
     return [reduce(combine, parts) for parts in grouped.values()]
-
-
-def expand_to_ordinal(ordinal, tensor):
-    shape = [1] * max(-frame.dim for frame in ordinal)
-    for frame in ordinal:
-        if frame.size is not None:
-            shape[frame.dim] = frame.size
-    tensor, _ = broadcast_all(tensor, torch.empty(torch.Size(shape)))
-    return tensor
 
 
 class Dice(object):
@@ -202,7 +194,6 @@ class Dice(object):
                 log_prob = log_prob - log_prob.detach()
             log_probs[ordinal].append(log_prob)
 
-        self.has_iaranges = any(ordinal for ordinal in ordering.values())
         self.log_denom = log_denom
         self.log_probs = log_probs
         self._log_factors_cache = {}
@@ -231,50 +222,7 @@ class Dice(object):
         self._log_factors_cache[target_ordinal] = log_factors
         return log_factors
 
-    def in_context(self, shape, ordinal):
-        """
-        Returns the DiCE operator at a given ordinal, summed to given shape.
-
-        :param torch.Size shape: a target shape
-        :param ordinal: an ordinal key that has been passed in to the
-            ``ordering`` argument of the :class:`Dice` constructor.
-        :return: the dice probability summed down to at most ``shape``.
-            This should be broadcastable up to ``shape``.
-        :rtype: torch.Tensor or float
-        """
-        # ignore leading 1's since they can be broadcast
-        while shape and shape[0] == 1:
-            shape = shape[1:]
-
-        # memoize
-        try:
-            return self._prob_cache[shape, ordinal]
-        except KeyError:
-            pass
-
-        # Version 1. correct
-        log_prob = sum(self._get_log_factors(ordinal))
-        if isinstance(log_prob, numbers.Number):
-            dice_prob = math.exp(log_prob)
-        else:
-            dice_prob = log_prob.exp()
-            while dice_prob.dim() > len(shape):
-                dice_prob = dice_prob.sum(0)
-            while dice_prob.dim() < len(shape):
-                dice_prob = dice_prob.unsqueeze(0)
-            for dim, (dice_size, target_size) in enumerate(zip(dice_prob.shape, shape)):
-                if dice_size > target_size:
-                    dice_prob = dice_prob.sum(dim, True)
-
-        # Version 2. fails test_normals
-        # log_factors = self._get_log_factors(ordinal)
-        # factors = [torch_exp(f) for f in log_factors]
-        # dice_prob = sumproduct(factors, shape, optimize=False)
-
-        self._prob_cache[shape, ordinal] = dice_prob
-        return dice_prob
-
-    def compute_expectation(self, costs, use_einsum=True):
+    def compute_expectation(self, costs):
         """
         Returns a differentiable expected cost, summing over costs at given ordinals.
 
@@ -282,52 +230,6 @@ class Dice(object):
         :returns: a scalar expected cost
         :rtype: torch.Tensor or float
         """
-        # einsum is currently incompatible with iarange
-        if use_einsum:
-            return self._opt_compute_expectation(costs)
-        else:
-            return self._naive_compute_expectation(costs)
-
-    def _naive_compute_expectation(self, costs):
-        expected_cost = 0.
-        for ordinal, cost_terms in costs.items():
-            # Version 1. correct
-            # cost = sum(cost_terms)
-            # prob = self.in_context(cost.shape, ordinal)
-            # mask = prob > 0
-            # if torch.is_tensor(mask) and not mask.all():
-            #     cost, prob, mask = broadcast_all(cost, prob, mask)
-            #     prob = prob[mask]
-            #     cost = cost[mask]
-            # expected_cost = expected_cost + (prob * cost).sum()
-
-            # Version 2. fails test_elbo_normals
-            # for cost in cost_terms:
-            #     cost = expand_to_ordinal(ordinal, cost)
-            #     prob = self.in_context(cost.shape, ordinal)
-            #     mask = prob > 0
-            #     if torch.is_tensor(mask) and not mask.all():
-            #         cost, prob, mask = broadcast_all(cost, prob, mask)
-            #         prob = prob[mask]
-            #         cost = cost[mask]
-            #     expected_cost = expected_cost + (prob * cost).sum()
-
-            # Version 3. fails test_elbo_normals
-            shape = broadcast_shape(*(c.shape for c in cost_terms))
-            for cost in cost_terms:
-                prob = self.in_context(cost.shape, ordinal)
-                # cost = cost.expand(shape)  # <-- this is the crux
-                # if cost.shape != shape:
-                #     import pdb; pdb.set_trace()
-                mask = prob > 0
-                if torch.is_tensor(mask) and not mask.all():
-                    cost, prob, mask = broadcast_all(cost, prob, mask)
-                    prob = prob[mask]
-                    cost = cost[mask]
-                expected_cost = expected_cost + (prob * cost).sum()
-        return expected_cost
-
-    def _opt_compute_expectation(self, costs):
         # precompute exponentials to be shared across calls to sumproduct
         exp_table = {}
         factors_table = defaultdict(list)
@@ -344,7 +246,7 @@ class Dice(object):
         # deduplicate by shape to increase sharing
         costs = {ordinal: deduplicate_by_shape(group)
                  for ordinal, group in costs.items()}
-        factors_table = {ordinal: deduplicate_by_shape(group, combine=lambda a, b: a * b)
+        factors_table = {ordinal: deduplicate_by_shape(group, combine=operator.mul)
                          for ordinal, group in factors_table.items()}
 
         # share computation across all cost terms

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -8,7 +8,7 @@ import torch
 from six.moves import reduce
 from torch.distributions.utils import broadcast_all
 
-from pyro.distributions.util import is_identically_zero
+from pyro.distributions.util import broadcast_shape, is_identically_zero
 from pyro.ops.einsum.deferred import shared_intermediates
 from pyro.ops.sumproduct import sumproduct
 from pyro.poutine.util import site_is_subsample
@@ -238,7 +238,7 @@ class Dice(object):
         except KeyError:
             pass
 
-        # TODO replace this naive sum-product computation with message passing.
+        # Version 1. correct
         log_prob = sum(self._get_log_factors(ordinal))
         if isinstance(log_prob, numbers.Number):
             dice_prob = math.exp(log_prob)
@@ -251,10 +251,11 @@ class Dice(object):
             for dim, (dice_size, target_size) in enumerate(zip(dice_prob.shape, shape)):
                 if dice_size > target_size:
                     dice_prob = dice_prob.sum(dim, True)
-        # Note that the following cheaper version appears to be broken:
+
+        # Version 2. fails test_normals
         # log_factors = self._get_log_factors(ordinal)
         # factors = [torch_exp(f) for f in log_factors]
-        # dice_prob = sumproduct(factors, shape)
+        # dice_prob = sumproduct(factors, shape, optimize=False)
 
         self._prob_cache[shape, ordinal] = dice_prob
         return dice_prob
@@ -268,7 +269,7 @@ class Dice(object):
         :rtype: torch.Tensor or float
         """
         # einsum is currently incompatible with iarange
-        if use_einsum and not self.has_iaranges:
+        if use_einsum:
             return self._opt_compute_expectation(costs)
         else:
             return self._naive_compute_expectation(costs)
@@ -276,14 +277,14 @@ class Dice(object):
     def _naive_compute_expectation(self, costs):
         expected_cost = 0.
         for ordinal, cost_terms in costs.items():
-            cost = sum(cost_terms)
-            prob = self.in_context(cost.shape, ordinal)
-            mask = prob > 0
-            if torch.is_tensor(mask) and not mask.all():
-                cost, prob, mask = broadcast_all(cost, prob, mask)
-                prob = prob[mask]
-                cost = cost[mask]
-            expected_cost = expected_cost + (prob * cost).sum()
+            for cost in cost_terms:
+                prob = self.in_context(cost.shape, ordinal)
+                mask = prob > 0
+                if torch.is_tensor(mask) and not mask.all():
+                    cost, prob, mask = broadcast_all(cost, prob, mask)
+                    prob = prob[mask]
+                    cost = cost[mask]
+                expected_cost = expected_cost + (prob * cost).sum()
         return expected_cost
 
     def _opt_compute_expectation(self, costs):
@@ -292,16 +293,19 @@ class Dice(object):
         factors_table = defaultdict(list)
         for ordinal in costs:
             for log_factor in self._get_log_factors(ordinal):
-                if id(log_factor) not in exp_table:
+                key = id(log_factor)
+                if key in exp_table:
+                    factor = exp_table[key]
+                else:
                     factor = torch_exp(log_factor)
-                    exp_table[id(log_factor)] = factor
-                    factors_table[ordinal].append(factor)
+                    exp_table[key] = factor
+                factors_table[ordinal].append(factor)
 
         # deduplicate by shape to increase sharing
         costs = {ordinal: deduplicate_by_shape(group)
-                 for ordinals, group in costs.items()}
+                 for ordinal, group in costs.items()}
         factors_table = {ordinal: deduplicate_by_shape(group, combine=lambda a, b: a * b)
-                         for ordinals, group in factors_table.items()}
+                         for ordinal, group in factors_table.items()}
 
         # share computation across all cost terms
         with shared_intermediates():

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -4,6 +4,7 @@ import operator
 from numbers import Number
 
 import torch
+from six.moves import reduce
 
 import opt_einsum
 from pyro.distributions.util import broadcast_shape

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -26,7 +26,6 @@ def sumproduct(factors, target_shape=(), optimize=True, backend='torch'):
     if numbers:
         number_part = reduce(operator.mul, numbers, 1.)
         tensor_part = sumproduct(tensors, target_shape, optimize=optimize, backend=backend)
-        contracted_shape = shape[:len(shape) - len(target_shape)]
         return tensor_part * number_part
 
     # Work around opt_einsum interface lack of support for pure broadcasting.

--- a/tests/ops/test_sumproduct.py
+++ b/tests/ops/test_sumproduct.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import operator
+
 import pytest
 import torch
 from six.moves import reduce
@@ -28,7 +30,7 @@ def test_sumproduct(factor_shapes, shape, optimize):
                for s in factor_shapes]
     actual = sumproduct(factors, shape, optimize=optimize)
 
-    expected = reduce(lambda x, y: x * y, factors)
+    expected = reduce(operator.mul, factors)
     while expected.dim() > len(shape):
         expected = expected.sum(0)
     while expected.dim() < len(shape):

--- a/tests/ops/test_sumproduct.py
+++ b/tests/ops/test_sumproduct.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+import torch
+from six.moves import reduce
 
-from pyro.ops.sumproduct import zip_align_right
+from pyro.ops.sumproduct import sumproduct, zip_align_right
+from tests.common import assert_equal
 
 
 @pytest.mark.parametrize('xs,ys,expected', [
@@ -13,3 +16,26 @@ from pyro.ops.sumproduct import zip_align_right
 def test_zip_align_right(xs, ys, expected):
     actual = list(zip_align_right(xs, ys))
     assert actual == expected
+
+
+@pytest.mark.parametrize('factor_shapes,shape', [
+    ([(), (100000, 1, 2, 1), (2, 100000, 1, 1, 1)], (100000, 1, 2, 1)),
+    ([None, (100000, 1, 2, 1), (2, 100000, 1, 1, 1)], (100000, 1, 2, 1)),
+])
+@pytest.mark.parametrize('optimize', [False, True])
+def test_sumproduct(factor_shapes, shape, optimize):
+    factors = [0.2 if s is None else torch.randn(s).exp()
+               for s in factor_shapes]
+    actual = sumproduct(factors, shape, optimize=optimize)
+
+    expected = reduce(lambda x, y: x * y, factors)
+    while expected.dim() > len(shape):
+        expected = expected.sum(0)
+    while expected.dim() < len(shape):
+        expected = expected.unsqueeze(0)
+    for i, (e, s) in enumerate(zip(expected.shape, shape)):
+        if e > s:
+            expected = expected.sum(i, keepdim=True)
+    assert expected.shape == shape
+
+    assert_equal(actual, expected)


### PR DESCRIPTION
Addresses #915 
Pair coded with @eb8680 

This fixes a number of bugs in the einsum backend for `Dice`, and switches to this backend for all models.

## Tested

- enabled einsum backend on existing unit tests (some of which failed before this PR)
- added unit tests for `sumproduct`
