### PR TITLE
Speed up pickling of dmm; use pickling in einsum

### DIFF
--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -17,8 +17,6 @@ import time
 from os.path import exists
 
 import numpy as np
-import six
-import six.moves.cPickle as pickle
 import torch
 import torch.nn as nn
 
@@ -271,12 +269,7 @@ def main(args):
     log = get_logger(args.log)
     log(args)
 
-    jsb_file_loc = "./data/jsb_processed.pkl"
-    # ingest training/validation/test data from disk
-    if six.PY2:
-        data = pickle.load(open(jsb_file_loc, "rb"))
-    else:
-        data = pickle.load(open(jsb_file_loc, "rb"), encoding="latin1")
+    data = poly.load_data()
     training_seq_lengths = data['train']['sequence_lengths']
     training_data_sequences = data['train']['sequences']
     test_seq_lengths = data['test']['sequence_lengths']

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -13,7 +13,7 @@ however, the original source of the data seems to be the Institut fuer Algorithm
 und Kognitive Systeme at Universitaet Karlsruhe.
 """
 
-from os.path import exists, join
+import os
 
 import numpy as np
 import six.moves.cPickle as pickle
@@ -24,9 +24,15 @@ from observations import jsb_chorales
 
 # this function processes the raw data; in particular it unsparsifies it
 def process_data(base_path, filename, T_max=160, min_note=21, note_range=88):
-    output = join(base_path, filename)
-    if exists(output):
-        return
+    output = os.path.join(base_path, filename)
+    if os.path.exists(output):
+        try:
+            with open(output, "rb") as f:
+                return pickle.load(f)
+        except (ValueError, UnicodeDecodeError):
+            # Assume python env has changed.
+            # Recreate pickle file in this env's format.
+            os.remove(output)
 
     print("processing raw polyphonic music data...")
     data = jsb_chorales(base_path)

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -44,13 +44,20 @@ def process_data(base_path, filename, T_max=160, min_note=21, note_range=88):
                 slice_length = len(note_slice)
                 if slice_length > 0:
                     processed_dataset[split]['sequences'][seq, t, note_slice] = np.ones((slice_length))
-    pickle.dump(processed_dataset, open(output, "wb"))
+    pickle.dump(processed_dataset, open(output, "wb"), pickle.HIGHEST_PROTOCOL)
     print("dumped processed data to %s" % output)
 
 
 # this logic will be initiated upon import
 base_path = './data'
 process_data(base_path, "jsb_processed.pkl")
+jsb_file_loc = "./data/jsb_processed.pkl"
+
+
+# ingest training/validation/test data from disk
+def load_data():
+    with open(jsb_file_loc, "rb") as f:
+        return pickle.load(f)
 
 
 # this function takes a numpy mini-batch and reverses each sequence

--- a/pyro/ops/einsum/__init__.py
+++ b/pyro/ops/einsum/__init__.py
@@ -6,33 +6,37 @@ import os
 import opt_einsum
 from six.moves import cPickle as pickle
 
+from pyro.ops.einsum.shared import handle_sharing, shared_intermediates
+
 _PATH_CACHE = {}
 
 
 def contract(equation, *operands, **kwargs):
     """
     Like :func:`opt_einsum.contract` but works with
-    :func:`~opt_einsum.shared_intermediates` contexts.
+    :func:`~pyro.ops.einsum.shared_intermediates` contexts.
 
     :param bool cache_path: whether to cache the contraction path.
         Defaults to True.
     """
     backend = kwargs.pop('backend', 'numpy')
-    cache_path = kwargs.pop('cache_path', True)
-    if not cache_path:
-        return opt_einsum.contract(equation, *operands, **kwargs)
+    with handle_sharing(backend) as backend:
 
-    # memoize the contraction path
-    out = kwargs.pop('out', None)
-    kwargs_key = tuple(kwargs.items())
-    shapes = tuple(tuple(t.shape) for t in operands)
-    key = equation, shapes, kwargs_key
-    if key in _PATH_CACHE:
-        expr = _PATH_CACHE[key]
-    else:
-        expr = opt_einsum.contract_expression(equation, *shapes, **kwargs)
-        _PATH_CACHE[key] = expr
-    return expr(*operands, backend=backend, out=out)
+        cache_path = kwargs.pop('cache_path', True)
+        if not cache_path:
+            return opt_einsum.contract(equation, *operands, backend=backend, **kwargs)
+
+        # memoize the contraction path
+        out = kwargs.pop('out', None)
+        kwargs_key = tuple(kwargs.items())
+        shapes = tuple(tuple(t.shape) for t in operands)
+        key = equation, shapes, kwargs_key
+        if key in _PATH_CACHE:
+            expr = _PATH_CACHE[key]
+        else:
+            expr = opt_einsum.contract_expression(equation, *shapes, **kwargs)
+            _PATH_CACHE[key] = expr
+        return expr(*operands, backend=backend, out=out)
 
 
 @contextlib.contextmanager
@@ -54,4 +58,4 @@ def cached_paths(filename):
             pickle.dump(_PATH_CACHE, f, pickle.HIGHEST_PROTOCOL)
 
 
-__all__ = ['contract', 'cached_paths']
+__all__ = ['contract', 'cached_paths', 'shared_intermediates']

--- a/pyro/ops/einsum/__init__.py
+++ b/pyro/ops/einsum/__init__.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-import opt_einsum
+import contextlib
+import os
 
-from pyro.ops.einsum.shared import handle_sharing, shared_intermediates
+import opt_einsum
+from six.moves import cPickle as pickle
 
 _PATH_CACHE = {}
 
@@ -10,29 +12,46 @@ _PATH_CACHE = {}
 def contract(equation, *operands, **kwargs):
     """
     Like :func:`opt_einsum.contract` but works with
-    :func:`~pyro.ops.einsum.shared_intermediates` contexts.
+    :func:`~opt_einsum.shared_intermediates` contexts.
 
     :param bool cache_path: whether to cache the contraction path.
         Defaults to True.
     """
     backend = kwargs.pop('backend', 'numpy')
-    with handle_sharing(backend) as backend:
+    cache_path = kwargs.pop('cache_path', True)
+    if not cache_path:
+        return opt_einsum.contract(equation, *operands, **kwargs)
 
-        cache_path = kwargs.pop('cache_path', True)
-        if not cache_path:
-            return opt_einsum.contract(equation, *operands, backend=backend, **kwargs)
-
-        # memoize the contraction path
-        out = kwargs.pop('out', None)
-        kwargs_key = tuple(kwargs.items())
-        shapes = tuple(tuple(t.shape) for t in operands)
-        key = equation, shapes, kwargs_key
-        if key in _PATH_CACHE:
-            expr = _PATH_CACHE[key]
-        else:
-            expr = opt_einsum.contract_expression(equation, *shapes, **kwargs)
-            _PATH_CACHE[key] = expr
-        return expr(*operands, backend=backend, out=out)
+    # memoize the contraction path
+    out = kwargs.pop('out', None)
+    kwargs_key = tuple(kwargs.items())
+    shapes = tuple(tuple(t.shape) for t in operands)
+    key = equation, shapes, kwargs_key
+    if key in _PATH_CACHE:
+        expr = _PATH_CACHE[key]
+    else:
+        expr = opt_einsum.contract_expression(equation, *shapes, **kwargs)
+        _PATH_CACHE[key] = expr
+    return expr(*operands, backend=backend, out=out)
 
 
-__all__ = ['contract', 'shared_intermediates']
+@contextlib.contextmanager
+def cached_paths(filename):
+    """
+    Context manager to load and save cached paths. This is most useful outside
+    of the training loop, so that optimized einsum paths can be saved across
+    training runs. Note that this saves even after user interrupt with CTRL-C.
+
+    :param str filename: path to a pickle file where the cache will be stored
+    """
+    if os.path.exists(filename):
+        with open(filename, 'rb') as f:
+            _PATH_CACHE.update(pickle.load(f))
+    try:
+        yield
+    finally:
+        with open(filename, 'wb') as f:
+            pickle.dump(_PATH_CACHE, f, pickle.HIGHEST_PROTOCOL)
+
+
+__all__ = ['contract', 'cached_paths']

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 import contextlib
 import numbers
 import os
+import shutil
+import tempfile
 import warnings
 from itertools import product
 
@@ -12,7 +14,6 @@ import torch
 import torch.cuda
 from numpy.testing import assert_allclose
 from pytest import approx
-
 
 """
 Contains test utilities for assertions, approximate comparison (of tensors and other objects).
@@ -37,6 +38,17 @@ def suppress_warnings(fn):
             fn(*args, **kwargs)
 
     return wrapper
+
+
+# backport of Python 3's context manager
+@contextlib.contextmanager
+def TemporaryDirectory():
+    try:
+        path = tempfile.mkdtemp()
+        yield path
+    finally:
+        if os.path.exists(path):
+            shutil.rmtree(path)
 
 
 requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(),

--- a/tests/ops/einsum/test_cache.py
+++ b/tests/ops/einsum/test_cache.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+import pytest
+import torch
+
+from pyro.ops.einsum import cached_paths, contract
+from tests.common import TemporaryDirectory
+
+
+@pytest.mark.parametrize('num_steps', [1, 2, 3])
+def test_cached_paths(num_steps):
+    with TemporaryDirectory() as dirname:
+        filename = os.path.join(dirname, 'paths.pkl')
+
+        assert not os.path.exists(filename)
+        with cached_paths(filename):
+            assert not os.path.exists(filename)
+
+            x = torch.randn(2, 3)
+            y = torch.randn(3, 4)
+            z = torch.randn(4, 5)
+            for i in range(num_steps):
+                contract("ab,bc,cd->ad", x, y, z)
+
+            assert not os.path.exists(filename)
+        assert os.path.exists(filename)
+    assert not os.path.exists(filename)

--- a/tests/ops/einsum/test_cache.py
+++ b/tests/ops/einsum/test_cache.py
@@ -8,21 +8,27 @@ from pyro.ops.einsum import cached_paths, contract
 from tests.common import TemporaryDirectory
 
 
+def perform_computation(num_steps):
+    x = torch.randn(2, 3)
+    y = torch.randn(3, 4)
+    z = torch.randn(4, 5)
+    for i in range(num_steps):
+        contract("ab,bc,cd->ad", x, y, z)
+
+
 @pytest.mark.parametrize('num_steps', [1, 2, 3])
 def test_cached_paths(num_steps):
     with TemporaryDirectory() as dirname:
         filename = os.path.join(dirname, 'paths.pkl')
-
         assert not os.path.exists(filename)
         with cached_paths(filename):
             assert not os.path.exists(filename)
-
-            x = torch.randn(2, 3)
-            y = torch.randn(3, 4)
-            z = torch.randn(4, 5)
-            for i in range(num_steps):
-                contract("ab,bc,cd->ad", x, y, z)
-
+            perform_computation(num_steps)
             assert not os.path.exists(filename)
+        assert os.path.exists(filename)
+        with cached_paths(filename):
+            assert os.path.exists(filename)
+            perform_computation(num_steps)
+            assert os.path.exists(filename)
         assert os.path.exists(filename)
     assert not os.path.exists(filename)


### PR DESCRIPTION
This PR does three things to speed up experiments:
1. Refactors the dmm example by moving unpickling logic into a `load_data()` function in `polyphonic_data_loader.py` so that it can be used by other examples.
2. Switches to `pickle.HIGHEST_PROTOCOL` which is about 1000x faster to load the dmm data (13seconds --> tens of milliseconds). This should be safe because we use these pickles as a local per-machine cache; we do not require portability because we don't move these pickles around.
3. Adds a `cached_paths` context manager that caches einsum paths via pickling. This is useful when running scripts that train models with large enumeration graphs.

## Tested

- [x] added a unit test
- [x] successfully used all of these tricks in the hmm-tutorial branch
- [x] verified that pickle is recreated when switching Python 2 --> 3 --> 2