### PR TITLE
Make einsum inputs deterministic to increase sharing

### DIFF
--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import warnings
 import weakref
-from collections import defaultdict
+from collections import OrderedDict
 
 import torch
 from six.moves import queue
@@ -25,13 +25,13 @@ def _compute_dice_elbo(model_trace, guide_trace):
                 for name, site in trace.nodes.items()
                 if site["type"] == "sample"}
 
-    costs = defaultdict(list)
+    costs = OrderedDict()
     for name, site in model_trace.nodes.items():
         if site["type"] == "sample":
-            costs[ordering[name]].append(site["log_prob"])
+            costs.setdefault(ordering[name], []).append(site["log_prob"])
     for name, site in guide_trace.nodes.items():
         if site["type"] == "sample":
-            costs[ordering[name]].append(-site["log_prob"])
+            costs.setdefault(ordering[name], []).append(-site["log_prob"])
 
     return Dice(guide_trace, ordering).compute_expectation(costs)
 

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -244,15 +244,15 @@ class Dice(object):
                 factors_table[ordinal].append(factor)
 
         # deduplicate by shape to increase sharing
-        costs = {ordinal: deduplicate_by_shape(group)
-                 for ordinal, group in costs.items()}
+        costs = [(ordinal, deduplicate_by_shape(group))
+                 for ordinal, group in costs.items()]
         factors_table = {ordinal: deduplicate_by_shape(group, combine=operator.mul)
                          for ordinal, group in factors_table.items()}
 
         # share computation across all cost terms
         with shared_intermediates():
             expected_cost = 0.
-            for ordinal, cost_terms in costs.items():
+            for ordinal, cost_terms in costs:
                 factors = factors_table.get(ordinal, [])
                 for cost in cost_terms:
                     prob = sumproduct(factors, cost.shape)

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -1207,7 +1207,7 @@ def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):
         ]))
 
 
-def test_elbo_hmm_in_guide_growth():
+def test_elbo_hmm_growth():
     pyro.clear_param_store()
     init_probs = torch.tensor([0.5, 0.5])
     elbo = TraceEnum_ELBO(max_iarange_nesting=0)
@@ -1258,6 +1258,9 @@ def test_elbo_hmm_in_guide_growth():
     print('times1 = {}'.format(repr(times1)))
     print('times2 = {}'.format(repr(times2)))
 
+    # This assertion may fail nondeterministically:
+    # assert costs[-3] + costs[-1] == 2 * costs[-2], 'cost is not asymptotically linear'
+
 
 def test_elbo_dbn_growth():
     pyro.clear_param_store()
@@ -1288,7 +1291,7 @@ def test_elbo_dbn_growth():
             x = pyro.sample("x_{}".format(i), dist.Categorical(probs_x[x]))
             y = pyro.sample("y_{}".format(i), dist.Categorical(probs_y[x, y]))
 
-    sizes = range(1, 31)
+    sizes = range(1, 11)
     costs = []
     times1 = []
     times2 = []
@@ -1310,6 +1313,9 @@ def test_elbo_dbn_growth():
     print('costs = {}'.format(repr(costs)))
     print('times1 = {}'.format(repr(times1)))
     print('times2 = {}'.format(repr(times2)))
+
+    # This assertion may fail nondeterministically:
+    # assert costs[-3] + costs[-1] == 2 * costs[-2], 'cost is not asymptotically linear'
 
 
 @pytest.mark.parametrize("pi_a", [0.33])

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -1259,6 +1259,59 @@ def test_elbo_hmm_in_guide_growth():
     print('times2 = {}'.format(repr(times2)))
 
 
+def test_elbo_dbn_growth():
+    pyro.clear_param_store()
+    elbo = TraceEnum_ELBO(max_iarange_nesting=0)
+
+    def model(data):
+        uniform = torch.tensor([0.5, 0.5])
+        probs_z = pyro.param("probs_z",
+                             torch.tensor([[0.75, 0.25], [0.25, 0.75]]),
+                             constraint=constraints.simplex)
+        for i, z in enumerate(data):
+            pyro.sample("x_{}".format(i), dist.Categorical(uniform))
+            y = pyro.sample("y_{}".format(i), dist.Categorical(uniform))
+            pyro.sample("z_{}".format(i), dist.Categorical(probs_z[y]), obs=z)
+
+    @config_enumerate(default="parallel", expand=False)
+    def guide(data):
+        probs_x = pyro.param("probs_x",
+                             torch.tensor([[0.75, 0.25], [0.25, 0.75]]),
+                             constraint=constraints.simplex)
+        probs_y = pyro.param("probs_y",
+                             torch.tensor([[[0.75, 0.25], [0.45, 0.55]],
+                                           [[0.55, 0.45], [0.25, 0.75]]]),
+                             constraint=constraints.simplex)
+        x = 0
+        y = 0
+        for i in range(len(data)):
+            x = pyro.sample("x_{}".format(i), dist.Categorical(probs_x[x]))
+            y = pyro.sample("y_{}".format(i), dist.Categorical(probs_y[x, y]))
+
+    sizes = range(1, 31)
+    costs = []
+    times1 = []
+    times2 = []
+    for size in sizes:
+        data = torch.ones(size)
+
+        time0 = timeit.default_timer()
+        elbo.loss_and_grads(model, guide, data)  # compiles paths
+        time1 = timeit.default_timer()
+        elbo.loss_and_grads(model, guide, data)  # reuses compiled path
+        time2 = timeit.default_timer()
+
+        times1.append(time1 - time0)
+        times2.append(time2 - time1)
+        costs.append(pyro.ops.einsum.shared.LAST_CACHE_SIZE[0])
+
+    print('Growth:')
+    print('sizes = {}'.format(repr(sizes)))
+    print('costs = {}'.format(repr(costs)))
+    print('times1 = {}'.format(repr(times1)))
+    print('times2 = {}'.format(repr(times2)))
+
+
 @pytest.mark.parametrize("pi_a", [0.33])
 @pytest.mark.parametrize("pi_b", [0.51, 0.77])
 @pytest.mark.parametrize("pi_c", [0.37])


### PR DESCRIPTION
Addresses #915 
Pair coded with @eb8680 

This make the cost list computation deterministic inside of `TraceEnum_ELBO` and `Dice`, thereby making the `einsum` path optimization more deterministic, and finally increasing the opportunity for sharing across multiple calls to `einsum.contract`.

## Tested

- added a test and manually inspected that the operation counts increase approximately linearly