### PR TITLE
Work around performance issues in torch.einsum

### DIFF
--- a/tests/ops/test_sumproduct.py
+++ b/tests/ops/test_sumproduct.py
@@ -7,10 +7,10 @@ import pytest
 import torch
 from six.moves import reduce
 
+import pyro.distributions.torch_patch  # noqa: F401
 from pyro.ops.einsum import contract, shared_intermediates
 from pyro.ops.sumproduct import sumproduct, zip_align_right
 from tests.common import assert_equal
-import pyro.distributions.torch_patch
 
 
 @pytest.mark.parametrize('xs,ys,expected', [


### PR DESCRIPTION
This can be removed after https://github.com/pytorch/pytorch/issues/10661 is fixed. The motivating example is tests/infer/mcmc/test_hmc.py::test_bernoulli_latent_model

# Tested

- added a performance test