### PR TITLE
Optimize to omit guide sites that exactly cancel model sites

### DIFF
--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -1239,9 +1239,9 @@ def test_elbo_hmm_exact(num_steps):
     optim_guide = poutine.infer_config(naive_guide, lambda msg: {'exact': True})
 
     expected = elbo.differentiable_loss(model, naive_guide, data)
-    naive_cost = pyro.ops.einsum.shared.LAST_CACHE_SIZE[0]
+    naive_cost = LAST_CACHE_SIZE[0]
     actual = elbo.differentiable_loss(model, optim_guide, data)
-    optim_cost = pyro.ops.einsum.shared.LAST_CACHE_SIZE[0]
+    optim_cost = LAST_CACHE_SIZE[0]
     print('naive_cost = {}, optim_cost = {}'.format(naive_cost, optim_cost))
 
     assert_equal(expected, actual)
@@ -1255,7 +1255,10 @@ def test_elbo_hmm_exact(num_steps):
         assert_equal(expected_grad, actual_grad,
                      msg='Expected {}:\n{}\nActual {}:\n{}'.format(name, expected, name, actual))
 
-    assert optim_cost < naive_cost
+    assert optim_cost['tensor'] <= naive_cost['tensor']
+    assert optim_cost['transpose'] <= naive_cost['transpose']
+    assert optim_cost['einsum'] < naive_cost['einsum']
+    assert optim_cost['tensordot'] <= naive_cost['tensordot']
 
 
 def test_elbo_hmm_growth():


### PR DESCRIPTION
Addresses #915 
~~Blocked by #1324~~

This implements an optimization in `TraceEnum_ELBO` that omits `log(p/q)` terms when `p` is exactly `q`. This is a common use case where part of the model is used exactly in the guide. For example consider the Baum-Welch algorithm where the hidden transition part of an HMM appears identically in the model and guide, so only the emission terms need to be considered.
```py
def hidden(num_steps):
    transition_probs = pyro.param("transition_probs", ...)
    x = 0
    for t in range(num_steps):
        x = pyro.sample("x_{}".format(t), dist.Categorical(transition_probs[x]))
        yield x

def model(data):
    emission_probs = pyro.param("emission_probs", ...)
    xs = list(hidden(len(data)))
    for t in pyro.irange("data", len(data)):
        pyro.sample("y_{}".format(t), dist.Categorical(emission_probs[xs[t]]),
                    obs=data[t])

@config_enumerate(default="parallel", expand=False)
def guide(data):
    with poutine.infer_config(config_fn=lambda msg: {'exact': True}):
        return list(hidden(len(data)))  # <--- this exactly matches the model
```
To help `TraceEnum_ELBO` omit cancelling terms, I've configured the guide's sample site infer dict with `{'exact': True}`. This results in significant savings in the number of `sumproduct` calls and `einsum` operations:
```
tests/infer/test_enum.py::test_elbo_hmm_exact[2] naive_cost = 5, optim_cost = 4
tests/infer/test_enum.py::test_elbo_hmm_exact[3] naive_cost = 11, optim_cost = 8
tests/infer/test_enum.py::test_elbo_hmm_exact[4] naive_cost = 17, optim_cost = 12
tests/infer/test_enum.py::test_elbo_hmm_exact[5] naive_cost = 23, optim_cost = 16
tests/infer/test_enum.py::test_elbo_hmm_exact[10] naive_cost = 53, optim_cost = 36
tests/infer/test_enum.py::test_elbo_hmm_exact[20] naive_cost = 113, optim_cost = 76
tests/infer/test_enum.py::test_elbo_hmm_exact[30] naive_cost = 173, optim_cost = 116
```

# Questions for reviewers

- [ ] Is this even the right guide? What I really want is to be able to enumerate model sites, and currently `TraceEnum_ELBO` enumerates over guide sites, so I'm replicating part of the model in the guide.

## Tested

- [x] added the above HMM example to `test_enum.py`, checking correctness of loss, gradients, and reduction in cost.