### PR TITLE
bugfix for AIR example

### DIFF
--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -233,7 +233,7 @@ class AIR(nn.Module):
         # Sample presence.
         z_pres = pyro.sample('z_pres_{}'.format(t),
                              dist.Bernoulli(z_pres_p * prev.z_pres).independent(1),
-                             infer=dict(baseline=dict(baseline_value=bl_value.squeeze(-1))))
+                             infer=bl_value)
 
         sample_mask = z_pres if self.use_masking else torch.tensor(1.0)
 
@@ -259,7 +259,7 @@ class AIR(nn.Module):
 
     def baseline_step(self, prev, inputs):
         if not self.use_baselines:
-            return None, None, None
+            return dict(), None, None
 
         # Prevent gradients flowing back from baseline loss to
         # inference net by detaching from graph here.
@@ -282,7 +282,8 @@ class AIR(nn.Module):
         if self.baseline_scalar is not None:
             bl_value = bl_value * self.baseline_scalar
 
-        return bl_value, bl_h, bl_c
+        infer_dict = dict(baseline_value=bl_value.squeeze(-1))
+        return infer_dict, bl_h, bl_c
 
 
 # Spatial transformer helpers.

--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -228,12 +228,12 @@ class AIR(nn.Module):
         z_pres_p, z_where_loc, z_where_scale = self.predict(h)
 
         # Compute baseline estimates for discrete choice z_pres.
-        bl_value, bl_h, bl_c = self.baseline_step(prev, inputs)
+        infer_dict, bl_h, bl_c = self.baseline_step(prev, inputs)
 
         # Sample presence.
         z_pres = pyro.sample('z_pres_{}'.format(t),
                              dist.Bernoulli(z_pres_p * prev.z_pres).independent(1),
-                             infer=bl_value)
+                             infer=infer_dict)
 
         sample_mask = z_pres if self.use_masking else torch.tensor(1.0)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,6 +15,7 @@ pytestmark = pytest.mark.stage('test_examples')
 
 CPU_EXAMPLES = [
     'air/main.py --num-steps=1',
+    'air/main.py --num-steps=1 --no-baseline',
     'baseball.py --num-samples=200 --warmup-steps=100',
     'bayesian_regression.py --num-epochs=1',
     'contrib/autoname/scoping_mixture.py --num-epochs=1',


### PR DESCRIPTION
The option `no-baseline` sets a variable `bl_value = None` which is later squeezed [here](https://github.com/uber/pyro/blob/dev/examples/air/air.py#L236).
This is now fixed. I also include a breaking test that now passes.