### PR TITLE
Simplify einsum shared

### DIFF
--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import math
 import numbers
 import operator
-from collections import defaultdict
+from collections import Counter, defaultdict
 
 import torch
 from six.moves import reduce
@@ -15,6 +15,7 @@ from pyro.ops.sumproduct import sumproduct
 from pyro.poutine.util import site_is_subsample
 
 _VALIDATION_ENABLED = False
+LAST_CACHE_SIZE = [Counter()]  # for profiling
 
 
 def enable_validation(is_validate):
@@ -250,7 +251,7 @@ class Dice(object):
                          for ordinal, group in factors_table.items()}
 
         # share computation across all cost terms
-        with shared_intermediates():
+        with shared_intermediates() as cache:
             expected_cost = 0.
             for ordinal, cost_terms in costs:
                 factors = factors_table.get(ordinal, [])
@@ -262,4 +263,5 @@ class Dice(object):
                         prob = prob[mask]
                         cost = cost[mask]
                     expected_cost = expected_cost + (prob * cost).sum()
+        LAST_CACHE_SIZE[0] = Counter(key[0] for key in cache.keys())
         return expected_cost

--- a/pyro/ops/einsum/__init__.py
+++ b/pyro/ops/einsum/__init__.py
@@ -1,3 +1,38 @@
-from pyro.ops.einsum.shared import contract, shared_intermediates
+from __future__ import absolute_import, division, print_function
+
+import opt_einsum
+
+from pyro.ops.einsum.shared import handle_sharing, shared_intermediates
+
+_PATH_CACHE = {}
+
+
+def contract(equation, *operands, **kwargs):
+    """
+    Like :func:`opt_einsum.contract` but works with
+    :func:`~pyro.ops.einsum.shared_intermediates` contexts.
+
+    :param bool cache_path: whether to cache the contraction path.
+        Defaults to True.
+    """
+    backend = kwargs.pop('backend', 'numpy')
+    with handle_sharing(backend) as backend:
+
+        cache_path = kwargs.pop('cache_path', True)
+        if not cache_path:
+            return opt_einsum.contract(equation, *operands, backend=backend, **kwargs)
+
+        # memoize the contraction path
+        out = kwargs.pop('out', None)
+        kwargs_key = tuple(kwargs.items())
+        shapes = tuple(tuple(t.shape) for t in operands)
+        key = equation, shapes, kwargs_key
+        if key in _PATH_CACHE:
+            expr = _PATH_CACHE[key]
+        else:
+            expr = opt_einsum.contract_expression(equation, *shapes, **kwargs)
+            _PATH_CACHE[key] = expr
+        return expr(*operands, backend=backend, out=out)
+
 
 __all__ = ['contract', 'shared_intermediates']

--- a/pyro/ops/einsum/shared.py
+++ b/pyro/ops/einsum/shared.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import contextlib
 import numbers
-from collections import Counter, OrderedDict
+from collections import OrderedDict
 
 import opt_einsum
 from opt_einsum.backends.dispatch import get_func
@@ -10,7 +10,6 @@ from opt_einsum.backends.dispatch import get_func
 _SHARING_STACK = []
 _CURRENT_BACKEND = []
 _PATH_CACHE = {}
-LAST_CACHE_SIZE = [Counter()]  # for profiling
 
 
 @contextlib.contextmanager
@@ -28,7 +27,6 @@ def shared_intermediates(cache=None):
         cache = {}
     _SHARING_STACK.append(cache)
     yield cache
-    LAST_CACHE_SIZE[0] = Counter(key[0] for key in cache.keys())
     _SHARING_STACK.pop()
 
 

--- a/pyro/ops/einsum/shared.py
+++ b/pyro/ops/einsum/shared.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import contextlib
 import numbers
-from collections import OrderedDict
+from collections import Counter, OrderedDict
 
 import opt_einsum
 from opt_einsum.backends.dispatch import get_func
@@ -10,7 +10,7 @@ from opt_einsum.backends.dispatch import get_func
 _SHARING_STACK = []
 _CURRENT_BACKEND = []
 _PATH_CACHE = {}
-LAST_CACHE_SIZE = [0]  # for profiling
+LAST_CACHE_SIZE = [Counter()]  # for profiling
 
 
 @contextlib.contextmanager
@@ -28,7 +28,7 @@ def shared_intermediates(cache=None):
         cache = {}
     _SHARING_STACK.append(cache)
     yield cache
-    LAST_CACHE_SIZE[0] = len(cache)
+    LAST_CACHE_SIZE[0] = Counter(key[0] for key in cache.keys())
     _SHARING_STACK.pop()
 
 

--- a/pyro/ops/einsum/shared.py
+++ b/pyro/ops/einsum/shared.py
@@ -4,12 +4,11 @@ import contextlib
 import numbers
 from collections import OrderedDict
 
-import opt_einsum
+from opt_einsum import get_symbol
 from opt_einsum.backends.dispatch import get_func
 
 _SHARING_STACK = []
-_CURRENT_BACKEND = []
-_PATH_CACHE = {}
+_CURRENT_BACKEND = None
 
 
 @contextlib.contextmanager
@@ -25,48 +24,26 @@ def shared_intermediates(cache=None):
     """
     if cache is None:
         cache = {}
-    _SHARING_STACK.append(cache)
-    yield cache
-    _SHARING_STACK.pop()
+    try:
+        _SHARING_STACK.append(cache)
+        yield cache
+    finally:
+        _SHARING_STACK.pop()
 
 
-def contract(equation, *operands, **kwargs):
-    """
-    Like :func:`opt_einsum.contract` but works with
-    :func:`~pyro.ops.einsum.shared_intermediates` contexts.
-
-    :param bool cache_path: whether to cache the contraction path.
-        Defaults to True.
-    """
-    backend = kwargs.pop('backend', 'numpy')
-    cache_path = kwargs.pop('cache_path', True)
-
-    # special handling under shared_intermediates()
-    if _SHARING_STACK and not _CURRENT_BACKEND:
-        _CURRENT_BACKEND.append(backend)
-        backend = 'pyro.ops.einsum.shared'
+@contextlib.contextmanager
+def handle_sharing(backend):
+    global _CURRENT_BACKEND
+    if _SHARING_STACK and _CURRENT_BACKEND is None:
         try:
-            return contract(equation, *operands, backend=backend, **kwargs)
+            _CURRENT_BACKEND = backend
+            yield __name__
         finally:
-            _CURRENT_BACKEND.pop()
-
-    if backend == 'pyro.ops.einsum.shared' and not _CURRENT_BACKEND:
+            _CURRENT_BACKEND = None
+    elif backend == __name__ and _CURRENT_BACKEND is None:
         raise ValueError('shared backend is available only via shared_intermediates')
-
-    if not cache_path:
-        return opt_einsum.contract(equation, *operands, backend=backend, **kwargs)
-
-    # memoize the contraction path
-    out = kwargs.pop('out', None)
-    kwargs_key = tuple(kwargs.items())
-    shapes = tuple(tuple(t.shape) for t in operands)
-    key = equation, shapes, kwargs_key
-    if key in _PATH_CACHE:
-        expr = _PATH_CACHE[key]
     else:
-        expr = opt_einsum.contract_expression(equation, *shapes, **kwargs)
-        _PATH_CACHE[key] = expr
-    return expr(*operands, backend=backend, out=out)
+        yield backend
 
 
 def _alpha_canonicalize(equation):
@@ -78,60 +55,69 @@ def _alpha_canonicalize(equation):
         if name in ',->':
             continue
         if name not in rename:
-            rename[name] = opt_einsum.get_symbol(len(rename))
+            rename[name] = get_symbol(len(rename))
     return ''.join(rename.get(x, x) for x in equation)
 
 
-def transpose(a, axes):
-    backend = _CURRENT_BACKEND[0]
+def _save_tensors(*tensors):
+    """Save tensors in the cache to prevent their ids from being recycled.
+    This is needed to prevent false cache lookups.
+    """
     cache = _SHARING_STACK[-1]
-    cache['tensor', id(a)] = a
+    for tensor in tensors:
+        cache['tensor', id(tensor)] = tensor
 
+
+def transpose(a, axes):
+    _save_tensors(a)
+
+    # hash by axes
     axes = tuple(axes)
-    key = 'transpose', backend, id(a), axes
+    key = 'transpose', _CURRENT_BACKEND, id(a), axes
+
+    cache = _SHARING_STACK[-1]
     if key in cache:
         return cache[key]
 
-    result = get_func('transpose', backend)(a, axes)
+    result = get_func('transpose', _CURRENT_BACKEND)(a, axes)
     cache[key] = result
     return result
 
 
 def tensordot(x, y, axes=2):
-    backend = _CURRENT_BACKEND[0]
-    cache = _SHARING_STACK[-1]
-    cache['tensor', id(x)] = x
-    cache['tensor', id(y)] = y
+    _save_tensors(x, y)
 
+    # hash based on the (axes_x,axes_y) form of axes
     if isinstance(axes, numbers.Number):
         axes = list(range(len(x.shape)))[len(x.shape) - axes:], list(range(len(y.shape)))[:axes]
     axes = tuple(axes[0]), tuple(axes[1])
-    key = 'tensordot', backend, id(x), id(y), axes
+    key = 'tensordot', _CURRENT_BACKEND, id(x), id(y), axes
+
+    cache = _SHARING_STACK[-1]
     if key in cache:
         return cache[key]
 
-    result = get_func('tensordot', backend)(x, y, axes)
+    result = get_func('tensordot', _CURRENT_BACKEND)(x, y, axes)
     cache[key] = result
     return result
 
 
 def einsum(equation, *operands):
-    backend = _CURRENT_BACKEND[0]
-    cache = _SHARING_STACK[-1]
-    for d in operands:
-        cache['tensor', id(d)] = d
+    _save_tensors(*operands)
 
-    # compute a canonical hash, modulo commutativity
+    # hash modulo commutativity by computing a canonical ordering and naming
     inputs, output = equation.split('->')
     inputs = inputs.split(',')
-    canonical = sorted(zip(inputs, operands), key=lambda x: id(x[1]))
+    canonical = sorted(zip(inputs, map(id, operands)), key=lambda x: x[1])
+    canonical_ids = tuple(id_ for _, id_ in canonical)
     canonical_inputs = ','.join(input_ for input_, _ in canonical)
     canonical_equation = _alpha_canonicalize('{}->{}'.format(canonical_inputs, output))
-    canonical_operands = tuple(d for _, d in canonical)
-    key = 'einsum', backend, canonical_equation, tuple(map(id, canonical_operands))
+    key = 'einsum', _CURRENT_BACKEND, canonical_equation, canonical_ids
+
+    cache = _SHARING_STACK[-1]
     if key in cache:
         return cache[key]
 
-    result = get_func('einsum', backend)(equation, *operands)
+    result = get_func('einsum', _CURRENT_BACKEND)(equation, *operands)
     cache[key] = result
     return result

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -1291,7 +1291,7 @@ def test_elbo_dbn_growth():
             x = pyro.sample("x_{}".format(i), dist.Categorical(probs_x[x]))
             y = pyro.sample("y_{}".format(i), dist.Categorical(probs_y[x, y]))
 
-    sizes = range(1, 11)
+    sizes = range(1, 31)
     costs = []
     times1 = []
     times2 = []

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -19,6 +19,7 @@ from pyro.distributions.testing.rejection_gamma import ShapeAugmentedGamma
 from pyro.infer import SVI, config_enumerate
 from pyro.infer.enum import iter_discrete_traces
 from pyro.infer.traceenum_elbo import TraceEnum_ELBO
+from pyro.infer.util import LAST_CACHE_SIZE
 from pyro.util import torch_isnan
 from tests.common import assert_equal
 
@@ -1251,7 +1252,7 @@ def test_elbo_hmm_growth():
 
         times1.append(time1 - time0)
         times2.append(time2 - time1)
-        costs.append(pyro.ops.einsum.shared.LAST_CACHE_SIZE[0])
+        costs.append(LAST_CACHE_SIZE[0])
 
     collated_costs = defaultdict(list)
     for counts in costs:
@@ -1296,7 +1297,7 @@ def test_elbo_dbn_growth():
             x = pyro.sample("x_{}".format(i), dist.Categorical(probs_x[x]))
             y = pyro.sample("y_{}".format(i), dist.Categorical(probs_y[x, y]))
 
-    sizes = range(2, 31)
+    sizes = range(2, 11)
     costs = []
     times1 = []
     times2 = []
@@ -1311,7 +1312,7 @@ def test_elbo_dbn_growth():
 
         times1.append(time1 - time0)
         times2.append(time2 - time1)
-        costs.append(pyro.ops.einsum.shared.LAST_CACHE_SIZE[0])
+        costs.append(LAST_CACHE_SIZE[0])
 
     collated_costs = defaultdict(list)
     for counts in costs:

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 import math
 import timeit
+from collections import defaultdict
 
 import pytest
 import torch
@@ -1235,7 +1236,7 @@ def test_elbo_hmm_growth():
             probs = init_probs if x is None else transition_probs[x]
             x = pyro.sample("x_{}".format(i), dist.Categorical(probs))
 
-    sizes = range(1, 11)
+    sizes = range(2, 11)
     costs = []
     times1 = []
     times2 = []
@@ -1252,9 +1253,13 @@ def test_elbo_hmm_growth():
         times2.append(time2 - time1)
         costs.append(pyro.ops.einsum.shared.LAST_CACHE_SIZE[0])
 
+    collated_costs = defaultdict(list)
+    for counts in costs:
+        for key, cost in counts.items():
+            collated_costs[key].append(cost)
     print('Growth:')
     print('sizes = {}'.format(repr(sizes)))
-    print('costs = {}'.format(repr(costs)))
+    print('costs = {}'.format(repr(dict(collated_costs))))
     print('times1 = {}'.format(repr(times1)))
     print('times2 = {}'.format(repr(times2)))
 
@@ -1291,7 +1296,7 @@ def test_elbo_dbn_growth():
             x = pyro.sample("x_{}".format(i), dist.Categorical(probs_x[x]))
             y = pyro.sample("y_{}".format(i), dist.Categorical(probs_y[x, y]))
 
-    sizes = range(1, 31)
+    sizes = range(2, 31)
     costs = []
     times1 = []
     times2 = []
@@ -1308,9 +1313,13 @@ def test_elbo_dbn_growth():
         times2.append(time2 - time1)
         costs.append(pyro.ops.einsum.shared.LAST_CACHE_SIZE[0])
 
+    collated_costs = defaultdict(list)
+    for counts in costs:
+        for key, cost in counts.items():
+            collated_costs[key].append(cost)
     print('Growth:')
     print('sizes = {}'.format(repr(sizes)))
-    print('costs = {}'.format(repr(costs)))
+    print('costs = {}'.format(repr(dict(collated_costs))))
     print('times1 = {}'.format(repr(times1)))
     print('times2 = {}'.format(repr(times2)))
 

--- a/tests/ops/einsum/test_shared.py
+++ b/tests/ops/einsum/test_shared.py
@@ -8,6 +8,10 @@ from pyro.ops.einsum import contract, shared_intermediates
 from tests.common import assert_equal
 
 
+def compute_cost(cache):
+    return sum(1 for key in cache.keys() if key[0] in ('einsum', 'tensordot'))
+
+
 def test_shared_backend():
     w = torch.randn(2, 3, 4)
     x = torch.randn(3, 4, 5)
@@ -57,26 +61,22 @@ def test_partial_sharing():
     num_exprs_nosharing = 0
     with shared_intermediates() as cache:
         contract('ab,bc,cd->', x, y, z1, backend='torch')
-        num_exprs_nosharing += len(cache) - 3  # ignore shared_tensor
+        num_exprs_nosharing += len(cache)
     with shared_intermediates() as cache:
         contract('ab,bc,cd->', x, y, z2, backend='torch')
-        num_exprs_nosharing += len(cache) - 3  # ignore shared_tensor
+        num_exprs_nosharing += len(cache)
 
     print('-' * 40)
     print('With sharing:')
     with shared_intermediates() as cache:
         contract('ab,bc,cd->', x, y, z1, backend='torch')
         contract('ab,bc,cd->', x, y, z2, backend='torch')
-        num_exprs_sharing = len(cache) - 4  # ignore shared_tensor
+        num_exprs_sharing = len(cache)
 
     print('-' * 40)
     print('Without sharing: {} expressions'.format(num_exprs_nosharing))
     print('With sharing: {} expressions'.format(num_exprs_sharing))
     assert num_exprs_nosharing > num_exprs_sharing
-
-
-def compute_cost(cache):
-    return sum(1 for key in cache.keys() if key[0] in ('einsum', 'tensordot'))
 
 
 @pytest.mark.parametrize('size', [3, 4, 5])


### PR DESCRIPTION
Addresses #915 
Pair coded with @eb8680 

This further simplifies the `pyro.ops.einsum.shared` backend in preparation for moving this backend upstream to `opt_einsum` https://github.com/dgasmith/opt_einsum/pull/43.

## Tested

- existing tests (this is pure refactoring)
-  updated growth tests to measure finer-grained op counts