### PR TITLE
Marginalize out discrete variables in the model

### DIFF
--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -20,6 +20,7 @@ from pyro.poutine.enumerate_messenger import EnumerateMessenger
 from pyro.util import check_traceenum_requirements, warn_if_nan
 
 
+# TODO move this logic into a poutine
 def _compute_model_costs(model_trace, guide_trace, ordering):
     # Collect model log_probs, possibly marginalizing out enumerated model variables.
     costs = OrderedDict()
@@ -28,7 +29,7 @@ def _compute_model_costs(model_trace, guide_trace, ordering):
     for name, site in model_trace.nodes.items():
         if site["type"] == "sample":
             site["log_prob"]._pyro_name = name  # DEBUG
-            if name in guide_trace or not site["infer"].get("_enumerated"):
+            if name in guide_trace or not site["infer"].get("_enumerate_dim") is not None:
                 costs.setdefault(ordering[name], []).append(site["log_prob"])
             else:
                 enum_logprobs.setdefault(ordering[name], []).append(site["log_prob"])

--- a/pyro/poutine/enumerate_messenger.py
+++ b/pyro/poutine/enumerate_messenger.py
@@ -40,9 +40,11 @@ class EnumerateMessenger(Messenger):
             if num_samples is None:
                 # Enumerate over the support of the distribution.
                 value = dist.enumerate_support(expand=msg["infer"].get("expand", EXPAND_DEFAULT))
+                msg["infer"]["_enumerated"] = "parallel"
             else:
                 # Monte Carlo sample the distribution.
                 value = dist(sample_shape=(num_samples,))
+                msg["infer"]["_enumerated"] = "monte_carlo"
             assert len(value.shape) == 1 + len(dist.batch_shape) + len(dist.event_shape)
 
             # Ensure enumeration happens at an available tensor dimension.

--- a/pyro/poutine/enumerate_messenger.py
+++ b/pyro/poutine/enumerate_messenger.py
@@ -10,9 +10,11 @@ class EnumerateMessenger(Messenger):
     Enumerates in parallel over discrete sample sites marked
     ``infer={"enumerate": "parallel"}``.
 
-    :param int first_available_dim: The first tensor dimension (counting
+    :param first_available_dim: The first tensor dimension (counting
         from the right) that is available for parallel enumeration. This
         dimension and all dimensions left may be used internally by Pyro.
+        This can be an integer or a callable returning an integer.
+    :type first_available_dim: int or callable
     """
     def __init__(self, first_available_dim):
         super(EnumerateMessenger, self).__init__()
@@ -20,7 +22,8 @@ class EnumerateMessenger(Messenger):
         self.next_available_dim = None
 
     def __enter__(self):
-        self.next_available_dim = self.first_available_dim
+        first = self.first_available_dim
+        self.next_available_dim = first() if callable(first) else first
         return super(EnumerateMessenger, self).__enter__()
 
     def _pyro_sample(self, msg):

--- a/pyro/poutine/enumerate_messenger.py
+++ b/pyro/poutine/enumerate_messenger.py
@@ -40,11 +40,9 @@ class EnumerateMessenger(Messenger):
             if num_samples is None:
                 # Enumerate over the support of the distribution.
                 value = dist.enumerate_support(expand=msg["infer"].get("expand", EXPAND_DEFAULT))
-                msg["infer"]["_enumerated"] = "parallel"
             else:
                 # Monte Carlo sample the distribution.
                 value = dist(sample_shape=(num_samples,))
-                msg["infer"]["_enumerated"] = "monte_carlo"
             assert len(value.shape) == 1 + len(dist.batch_shape) + len(dist.event_shape)
 
             # Ensure enumeration happens at an available tensor dimension.
@@ -62,5 +60,6 @@ class EnumerateMessenger(Messenger):
                 diff = target_dim - actual_dim
                 value = value.reshape(value.shape[:1] + (1,) * diff + value.shape[1:])
 
+            msg["infer"]["_enumerate_dim"] = target_dim
             msg["value"] = value
             msg["done"] = True

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -48,7 +48,7 @@ def sample(name, fn, *args, **kwargs):
     :returns: sample
     """
     obs = kwargs.pop("obs", None)
-    infer = kwargs.pop("infer", {})
+    infer = kwargs.pop("infer", {}).copy()
     # check if stack is empty
     # if stack empty, default behavior (defined here)
     if not am_i_wrapped():

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -177,10 +177,10 @@ def check_model_guide_match(model_trace, guide_trace, max_iarange_nesting=float(
                    if site["infer"].get("is_auxiliary"))
     if aux_vars & model_vars:
         warnings.warn("Found auxiliary vars in the model: {}".format(aux_vars & model_vars))
-    if not (guide_vars <= replay_vars | aux_vars):
-        warnings.warn("Found non-auxiliary vars in guide but not model, "
-                      "consider marking these infer={{'is_auxiliary': True}}:\n{}".format(
-                          guide_vars - aux_vars - model_vars))
+    # if not (guide_vars <= replay_vars | aux_vars):
+    #     warnings.warn("Found non-auxiliary vars in guide but not model, "
+    #                   "consider marking these infer={{'is_auxiliary': True}}:\n{}".format(
+    #                       guide_vars - aux_vars - replay_vars))
     if not (replay_vars <= guide_vars):
         warnings.warn("Found vars in model but not guide: {}".format(replay_vars - guide_vars))
 

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -160,32 +160,31 @@ def check_model_guide_match(model_trace, guide_trace, max_iarange_nesting=float(
         and guide agree on sample shape.
     """
     # Check ordinary sample sites.
-    replay_vars = set(name for name, site in model_trace.nodes.items()
-                      if site["type"] == "sample" and not site["is_observed"]
-                      if type(site["fn"]).__name__ != "_Subsample"
-                      if not site["infer"].get("enumerate"))
-    enum_vars = set(name for name, site in model_trace.nodes.items()
-                    if site["type"] == "sample" and not site["is_observed"]
-                    if type(site["fn"]).__name__ != "_Subsample"
-                    if site["infer"].get("enumerate"))
-    model_vars = replay_vars | enum_vars
     guide_vars = set(name for name, site in guide_trace.nodes.items()
                      if site["type"] == "sample"
                      if type(site["fn"]).__name__ != "_Subsample")
     aux_vars = set(name for name, site in guide_trace.nodes.items()
                    if site["type"] == "sample"
                    if site["infer"].get("is_auxiliary"))
+    model_vars = set(name for name, site in model_trace.nodes.items()
+                     if site["type"] == "sample" and not site["is_observed"]
+                     if type(site["fn"]).__name__ != "_Subsample")
+    enum_vars = set(name for name, site in model_trace.nodes.items()
+                    if site["type"] == "sample" and not site["is_observed"]
+                    if type(site["fn"]).__name__ != "_Subsample"
+                    if site["infer"].get("_enumerate_dim") is not None
+                    if name not in guide_vars)
     if aux_vars & model_vars:
         warnings.warn("Found auxiliary vars in the model: {}".format(aux_vars & model_vars))
-    # if not (guide_vars <= replay_vars | aux_vars):
-    #     warnings.warn("Found non-auxiliary vars in guide but not model, "
-    #                   "consider marking these infer={{'is_auxiliary': True}}:\n{}".format(
-    #                       guide_vars - aux_vars - replay_vars))
-    if not (replay_vars <= guide_vars):
-        warnings.warn("Found vars in model but not guide: {}".format(replay_vars - guide_vars))
+    if not (guide_vars <= model_vars | aux_vars):
+        warnings.warn("Found non-auxiliary vars in guide but not model, "
+                      "consider marking these infer={{'is_auxiliary': True}}:\n{}".format(
+                          guide_vars - aux_vars - model_vars))
+    if not (model_vars <= guide_vars | enum_vars):
+        warnings.warn("Found vars in model but not guide: {}".format(model_vars - guide_vars - enum_vars))
 
     # Check shapes agree.
-    for name in replay_vars & guide_vars:
+    for name in model_vars & guide_vars:
         model_site = model_trace.nodes[name]
         guide_site = guide_trace.nodes[name]
 

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -1083,6 +1083,18 @@ def test_enum_iarange_in_model_ok():
     assert_ok(model, guide, TraceEnum_ELBO(max_iarange_nesting=1))
 
 
+def test_enum_sequential_in_model_error():
+
+    def model():
+        p = pyro.param('p', torch.tensor(0.25))
+        pyro.sample('a', dist.Bernoulli(p), infer={'enumerate': 'sequential'})
+
+    def guide():
+        pass
+
+    assert_error(model, guide, TraceEnum_ELBO(max_iarange_nesting=0))
+
+
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
 def test_vectorized_num_particles(Elbo):
     data = torch.ones(1000, 2)


### PR DESCRIPTION
Addresses #915 
Pair coded with @eb8680 

This supports exact marginalization out discrete variables that may appear in the model but not the guide. For example to infer parameters of an HMM in Bayesian Baum-Welch inference, we can
```py
def model(data):
    dim = data.shape[-1]
    jeffreys_prior = dist.Dirichlet(0.5 * torch.ones(dim, dim)).independent(1)
    trans = pyro.sample("trans", jeffreys_prior)
    emit = pyro.sample("emit", jeffreys_prior)
    x = 0
    for t, y in enumerate(data):
        x = pyro.sample("x_{}".format(t), dist.Categorical(trans[x]),
                        infer={"enumerate": "parallel", "expand": False})
        pyro.sample("y_{}".format(t), dist.Categorical(emit[x]), obs=y)

guide = AutoMultivariateNormal(poutine.block(model, expose=["trans", "emit"]))
```
A follow-up PR will add this example as a tutorial.

## Design choices

This adds model enumeration logic to `TraceEnum_ELBO`. @martinjankowiak suggested a cleaner alternative design that modifies arbitrary models, with an interface closer to either `poutine` or a `Distribution`. Ideally we can refactor to this more general interface later. For now I'd like to merge this working implementation in `TraceEnum_ELBO` to enable modeling and to serve as a reference implementation for the more general version.

## Tested

- [x] added smoke tests of the HMM in the model
- [x] added loss-and-grads tests for various models, including `iarange`
- [x] added validity and error tests to `test_valid_models.py`