### PR TITLE
Implement logsumproductexp()

### DIFF
--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -15,7 +15,7 @@ from pyro.infer.elbo import ELBO
 from pyro.infer.enum import get_importance_trace, iter_discrete_escape, iter_discrete_extend
 from pyro.infer.util import Dice, is_validation_enabled
 from pyro.ops.einsum import shared_intermediates
-from pyro.ops.sumproduct import sumproduct
+from pyro.ops.sumproduct import logsumproductexp
 from pyro.poutine.enumerate_messenger import EnumerateMessenger
 from pyro.util import check_traceenum_requirements, warn_if_nan
 
@@ -51,8 +51,7 @@ def _compute_model_costs(model_trace, guide_trace, ordering):
             for cost_t in costs_t:
                 target_shape = broadcast_shape(cost_t.shape, ordinal_shape)
                 target_shape = target_shape[enum_boundary:] if enum_boundary else ()
-                marginal_costs[t].append(sumproduct(logprobs_t + [cost_t], target_shape,
-                                                    backend='pyro.ops.einsum.torch_log'))
+                marginal_costs[t].append(logsumproductexp(logprobs_t + [cost_t], target_shape))
     return marginal_costs
 
 

--- a/tests/ops/einsum/test_torch_log.py
+++ b/tests/ops/einsum/test_torch_log.py
@@ -5,7 +5,7 @@ import torch
 
 from pyro.infer.util import torch_exp
 from pyro.ops.einsum import contract
-from pyro.ops.sumproduct import sumproduct
+from pyro.ops.sumproduct import logsumproductexp, sumproduct
 from tests.common import assert_equal
 
 
@@ -59,9 +59,9 @@ def test_einsum(equation):
     (None, (1,), (1, 2)),
     (None, (2,)),
 ])
-def test_sumproduct(shapes):
+def test_logsumproductexp(shapes):
     factors = [float(torch.randn(torch.Size())) if shape is None else torch.randn(shape)
                for shape in shapes]
     expected = sumproduct([torch_exp(x) for x in factors]).log()
-    actual = sumproduct(factors, backend='pyro.ops.einsum.torch_log')
+    actual = logsumproductexp(factors)
     assert_equal(actual, expected)

--- a/tests/ops/test_sumproduct.py
+++ b/tests/ops/test_sumproduct.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import numbers
 import operator
 import timeit
 
@@ -8,8 +9,9 @@ import torch
 from six.moves import reduce
 
 import pyro.distributions.torch_patch  # noqa: F401
+from pyro.infer.util import torch_exp
 from pyro.ops.einsum import contract, shared_intermediates
-from pyro.ops.sumproduct import sumproduct, zip_align_right
+from pyro.ops.sumproduct import logsumproductexp, sumproduct, zip_align_right
 from tests.common import assert_equal
 
 
@@ -23,26 +25,73 @@ def test_zip_align_right(xs, ys, expected):
     assert actual == expected
 
 
-@pytest.mark.parametrize('factor_shapes,shape', [
+# pairs of (factor_shapes, target_shape)
+EXAMPLES = [
+    ([None], ()),
+    ([None], (2,)),
+    ([None, None], ()),
+    ([None, None], (2,)),
+    ([()], ()),
+    ([()], (2,)),
+    ([(), ()], ()),
+    ([(), ()], (2,)),
+    ([None, ()], ()),
+    ([None, ()], (2,)),
+    ([None, (), (2,), (3, 1)], ()),
+    ([None, (), (2,), (3, 1)], (2,)),
+    ([None, (), (2,), (3, 1)], (3, 1)),
+    ([None, (), (2,), (3, 1)], (3, 2)),
+    ([None, (), (2,), (3, 1)], (4, 3, 1)),
+    ([None, (), (2,), (3, 2), (4, 3, 1)], ()),
+    ([None, (), (2,), (3, 2), (4, 3, 1)], (3, 1)),
+    ([None, (), (2,), (3, 2), (4, 3, 1)], (5, 1, 3, 1)),
+    ([None, (), (2,), (3, 2), (4, 3, 1), (5, 4, 1, 1)], ()),
+    ([None, (), (2,), (3, 2), (4, 3, 1), (5, 4, 1, 1)], (4, 1, 1)),
+    ([(2,), (3, 2), (4, 3, 1), (5, 4, 1, 1), (3, 1), (4, 1, 1), (5, 1, 1, 1)], ()),
+    ([(2,), (3, 2), (4, 3, 1), (5, 4, 1, 1), (3, 1), (4, 1, 1), (5, 1, 1, 1)], (2,)),
+    ([(2,), (3, 2), (4, 3, 1), (5, 4, 1, 1), (3, 1), (4, 1, 1), (5, 1, 1, 1)], (5, 1, 3, 1)),
+    ([(2,), (3, 2), (4, 3, 1), (5, 4, 1, 1), (3, 1), (4, 1, 1), (5, 1, 1, 1)], ()),
     ([(), (100000, 1, 2, 1), (2, 100000, 1, 1, 1)], (100000, 1, 2, 1)),
     ([None, (100000, 1, 2, 1), (2, 100000, 1, 1, 1)], (100000, 1, 2, 1)),
-])
-@pytest.mark.parametrize('optimize', [False, True])
+]
+
+
+def reference_sumproduct(factors, target_shape):
+    tensors = [torch.tensor(x) if isinstance(x, numbers.Number) else x for x in factors]
+    result = reduce(operator.mul, tensors, 1.)
+    while result.dim() > len(target_shape):
+        result = result.sum(0)
+    while result.dim() < len(target_shape):
+        result = result.unsqueeze(0)
+    for i, (e, s) in enumerate(zip(result.shape, target_shape)):
+        if e > s:
+            result = result.sum(i, keepdim=True)
+    result = result.expand(target_shape)
+    assert result.shape == target_shape
+    return result
+
+
+@pytest.mark.parametrize('factor_shapes,shape', EXAMPLES)
+@pytest.mark.parametrize('optimize', [False, True], ids=['naive', 'opt'])
 def test_sumproduct(factor_shapes, shape, optimize):
-    factors = [0.2 if s is None else torch.randn(s).exp()
+    factors = [float(torch.randn(torch.Size()).exp().item()) if s is None else
+               torch.randn(s).exp()
                for s in factor_shapes]
     actual = sumproduct(factors, shape, optimize=optimize)
+    expected = reference_sumproduct(factors, shape)
+    assert_equal(actual, expected)
 
-    expected = reduce(operator.mul, factors)
-    while expected.dim() > len(shape):
-        expected = expected.sum(0)
-    while expected.dim() < len(shape):
-        expected = expected.unsqueeze(0)
-    for i, (e, s) in enumerate(zip(expected.shape, shape)):
-        if e > s:
-            expected = expected.sum(i, keepdim=True)
-    assert expected.shape == shape
 
+@pytest.mark.parametrize('factor_shapes,shape', EXAMPLES)
+@pytest.mark.parametrize('optimize', [False, True], ids=['naive', 'opt'])
+def test_logsumproductexp(factor_shapes, shape, optimize):
+    log_factors = [float(torch.randn(torch.Size()).item()) if s is None else
+                   torch.randn(s)
+                   for s in factor_shapes]
+    actual = logsumproductexp(log_factors, shape, optimize=optimize)
+    factors = [torch_exp(x) for x in log_factors]
+    expected_exp = reference_sumproduct(factors, shape)
+    expected = expected_exp.log()
     assert_equal(actual, expected)
 
 


### PR DESCRIPTION
Addresses #915 

This refactors to create a `logsumproductexp()` operation that is a log-space version of `sumproduct()`.

This PR is pure refactoring in preparation for a follow-up PR that optimizes `logsumproductexp`. After this PR, we should be able to hide the `backend='pyro.ops.einsum.torch_log'` behind the `logsumproductexp()` interface.

## Tasks

There are a two merge conflicts due to removal of the `sumproduct(backend=_)` kwarg. These can each be resolved in whichever PR is merged later (this PR or each of those PRs).
- [x] resolve merge conflicts with #1328 (@fritzo)
- [ ] resolve merge conflicts with #1322 (@neerajprad)

## Tested

- added value and shape tests for both `sumproduct()` and `logsumproductexp()`