### PR TITLE
Set expand=False by default in discrete enumeration

### DIFF
--- a/examples/vae/ss_vae_M2.py
+++ b/examples/vae/ss_vae_M2.py
@@ -299,7 +299,7 @@ def main(args):
 
     # set up the loss(es) for inference. wrapping the guide in config_enumerate builds the loss as a sum
     # by enumerating each class label for the sampled discrete categorical distribution in the model
-    guide = config_enumerate(ss_vae.guide, args.enum_discrete)
+    guide = config_enumerate(ss_vae.guide, args.enum_discrete, expand=True)
     elbo = (JitTraceEnum_ELBO if args.jit else TraceEnum_ELBO)(max_iarange_nesting=1)
     loss_basic = SVI(ss_vae.model, guide, optimizer, loss=elbo)
 

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -7,7 +7,6 @@ from six.moves.queue import LifoQueue
 from pyro import poutine
 from pyro.infer.util import is_validation_enabled
 from pyro.poutine import Trace
-from pyro.poutine.enumerate_messenger import EXPAND_DEFAULT
 from pyro.poutine.util import prune_subsample_sites
 from pyro.util import check_model_guide_match, check_site_shape
 
@@ -20,7 +19,7 @@ def iter_discrete_escape(trace, msg):
 
 
 def iter_discrete_extend(trace, site, **ignored):
-    values = site["fn"].enumerate_support(expand=site["infer"].get("expand", EXPAND_DEFAULT))
+    values = site["fn"].enumerate_support(expand=site["infer"].get("expand", False))
     for i, value in enumerate(values):
         extended_site = site.copy()
         extended_site["infer"] = site["infer"].copy()
@@ -101,7 +100,7 @@ def _config_enumerate(default, expand, num_samples):
     return config_fn
 
 
-def config_enumerate(guide=None, default="sequential", expand=EXPAND_DEFAULT, num_samples=None):
+def config_enumerate(guide=None, default="sequential", expand=False, num_samples=None):
     """
     Configures enumeration for all relevant sites in a guide. This is mainly
     used in conjunction with :class:`~pyro.infer.traceenum_elbo.TraceEnum_ELBO`.
@@ -123,7 +122,7 @@ def config_enumerate(guide=None, default="sequential", expand=EXPAND_DEFAULT, nu
         def guide1(*args, **kwargs):
             ...
 
-        @config_enumerate(default="parallel", expand=False)
+        @config_enumerate(default="parallel", expand=True)
         def guide2(*args, **kwargs):
             ...
 

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -81,7 +81,7 @@ class HMC(TraceKernel):
                  max_iarange_nesting=float("inf")):
         # Wrap model in `poutine.enum` to enumerate over discrete latent sites.
         # No-op if model does not have any discrete latents.
-        self.model = poutine.enum(config_enumerate(model, default="parallel", expand=False),
+        self.model = poutine.enum(config_enumerate(model, default="parallel"),
                                   first_available_dim=max_iarange_nesting)
         # broadcast sample sites inside iarange.
         self.model = poutine.broadcast(self.model)

--- a/pyro/poutine/enumerate_messenger.py
+++ b/pyro/poutine/enumerate_messenger.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 from .messenger import Messenger
 
-EXPAND_DEFAULT = True  # TODO(fritzo,eb8680) Flip this to False in Pyro 0.3.
-
 
 class EnumerateMessenger(Messenger):
     """
@@ -39,7 +37,7 @@ class EnumerateMessenger(Messenger):
             num_samples = msg["infer"].get("num_samples")
             if num_samples is None:
                 # Enumerate over the support of the distribution.
-                value = dist.enumerate_support(expand=msg["infer"].get("expand", EXPAND_DEFAULT))
+                value = dist.enumerate_support(expand=msg["infer"].get("expand", False))
             else:
                 # Monte Carlo sample the distribution.
                 value = dist(sample_shape=(num_samples,))

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -1213,7 +1213,7 @@ def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):
 def test_hmm_enumerate_model(num_steps):
     data = dist.Categorical(torch.tensor([0.5, 0.5])).sample((num_steps,))
 
-    @config_enumerate(default="parallel", expand=False)
+    @config_enumerate(default="parallel")
     def model(data):
         transition_probs = pyro.param("transition_probs",
                                       torch.tensor([[0.75, 0.25], [0.25, 0.75]]),
@@ -1249,7 +1249,7 @@ def test_hmm_enumerate_model_and_guide(num_steps):
         print('-1\t{}'.format(tuple(x.shape)))
         for t, y in enumerate(data):
             x = pyro.sample("x_{}".format(t), dist.Categorical(transition_probs[x]),
-                            infer={"enumerate": "parallel", "expand": False})
+                            infer={"enumerate": "parallel"})
             pyro.sample("y_{}".format(t), dist.Categorical(emission_probs[x]), obs=y)
             print('{}\t{}'.format(t, tuple(x.shape)))
 
@@ -1258,7 +1258,7 @@ def test_hmm_enumerate_model_and_guide(num_steps):
                                 torch.tensor([0.75, 0.25]),
                                 constraint=constraints.simplex)
         pyro.sample("x", dist.Categorical(init_probs),
-                    infer={"enumerate": "parallel", "expand": False})
+                    infer={"enumerate": "parallel"})
 
     elbo = TraceEnum_ELBO(max_iarange_nesting=0)
     elbo.differentiable_loss(model, guide, data)
@@ -1284,7 +1284,7 @@ def test_elbo_enumerate_1():
         probs_z = pyro.param("model_probs_z")
         x = pyro.sample("x", dist.Categorical(probs_x))
         pyro.sample("y", dist.Categorical(probs_y[x]),
-                    infer={"enumerate": "parallel", "expand": False})
+                    infer={"enumerate": "parallel"})
         pyro.sample("z", dist.Categorical(probs_z), obs=torch.tensor(0))
 
     def hand_model():
@@ -1293,7 +1293,7 @@ def test_elbo_enumerate_1():
         pyro.sample("x", dist.Categorical(probs_x))
         pyro.sample("z", dist.Categorical(probs_z), obs=torch.tensor(0))
 
-    @config_enumerate(default="parallel", expand=False)
+    @config_enumerate(default="parallel")
     def guide():
         probs_x = pyro.param("guide_probs_x")
         pyro.sample("x", dist.Categorical(probs_x))
@@ -1338,7 +1338,7 @@ def test_elbo_enumerate_2():
         probs_z = pyro.param("model_probs_z")
         x = pyro.sample("x", dist.Categorical(probs_x))
         y = pyro.sample("y", dist.Categorical(probs_y[x]),
-                        infer={"enumerate": "parallel", "expand": False})
+                        infer={"enumerate": "parallel"})
         pyro.sample("z", dist.Categorical(probs_z[y]), obs=torch.tensor(0))
 
     def hand_model():
@@ -1349,7 +1349,7 @@ def test_elbo_enumerate_2():
         x = pyro.sample("x", dist.Categorical(probs_x))
         pyro.sample("z", dist.Categorical(probs_yz[x]), obs=torch.tensor(0))
 
-    @config_enumerate(default="parallel", expand=False)
+    @config_enumerate(default="parallel")
     def guide():
         probs_x = pyro.param("guide_probs_x")
         pyro.sample("x", dist.Categorical(probs_x))
@@ -1393,7 +1393,7 @@ def test_elbo_enumerate_iarange_1(num_samples):
         probs_z = pyro.param("model_probs_z")
         x = pyro.sample("x", dist.Categorical(probs_x))
         y = pyro.sample("y", dist.Categorical(probs_y[x]),
-                        infer={"enumerate": "parallel", "expand": False})
+                        infer={"enumerate": "parallel"})
         with pyro.iarange("data", len(data)):
             pyro.sample("z", dist.Categorical(probs_z[y]), obs=data)
 
@@ -1406,7 +1406,7 @@ def test_elbo_enumerate_iarange_1(num_samples):
         with pyro.iarange("data", len(data)):
             pyro.sample("z", dist.Categorical(probs_yz[x]), obs=data)
 
-    @config_enumerate(default="parallel", expand=False)
+    @config_enumerate(default="parallel")
     def guide(data):
         probs_x = pyro.param("guide_probs_x")
         pyro.sample("x", dist.Categorical(probs_x))
@@ -1452,7 +1452,7 @@ def test_elbo_enumerate_iarange_2(num_samples):
         x = pyro.sample("x", dist.Categorical(probs_x))
         with pyro.iarange("data", len(data)):
             y = pyro.sample("y", dist.Categorical(probs_y[x]),
-                            infer={"enumerate": "parallel", "expand": False})
+                            infer={"enumerate": "parallel"})
             pyro.sample("z", dist.Categorical(probs_z[y]), obs=data)
 
     def hand_model(data):
@@ -1464,7 +1464,7 @@ def test_elbo_enumerate_iarange_2(num_samples):
         with pyro.iarange("data", len(data)):
             pyro.sample("z", dist.Categorical(probs_yz[x]), obs=data)
 
-    @config_enumerate(default="parallel", expand=False)
+    @config_enumerate(default="parallel")
     def guide(data):
         probs_x = pyro.param("guide_probs_x")
         pyro.sample("x", dist.Categorical(probs_x))
@@ -1510,7 +1510,7 @@ def test_elbo_enumerate_iarange_3(num_samples):
         with pyro.iarange("data", len(data)):
             x = pyro.sample("x", dist.Categorical(probs_x))
             y = pyro.sample("y", dist.Categorical(probs_y[x]),
-                            infer={"enumerate": "parallel", "expand": False})
+                            infer={"enumerate": "parallel"})
             pyro.sample("z", dist.Categorical(probs_z[y]), obs=data)
 
     def hand_model(data):
@@ -1522,7 +1522,7 @@ def test_elbo_enumerate_iarange_3(num_samples):
             x = pyro.sample("x", dist.Categorical(probs_x))
             pyro.sample("z", dist.Categorical(probs_yz[x]), obs=data)
 
-    @config_enumerate(default="parallel", expand=False)
+    @config_enumerate(default="parallel")
     def guide(data):
         probs_x = pyro.param("guide_probs_x")
         with pyro.iarange("data", len(data)):
@@ -1565,7 +1565,7 @@ def test_elbo_hmm_growth():
             x = pyro.sample("x_{}".format(i), dist.Categorical(probs))
             pyro.sample("y_{}".format(i), dist.Categorical(emission_probs[x]), obs=y)
 
-    @config_enumerate(default="parallel", expand=False)
+    @config_enumerate(default="parallel")
     def guide(data):
         transition_probs = pyro.param("transition_probs",
                                       torch.tensor([[0.75, 0.25], [0.25, 0.75]]),
@@ -1620,7 +1620,7 @@ def test_elbo_dbn_growth():
             y = pyro.sample("y_{}".format(i), dist.Categorical(uniform))
             pyro.sample("z_{}".format(i), dist.Categorical(probs_z[y]), obs=z)
 
-    @config_enumerate(default="parallel", expand=False)
+    @config_enumerate(default="parallel")
     def guide(data):
         probs_x = pyro.param("probs_x",
                              torch.tensor([[0.75, 0.25], [0.25, 0.75]]),

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -1006,7 +1006,7 @@ def test_dim_allocation_error(Elbo, expand):
 
 
 def test_enum_in_model_ok():
-    infer = {'enumerate': 'parallel', 'expand': False}
+    infer = {'enumerate': 'parallel'}
 
     def model():
         p = pyro.param('p', torch.tensor(0.25))
@@ -1044,7 +1044,7 @@ def test_enum_in_model_ok():
 
 
 def test_enum_iarange_in_model_ok():
-    infer = {'enumerate': 'parallel', 'expand': False}
+    infer = {'enumerate': 'parallel'}
 
     def model():
         p = pyro.param('p', torch.tensor(0.25))

--- a/tutorial/source/tensor_shapes.ipynb
+++ b/tutorial/source/tensor_shapes.ipynb
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,39 +546,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-48-6f1f4ea7d412>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     62\u001b[0m     \u001b[0mtest_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mTraceEnum_ELBO\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmax_iarange_nesting\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     63\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 64\u001b[0;31m \u001b[0mtest_model_with_sample_fn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msample_pixel_locations_no_broadcasting\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     65\u001b[0m \u001b[0mtest_model_with_sample_fn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msample_pixel_locations_automatic_broadcasting\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbroadcast\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     66\u001b[0m \u001b[0mtest_model_with_sample_fn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msample_pixel_locations_partial_broadcasting\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbroadcast\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m<ipython-input-48-6f1f4ea7d412>\u001b[0m in \u001b[0;36mtest_model_with_sample_fn\u001b[0;34m(sample_fn, broadcast)\u001b[0m\n\u001b[1;32m     60\u001b[0m         \u001b[0mmodel\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbroadcast\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     61\u001b[0m         \u001b[0mguide\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbroadcast\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mguide\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 62\u001b[0;31m     \u001b[0mtest_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mTraceEnum_ELBO\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmax_iarange_nesting\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     63\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     64\u001b[0m \u001b[0mtest_model_with_sample_fn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msample_pixel_locations_no_broadcasting\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m<ipython-input-32-f7b3e6281d7e>\u001b[0m in \u001b[0;36mtest_model\u001b[0;34m(model, guide, loss)\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mtest_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mloss\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m     \u001b[0mpyro\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclear_param_store\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 17\u001b[0;31m     \u001b[0mloss\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloss\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/infer/traceenum_elbo.pyc\u001b[0m in \u001b[0;36mloss\u001b[0;34m(self, model, guide, *args, **kwargs)\u001b[0m\n\u001b[1;32m    147\u001b[0m         \"\"\"\n\u001b[1;32m    148\u001b[0m         \u001b[0melbo\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 149\u001b[0;31m         \u001b[0;32mfor\u001b[0m \u001b[0mmodel_trace\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide_trace\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_traces\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    150\u001b[0m             \u001b[0melbo_particle\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_compute_dice_elbo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel_trace\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide_trace\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    151\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mis_identically_zero\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0melbo_particle\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/infer/traceenum_elbo.pyc\u001b[0m in \u001b[0;36m_get_traces\u001b[0;34m(self, model, guide, *args, **kwargs)\u001b[0m\n\u001b[1;32m    137\u001b[0m             \u001b[0mq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mput\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTrace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    138\u001b[0m             \u001b[0;32mwhile\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mempty\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 139\u001b[0;31m                 \u001b[0;32myield\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_trace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    140\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    141\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mloss\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/infer/traceenum_elbo.pyc\u001b[0m in \u001b[0;36m_get_trace\u001b[0;34m(self, model, guide, *args, **kwargs)\u001b[0m\n\u001b[1;32m     94\u001b[0m         \"\"\"\n\u001b[1;32m     95\u001b[0m         model_trace, guide_trace = get_importance_trace(\n\u001b[0;32m---> 96\u001b[0;31m             \"flat\", self.max_iarange_nesting, model, guide, *args, **kwargs)\n\u001b[0m\u001b[1;32m     97\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     98\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mis_validation_enabled\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/infer/enum.pyc\u001b[0m in \u001b[0;36mget_importance_trace\u001b[0;34m(graph_type, max_iarange_nesting, model, guide, *args, **kwargs)\u001b[0m\n\u001b[1;32m     38\u001b[0m     \u001b[0mguide\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbroadcast\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mguide\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     39\u001b[0m     \u001b[0mmodel\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbroadcast\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 40\u001b[0;31m     \u001b[0mguide_trace\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mgraph_type\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mgraph_type\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_trace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     41\u001b[0m     model_trace = poutine.trace(poutine.replay(model, trace=guide_trace),\n\u001b[1;32m     42\u001b[0m                                 graph_type=graph_type).get_trace(*args, **kwargs)\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/trace_messenger.pyc\u001b[0m in \u001b[0;36mget_trace\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    190\u001b[0m         \u001b[0mCalls\u001b[0m \u001b[0mthis\u001b[0m \u001b[0mpoutine\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mreturns\u001b[0m \u001b[0mits\u001b[0m \u001b[0mtrace\u001b[0m \u001b[0minstead\u001b[0m \u001b[0mof\u001b[0m \u001b[0mthe\u001b[0m \u001b[0mfunction\u001b[0m\u001b[0;31m'\u001b[0m\u001b[0ms\u001b[0m \u001b[0;32mreturn\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    191\u001b[0m         \"\"\"\n\u001b[0;32m--> 192\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    193\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_trace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/trace_messenger.pyc\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    174\u001b[0m                                       \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"_INPUT\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"args\"\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    175\u001b[0m                                       args=args, kwargs=kwargs)\n\u001b[0;32m--> 176\u001b[0;31m             \u001b[0mret\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    177\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrace\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_node\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"_RETURN\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"_RETURN\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"return\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mret\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    178\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mret\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/handlers.pyc\u001b[0m in \u001b[0;36m_fn\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    460\u001b[0m                                        escape_fn=functools.partial(escape_fn,\n\u001b[1;32m    461\u001b[0m                                                                    next_trace)))\n\u001b[0;32m--> 462\u001b[0;31m                     \u001b[0;32mreturn\u001b[0m \u001b[0mftr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    463\u001b[0m                 \u001b[0;32mexcept\u001b[0m \u001b[0mNonlocalExit\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0msite_container\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    464\u001b[0m                     \u001b[0msite_container\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreset_stack\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/trace_messenger.pyc\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    174\u001b[0m                                       \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"_INPUT\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"args\"\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    175\u001b[0m                                       args=args, kwargs=kwargs)\n\u001b[0;32m--> 176\u001b[0;31m             \u001b[0mret\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    177\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrace\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_node\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"_RETURN\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"_RETURN\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"return\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mret\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    178\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mret\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m<ipython-input-48-6f1f4ea7d412>\u001b[0m in \u001b[0;36mguide\u001b[0;34m()\u001b[0m\n\u001b[1;32m     55\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mconfig_enumerate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdefault\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"parallel\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 57\u001b[0;31m         \u001b[0mfun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobserve\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msample_fn\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msample_fn\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     58\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     59\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mbroadcast\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m<ipython-input-48-6f1f4ea7d412>\u001b[0m in \u001b[0;36mfun\u001b[0;34m(observe, sample_fn)\u001b[0m\n\u001b[1;32m     35\u001b[0m         \u001b[0;31m# Indices corresponding to \"parallel\" enumeration are appended\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m         \u001b[0;31m# to the left of the \"num_particles\" iarange dim.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 37\u001b[0;31m         \u001b[0;32massert\u001b[0m \u001b[0mx_active\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshape\u001b[0m  \u001b[0;34m==\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnum_particles\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwidth\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     38\u001b[0m         \u001b[0;32massert\u001b[0m \u001b[0my_active\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshape\u001b[0m  \u001b[0;34m==\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnum_particles\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mheight\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     39\u001b[0m         \u001b[0mp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.1\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;36m0.5\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mx_active\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0my_active\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "num_particles = 100  # Number of samples for the ELBO estimator\n",
     "width = 8\n",
@@ -616,15 +586,15 @@
     "        x_active, y_active = sample_fn(p_x, p_y, x_axis, y_axis)\n",
     "        # Indices corresponding to \"parallel\" enumeration are appended \n",
     "        # to the left of the \"num_particles\" iarange dim.\n",
-    "        assert x_active.shape  == (2, num_particles, width, 1)\n",
-    "        assert y_active.shape  == (2, 1, num_particles, 1, height)\n",
+    "        assert x_active.shape  == (2, 1, 1, 1)\n",
+    "        assert y_active.shape  == (2, 1, 1, 1, 1)\n",
     "        p = 0.1 + 0.5 * x_active * y_active\n",
-    "        assert p.shape == (2, 2, num_particles, width, height)\n",
+    "        assert p.shape == (2, 2, 1, 1, 1)\n",
     "\n",
-    "        dense_pixels = torch.zeros_like(p)\n",
+    "        dense_pixels = p.new_zeros(broadcast_shape(p.shape, (width, height)))\n",
     "        for x, y in sparse_pixels:\n",
     "            dense_pixels[..., x, y] = 1\n",
-    "        assert dense_pixels.shape == (2, 2, num_particles, width, height)\n",
+    "        assert dense_pixels.shape == (2, 2, 1, width, height)\n",
     "\n",
     "        with x_axis, y_axis:    \n",
     "            if observe:\n",
@@ -662,6 +632,13 @@
     "\n",
     "Note how simple it is to achieve parallelization via tensorized operations using `pyro.iarange` and `poutine.broadcast`! `poutine.broadcast` also helps in code modularization because model components can be written agnostic of the `iarange` contexts in which they may subsequently get embedded in."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tutorial/source/tensor_shapes.ipynb
+++ b/tutorial/source/tensor_shapes.ipynb
@@ -250,7 +250,7 @@
     "with x_axis, y_axis:\n",
     "    # within this context, batch dimensions -3 and -2 are independent\n",
     "```\n",
-    "Let's take a closer look at batch sizes within `iarange`s."
+    "Let's take a closer look at batch sizes within `iarange`s. (See the [broadcasting](#Broadcasting-to-allow-parallel-enumeration) section below for explanation of `@poutine.broadcast`.)"
    ]
   },
   {
@@ -259,6 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "@poutine.broadcast\n",
     "def model1():\n",
     "    a = pyro.sample(\"a\", Normal(0, 1))\n",
     "    b = pyro.sample(\"b\", Normal(torch.zeros(2), 1).independent(1))\n",
@@ -338,6 +339,7 @@
    "source": [
     "data = torch.arange(100.)\n",
     "\n",
+    "@poutine.broadcast\n",
     "def model2():\n",
     "    mean = pyro.param(\"mean\", torch.zeros(len(data)))\n",
     "    with pyro.iarange(\"data\", len(data), subsample_size=10) as ind:\n",
@@ -535,7 +537,7 @@
    "source": [
     "### Automatic broadcasting via broadcast poutine<a class=\"anchor\" id=\"Automatic-broadcasting-via-broadcast-poutine\"></a>\n",
     "\n",
-    "Note that in all our model/guide specifications, we hve relied on [poutine.broadcast](http://docs.pyro.ai/en/latest/poutine.html#pyro.poutine.broadcast) to automatically expand sample shapes to satisfy the constraints on batch shape enforced by `pyro.iarange` statements. However `poutine.broadcast` is equavlent to hand-annotated `.expand()` statements.\n",
+    "Note that in all our model/guide specifications, we hve relied on [poutine.broadcast](http://docs.pyro.ai/en/latest/poutine.html#pyro.poutine.broadcast) to automatically expand sample shapes to satisfy the constraints on batch shape enforced by `pyro.iarange` statements. However `poutine.broadcast` is equivalent to hand-annotated `.expand()` statements.\n",
     "\n",
     "We will demonstrate this using `model4` from the [previous section](#Writing-parallelizable-code). Note the following changes to the code from earlier:\n",
     "\n",

--- a/tutorial/source/tensor_shapes.ipynb
+++ b/tutorial/source/tensor_shapes.ipynb
@@ -643,21 +643,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/tutorial/source/tensor_shapes.ipynb
+++ b/tutorial/source/tensor_shapes.ipynb
@@ -13,7 +13,7 @@
     "- Tensors broadcast by aligning on the right: `torch.ones(3,4,5) + torch.ones(5)`.\n",
     "- Distribution `.sample().shape == batch_shape + event_shape`.\n",
     "- Distribution `.log_prob(x).shape == batch_shape` (but not `event_shape`!).\n",
-    "- Use `my_dist.expand_by([2,3,4])` to draw a batch of samples.\n",
+    "- Use `.expand()` or `poutine.broadcast` to draw a batch of samples.\n",
     "- Use `my_dist.independent(1)` to declare a dimension as dependent.\n",
     "- Use `with pyro.iarange('name', size):` to declare a dimension as independent.\n",
     "- All dimensions must be declared either dependent or independent.\n",
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,6 +44,7 @@
     "import pyro\n",
     "from torch.distributions import constraints\n",
     "from pyro.distributions import Bernoulli, Categorical, MultivariateNormal, Normal\n",
+    "from pyro.distributions.util import broadcast_shape\n",
     "from pyro.infer import Trace_ELBO, TraceEnum_ELBO, config_enumerate\n",
     "import pyro.poutine as poutine\n",
     "from pyro.optim import Adam\n",
@@ -92,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,17 +130,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another way to batch distributions is via the `.expand_by()` method. This only works if \n",
+    "Another way to batch distributions is via the `.expand()` method. This only works if \n",
     "parameters are identical along the leftmost dimensions."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
-    "d = Bernoulli(torch.tensor([0.1, 0.2, 0.3, 0.4])).expand_by([3])\n",
+    "d = Bernoulli(torch.tensor([0.1, 0.2, 0.3, 0.4])).expand([3, 4])\n",
     "assert d.batch_shape == (3, 4)\n",
     "assert d.event_shape == ()\n",
     "x = d.sample()\n",
@@ -156,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,12 +202,12 @@
     "\n",
     "Often in Pyro we'll declare some dimensions as dependent even though they are in fact independent, e.g.\n",
     "```py\n",
-    "pyro.sample(\"x\", dist.Normal(0, 1).expand_by([10]).independent(1))\n",
+    "pyro.sample(\"x\", dist.Normal(0, 1).expand([10]).independent(1))\n",
     "```\n",
     "This is useful for two reasons: First it allows us to easily swap in a `MultivariateNormal` distribution later. Second it simplifies the code a bit since we don't need an `iarange` (see below) as in\n",
     "```py\n",
     "with pyro.iarange(\"x_iarange\", 10):\n",
-    "    pyro.sample(\"x\", dist.Normal(0, 1).expand_by([10]))\n",
+    "    pyro.sample(\"x\", dist.Normal(0, 1).expand([10]))\n",
     "```\n",
     "The difference between these two versions is that the second version with `iarange` informs Pyro that it can make use of independence information when estimating gradients, whereas in the first version Pyro must assume they are dependent (even though the normals are in fact independent). This is analogous to d-separation in graphical models: it is always safe to add edges and assume variables *may* be dependent (i.e. to widen the model class), but it is unsafe to assume independence when variables are actually dependent (i.e. narrowing the model class so the true model lies outside of the class, as in mean field). In practice Pyro's SVI inference algorithm uses reparameterized gradient estimators for `Normal` distributions so both gradient estimators have the same performance."
    ]
@@ -254,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,12 +274,12 @@
     "    x_axis = pyro.iarange(\"x_axis\", 3, dim=-2)\n",
     "    y_axis = pyro.iarange(\"y_axis\", 2, dim=-3)\n",
     "    with x_axis:\n",
-    "        x = pyro.sample(\"x\", Normal(0, 1).expand_by([3, 1]))\n",
+    "        x = pyro.sample(\"x\", Normal(0, 1))\n",
     "    with y_axis:\n",
-    "        y = pyro.sample(\"y\", Normal(0, 1).expand_by([2, 1, 1]))\n",
+    "        y = pyro.sample(\"y\", Normal(0, 1))\n",
     "    with x_axis, y_axis:\n",
-    "        xy = pyro.sample(\"xy\", Normal(0, 1).expand_by([2, 3, 1]))\n",
-    "        z = pyro.sample(\"z\", Normal(0, 1).expand_by([2, 3, 1, 5]).independent(1))\n",
+    "        xy = pyro.sample(\"xy\", Normal(0, 1))\n",
+    "        z = pyro.sample(\"z\", Normal(0, 1).expand([5]).independent(1))\n",
     "    assert x.shape == (3, 1)        # batch_shape == (3,1)     event_shape == ()\n",
     "    assert y.shape == (2, 1, 1)     # batch_shape == (2,1,1)   event_shape == ()\n",
     "    assert xy.shape == (2, 3, 1)    # batch_shape == (2,3,1)   event_shape == ()\n",
@@ -307,12 +308,12 @@
     "           |        x_axis = iarange(\"x\", 3, dim=-2)\n",
     "           |        y_axis = iarange(\"y\", 2, dim=-3)\n",
     "           |        with x_axis:\n",
-    "        3 1|            x = sample(\"x\", Normal(0, 1).expand_by([3, 1]))\n",
+    "        3 1|            x = sample(\"x\", Normal(0, 1))\n",
     "           |        with y_axis:\n",
-    "      2 1 1|            y = sample(\"y\", Normal(0, 1).expand_by([2, 1, 1]))\n",
+    "      2 1 1|            y = sample(\"y\", Normal(0, 1))\n",
     "           |        with x_axis, y_axis:\n",
-    "      2 3 1|            xy = sample(\"xy\", Normal(0, 1).expand_by([2, 3, 1]))\n",
-    "      2 3 1|5           z = sample(\"z\", Normal(0, 1).expand_by([2, 3, 1, 5])\n",
+    "      2 3 1|            xy = sample(\"xy\", Normal(0, 1))\n",
+    "      2 3 1|5           z = sample(\"z\", Normal(0, 1).expand([5])\n",
     "           |                       .independent(1))\n",
     "```\n",
     "As an exercise, try to tabulate the shapes of sample sites in one of your own programs."
@@ -331,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,7 +359,7 @@
     "\n",
     "Pyro 0.2 introduces the ability to enumerate discrete latent variables in parallel. This can significantly reduce the variance of gradient estimators when learning a posterior via [SVI](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.svi.SVI).\n",
     "\n",
-    "To use discrete enumeration, Pyro needs to allocate tensor dimension that it can use for enumeration. To avoid conflicting with other dimensions that we want to use for `iarange`s, we need to declare a budget of the maximum number of tensor dimensions we'll use. This budget is called `max_iarange_nesting` and is an argument to [SVI](http://docs.pyro.ai/en/dev/inference_algos.html) (the argument is simply passed through to [TraceEnum_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.traceenum_elbo.TraceEnum_ELBO)).\n",
+    "To use parallel enumeration, Pyro needs to allocate tensor dimension that it can use for enumeration. To avoid conflicting with other dimensions that we want to use for `iarange`s, we need to declare a budget of the maximum number of tensor dimensions we'll use. This budget is called `max_iarange_nesting` and is an argument to [SVI](http://docs.pyro.ai/en/dev/inference_algos.html) (the argument is simply passed through to [TraceEnum_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.traceenum_elbo.TraceEnum_ELBO)).\n",
     "\n",
     "To understand `max_iarange_nesting` and how Pyro allocates dimensions for enumeration, let's revisit `model1()` from above. This time we'll map out three types of dimensions:\n",
     "enumeration dimensions on the left (Pyro takes control of these), batch dimensions in the middle, and event dimensions on the right."
@@ -385,12 +386,12 @@
     "           |     |      x_axis = iarange(\"x\", 3, dim=-2)\n",
     "           |     |      y_axis = iarange(\"y\", 2, dim=-3)\n",
     "           |     |      with x_axis:\n",
-    "           |. 3 1|          x = sample(\"x\", Normal(0, 1).expand_by([3,1]))\n",
+    "           |. 3 1|          x = sample(\"x\", Normal(0, 1))\n",
     "           |     |      with y_axis:\n",
-    "           |2 1 1|          y = sample(\"y\", Normal(0, 1).expand_by([2,1,1]))\n",
+    "           |2 1 1|          y = sample(\"y\", Normal(0, 1))\n",
     "           |     |      with x_axis, y_axis:\n",
-    "           |2 3 1|          xy = sample(\"xy\", Normal(0, 1).expand_by([2,3,1]))\n",
-    "           |2 3 1|5         z = sample(\"z\", Normal(0, 1).expand_by([2,3,1,5]))\n",
+    "           |2 3 1|          xy = sample(\"xy\", Normal(0, 1))\n",
+    "           |2 3 1|5         z = sample(\"z\", Normal(0, 1).expand([5]))\n",
     "           |     |                     .independent(1))\n",
     "```\n",
     "Note that it is safe to overprovision `max_iarange_nesting=4` but we cannot underprovision `max_iarange_nesting=2` (or Pyro will error). Let's see how this works in practice."
@@ -398,11 +399,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
     "@config_enumerate(default=\"parallel\")\n",
+    "@poutine.broadcast\n",
     "def model3():\n",
     "    p = pyro.param(\"p\", torch.arange(6.) / 6)\n",
     "    locs = pyro.param(\"locs\", torch.tensor([-1., 1.]))\n",
@@ -410,9 +412,9 @@
     "    a = pyro.sample(\"a\", Categorical(torch.ones(6) / 6))\n",
     "    b = pyro.sample(\"b\", Bernoulli(p[a]))  # Note this depends on a.\n",
     "    with pyro.iarange(\"c_iarange\", 4):\n",
-    "        c = pyro.sample(\"c\", Bernoulli(0.3).expand_by([4]))\n",
+    "        c = pyro.sample(\"c\", Bernoulli(0.3))\n",
     "        with pyro.iarange(\"d_iarange\", 5):\n",
-    "            d = pyro.sample(\"d\", Bernoulli(0.4).expand_by([5,4]))\n",
+    "            d = pyro.sample(\"d\", Bernoulli(0.4))\n",
     "            e_loc = locs[d.long()].unsqueeze(-1)\n",
     "            e_scale = torch.arange(1., 8.)\n",
     "            e = pyro.sample(\"e\", Normal(e_loc, e_scale)\n",
@@ -420,12 +422,12 @@
     "\n",
     "    #                   enumerated|batch|event dims\n",
     "    assert a.shape == (         6, 1, 1   )  # Six enumerated values of the Categorical.\n",
-    "    assert b.shape == (      2, 6, 1, 1   )  # 2 enumerated Bernoullis x 6 Categoricals.\n",
-    "    assert c.shape == (   2, 1, 1, 1, 4   )  # Only 2 Bernoullis; does not depend on a or b.\n",
-    "    assert d.shape == (2, 1, 1, 1, 5, 4   )  # Only two Bernoullis.\n",
+    "    assert b.shape == (      2, 1, 1, 1   )  # Two enumerated Bernoullis, unexpanded.\n",
+    "    assert c.shape == (   2, 1, 1, 1, 1   )  # Only two Bernoullis, unexpanded.\n",
+    "    assert d.shape == (2, 1, 1, 1, 1, 1   )  # Only two Bernoullis, unexpanded.\n",
     "    assert e.shape == (2, 1, 1, 1, 5, 4, 7)  # This is sampled and depends on d.\n",
     "\n",
-    "    assert e_loc.shape   == (2, 1, 1, 1, 5, 4, 1,)\n",
+    "    assert e_loc.shape   == (2, 1, 1, 1, 1, 1, 1,)\n",
     "    assert e_scale.shape == (                  7,)\n",
     "            \n",
     "test_model(model3, model3, TraceEnum_ELBO(max_iarange_nesting=2))"
@@ -435,7 +437,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's take a closer look at those dimensions. First note that Pyro allocates enumeration dims starting from the right at `max_iarange_nesting`: Pyro allocates dim -3 to enumerate `a`, then dim -4 to enumerate `b`, then dim -5 to enumerate `c`, and finally dim -6 to enumerate `d`. Next note that variables only have extent (size > 1) in dimensions they depend on. This helps keep tensors small and computation cheap. We can draw a similar map of the tensor dimensions:\n",
+    "Let's take a closer look at those dimensions. First note that Pyro allocates enumeration dims starting from the right at `max_iarange_nesting`: Pyro allocates dim -3 to enumerate `a`, then dim -4 to enumerate `b`, then dim -5 to enumerate `c`, and finally dim -6 to enumerate `d`. Next note that samples only have extent (size > 1) in the new enumeration dimension. This helps keep tensors small and computation cheap. (Note that the `log_prob` shape will be broadcast up to contain both enumeratin shape and batch shape, so e.g. `trace.nodes['d']['log_prob'].shape == (2, 1, 1, 1, 5, 4)`.)\n",
+    "\n",
+    "We can draw a similar map of the tensor dimensions:\n",
     "```\n",
     "     max_iarange_nesting = 2\n",
     "            |<->|\n",
@@ -444,10 +448,10 @@
     "           6|1 1|     a = pyro.sample(\"a\", Categorical(torch.ones(6) / 6))\n",
     "         2 1|1 1|     b = pyro.sample(\"b\", Bernoulli(p[a]))\n",
     "            |   |     with pyro.iarange(\"c_iarange\", 4):\n",
-    "       2 1 1|1 4|         c = pyro.sample(\"c\", Bernoulli(0.3).expand_by([4]))\n",
+    "       2 1 1|1 1|         c = pyro.sample(\"c\", Bernoulli(0.3))\n",
     "            |   |         with pyro.iarange(\"d_iarange\", 5):\n",
-    "     2 1 1 1|5 4|             d = pyro.sample(\"d\", Bernoulli(0.4).expand_by([5,4]))\n",
-    "     2 1 1 1|5 4|1            e_loc = locs[d.long()].unsqueeze(-1)\n",
+    "     2 1 1 1|1 1|             d = pyro.sample(\"d\", Bernoulli(0.4))\n",
+    "     2 1 1 1|1 1|1            e_loc = locs[d.long()].unsqueeze(-1)\n",
     "            |   |7            e_scale = torch.arange(1., 8.)\n",
     "     2 1 1 1|5 4|7            e = pyro.sample(\"e\", Normal(e_loc, e_scale)\n",
     "            |   |                             .independent(1))\n",
@@ -460,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,6 +473,7 @@
     "sparse_pixels = torch.LongTensor([[3, 2], [3, 5], [3, 9], [7, 1]])\n",
     "enumerated = None  # set to either True or False below\n",
     "\n",
+    "@poutine.broadcast\n",
     "def fun(observe):\n",
     "    p_x = pyro.param(\"p_x\", torch.tensor(0.1), constraint=constraints.unit_interval)\n",
     "    p_y = pyro.param(\"p_y\", torch.tensor(0.1), constraint=constraints.unit_interval)\n",
@@ -477,12 +482,12 @@
     "\n",
     "    # Note that the shapes of these sites depend on whether Pyro is enumerating.\n",
     "    with x_axis:\n",
-    "        x_active = pyro.sample(\"x_active\", Bernoulli(p_x).expand_by([width, 1]))\n",
+    "        x_active = pyro.sample(\"x_active\", Bernoulli(p_x))\n",
     "    with y_axis:\n",
-    "        y_active = pyro.sample(\"y_active\", Bernoulli(p_y).expand_by([height]))\n",
+    "        y_active = pyro.sample(\"y_active\", Bernoulli(p_y))\n",
     "    if enumerated:\n",
-    "        assert x_active.shape  == (2, width, 1)\n",
-    "        assert y_active.shape  == (2, 1, 1, height)\n",
+    "        assert x_active.shape  == (2, 1, 1)\n",
+    "        assert y_active.shape  == (2, 1, 1, 1)\n",
     "    else:\n",
     "        assert x_active.shape  == (width, 1)\n",
     "        assert y_active.shape  == (height,)\n",
@@ -490,13 +495,13 @@
     "    # The first trick is to broadcast. This works with or without enumeration.\n",
     "    p = 0.1 + 0.5 * x_active * y_active\n",
     "    if enumerated:\n",
-    "        assert p.shape == (2, 2, width, height)\n",
+    "        assert p.shape == (2, 2, 1, 1)\n",
     "    else:\n",
     "        assert p.shape == (width, height)\n",
+    "    dense_pixels = p.new_zeros(broadcast_shape(p.shape, (width, height)))\n",
     "\n",
     "    # The second trick is to index using ellipsis slicing.\n",
     "    # This allows Pyro to add arbitrary dimensions on the left.\n",
-    "    dense_pixels = torch.zeros_like(p)\n",
     "    for x, y in sparse_pixels:\n",
     "        dense_pixels[..., x, y] = 1\n",
     "    if enumerated:\n",
@@ -530,7 +535,7 @@
    "source": [
     "### Automatic broadcasting via broadcast poutine<a class=\"anchor\" id=\"Automatic-broadcasting-via-broadcast-poutine\"></a>\n",
     "\n",
-    "Note that in all our model/guide specifications, we had to expand sample shapes by hand to satisfy the constraints on batch shape enforced by `pyro.iarange` statements. This code can be simplified by using [poutine.broadcast](http://docs.pyro.ai/en/latest/poutine.html#pyro.poutine.broadcast), which automatically broadcasts the batch shape of `pyro.sample` statements when inside a single or nested iarange context. \n",
+    "Note that in all our model/guide specifications, we hve relied on [poutine.broadcast](http://docs.pyro.ai/en/latest/poutine.html#pyro.poutine.broadcast) to automatically expand sample shapes to satisfy the constraints on batch shape enforced by `pyro.iarange` statements. However `poutine.broadcast` is equavlent to hand-annotated `.expand()` statements.\n",
     "\n",
     "We will demonstrate this using `model4` from the [previous section](#Writing-parallelizable-code). Note the following changes to the code from earlier:\n",
     "\n",
@@ -541,9 +546,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-48-6f1f4ea7d412>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     62\u001b[0m     \u001b[0mtest_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mTraceEnum_ELBO\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmax_iarange_nesting\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     63\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 64\u001b[0;31m \u001b[0mtest_model_with_sample_fn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msample_pixel_locations_no_broadcasting\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     65\u001b[0m \u001b[0mtest_model_with_sample_fn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msample_pixel_locations_automatic_broadcasting\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbroadcast\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     66\u001b[0m \u001b[0mtest_model_with_sample_fn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msample_pixel_locations_partial_broadcasting\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbroadcast\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-48-6f1f4ea7d412>\u001b[0m in \u001b[0;36mtest_model_with_sample_fn\u001b[0;34m(sample_fn, broadcast)\u001b[0m\n\u001b[1;32m     60\u001b[0m         \u001b[0mmodel\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbroadcast\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     61\u001b[0m         \u001b[0mguide\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbroadcast\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mguide\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 62\u001b[0;31m     \u001b[0mtest_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mTraceEnum_ELBO\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmax_iarange_nesting\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     63\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     64\u001b[0m \u001b[0mtest_model_with_sample_fn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msample_pixel_locations_no_broadcasting\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-32-f7b3e6281d7e>\u001b[0m in \u001b[0;36mtest_model\u001b[0;34m(model, guide, loss)\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mtest_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mloss\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m     \u001b[0mpyro\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclear_param_store\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 17\u001b[0;31m     \u001b[0mloss\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloss\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/infer/traceenum_elbo.pyc\u001b[0m in \u001b[0;36mloss\u001b[0;34m(self, model, guide, *args, **kwargs)\u001b[0m\n\u001b[1;32m    147\u001b[0m         \"\"\"\n\u001b[1;32m    148\u001b[0m         \u001b[0melbo\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 149\u001b[0;31m         \u001b[0;32mfor\u001b[0m \u001b[0mmodel_trace\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide_trace\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_traces\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    150\u001b[0m             \u001b[0melbo_particle\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_compute_dice_elbo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel_trace\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide_trace\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    151\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mis_identically_zero\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0melbo_particle\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/infer/traceenum_elbo.pyc\u001b[0m in \u001b[0;36m_get_traces\u001b[0;34m(self, model, guide, *args, **kwargs)\u001b[0m\n\u001b[1;32m    137\u001b[0m             \u001b[0mq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mput\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTrace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    138\u001b[0m             \u001b[0;32mwhile\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mempty\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 139\u001b[0;31m                 \u001b[0;32myield\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_trace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    140\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    141\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mloss\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmodel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/infer/traceenum_elbo.pyc\u001b[0m in \u001b[0;36m_get_trace\u001b[0;34m(self, model, guide, *args, **kwargs)\u001b[0m\n\u001b[1;32m     94\u001b[0m         \"\"\"\n\u001b[1;32m     95\u001b[0m         model_trace, guide_trace = get_importance_trace(\n\u001b[0;32m---> 96\u001b[0;31m             \"flat\", self.max_iarange_nesting, model, guide, *args, **kwargs)\n\u001b[0m\u001b[1;32m     97\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     98\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mis_validation_enabled\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/infer/enum.pyc\u001b[0m in \u001b[0;36mget_importance_trace\u001b[0;34m(graph_type, max_iarange_nesting, model, guide, *args, **kwargs)\u001b[0m\n\u001b[1;32m     38\u001b[0m     \u001b[0mguide\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbroadcast\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mguide\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     39\u001b[0m     \u001b[0mmodel\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbroadcast\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 40\u001b[0;31m     \u001b[0mguide_trace\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpoutine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mguide\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mgraph_type\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mgraph_type\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_trace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     41\u001b[0m     model_trace = poutine.trace(poutine.replay(model, trace=guide_trace),\n\u001b[1;32m     42\u001b[0m                                 graph_type=graph_type).get_trace(*args, **kwargs)\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/trace_messenger.pyc\u001b[0m in \u001b[0;36mget_trace\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    190\u001b[0m         \u001b[0mCalls\u001b[0m \u001b[0mthis\u001b[0m \u001b[0mpoutine\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mreturns\u001b[0m \u001b[0mits\u001b[0m \u001b[0mtrace\u001b[0m \u001b[0minstead\u001b[0m \u001b[0mof\u001b[0m \u001b[0mthe\u001b[0m \u001b[0mfunction\u001b[0m\u001b[0;31m'\u001b[0m\u001b[0ms\u001b[0m \u001b[0;32mreturn\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    191\u001b[0m         \"\"\"\n\u001b[0;32m--> 192\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    193\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_trace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/trace_messenger.pyc\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    174\u001b[0m                                       \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"_INPUT\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"args\"\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    175\u001b[0m                                       args=args, kwargs=kwargs)\n\u001b[0;32m--> 176\u001b[0;31m             \u001b[0mret\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    177\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrace\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_node\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"_RETURN\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"_RETURN\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"return\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mret\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    178\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mret\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/handlers.pyc\u001b[0m in \u001b[0;36m_fn\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    460\u001b[0m                                        escape_fn=functools.partial(escape_fn,\n\u001b[1;32m    461\u001b[0m                                                                    next_trace)))\n\u001b[0;32m--> 462\u001b[0;31m                     \u001b[0;32mreturn\u001b[0m \u001b[0mftr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    463\u001b[0m                 \u001b[0;32mexcept\u001b[0m \u001b[0mNonlocalExit\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0msite_container\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    464\u001b[0m                     \u001b[0msite_container\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreset_stack\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/trace_messenger.pyc\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    174\u001b[0m                                       \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"_INPUT\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"args\"\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    175\u001b[0m                                       args=args, kwargs=kwargs)\n\u001b[0;32m--> 176\u001b[0;31m             \u001b[0mret\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    177\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrace\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_node\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"_RETURN\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"_RETURN\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"return\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mret\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    178\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mret\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/fritzobermeyer/github/uber/pyro/pyro/poutine/messenger.pyc\u001b[0m in \u001b[0;36m_wraps\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     25\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0m_wraps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmsngr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_wraps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-48-6f1f4ea7d412>\u001b[0m in \u001b[0;36mguide\u001b[0;34m()\u001b[0m\n\u001b[1;32m     55\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mconfig_enumerate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdefault\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"parallel\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mguide\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 57\u001b[0;31m         \u001b[0mfun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobserve\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msample_fn\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msample_fn\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     58\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     59\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mbroadcast\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-48-6f1f4ea7d412>\u001b[0m in \u001b[0;36mfun\u001b[0;34m(observe, sample_fn)\u001b[0m\n\u001b[1;32m     35\u001b[0m         \u001b[0;31m# Indices corresponding to \"parallel\" enumeration are appended\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m         \u001b[0;31m# to the left of the \"num_particles\" iarange dim.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 37\u001b[0;31m         \u001b[0;32massert\u001b[0m \u001b[0mx_active\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshape\u001b[0m  \u001b[0;34m==\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnum_particles\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwidth\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     38\u001b[0m         \u001b[0;32massert\u001b[0m \u001b[0my_active\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshape\u001b[0m  \u001b[0;34m==\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnum_particles\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mheight\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     39\u001b[0m         \u001b[0mp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.1\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;36m0.5\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mx_active\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0my_active\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
    "source": [
     "num_particles = 100  # Number of samples for the ELBO estimator\n",
     "width = 8\n",
@@ -552,9 +587,9 @@
     "\n",
     "def sample_pixel_locations_no_broadcasting(p_x, p_y, x_axis, y_axis):\n",
     "    with x_axis:\n",
-    "        x_active = pyro.sample(\"x_active\", Bernoulli(p_x).expand_by([num_particles, width, 1]))\n",
+    "        x_active = pyro.sample(\"x_active\", Bernoulli(p_x).expand([num_particles, width, 1]))\n",
     "    with y_axis:\n",
-    "        y_active = pyro.sample(\"y_active\", Bernoulli(p_y).expand_by([num_particles, 1, height]))\n",
+    "        y_active = pyro.sample(\"y_active\", Bernoulli(p_y).expand([num_particles, 1, height]))\n",
     "    return x_active, y_active\n",
     "\n",
     "def sample_pixel_locations_automatic_broadcasting(p_x, p_y, x_axis, y_axis):\n",
@@ -566,9 +601,9 @@
     "\n",
     "def sample_pixel_locations_partial_broadcasting(p_x, p_y, x_axis, y_axis):\n",
     "    with x_axis:\n",
-    "        x_active = pyro.sample(\"x_active\", Bernoulli(p_x).expand_by([width, 1]))\n",
+    "        x_active = pyro.sample(\"x_active\", Bernoulli(p_x).expand([width, 1]))\n",
     "    with y_axis:\n",
-    "        y_active = pyro.sample(\"y_active\", Bernoulli(p_y).expand_by([height]))\n",
+    "        y_active = pyro.sample(\"y_active\", Bernoulli(p_y).expand([height]))\n",
     "    return x_active, y_active \n",
     "\n",
     "def fun(observe, sample_fn):\n",
@@ -631,21 +666,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Addresses #915, #1337 

This PR flips our default behavior of discrete enumeration from `expand=True` to `expand=False`.

While updating the tensor shapes tutorial, I've also rewritten to rely more heavily on `poutine.broadcast` and to avoid mention of `.expand_by()` in favor of `.expand()`.

## Tasks

- [x] Simplify existing unit tests
- [x] Update tensor shapes tutorial
- [x] Fix internal applications to set `expand=True` to avoid breakage