### PR TITLE
Implement contract_to_tensor() helper for querying marginals

### DIFF
--- a/tests/infer/test_contract.py
+++ b/tests/infer/test_contract.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
+from collections import OrderedDict
+
 import pytest
 import torch
 
-from pyro.infer.contract import _partition_terms
+from pyro.infer.contract import _partition_terms, contract_to_tensor
+from pyro.poutine.indep_messenger import CondIndepStackFrame
 
 
 @pytest.mark.parametrize('shapes,dims,expected_num_components', [
@@ -48,3 +51,97 @@ def test_partition_terms(shapes, dims, expected_num_components):
                 if any(dim >= -x.dim() and x.shape[dim] > 1 and
                        dim >= -y.dim() and y.shape[dim] > 1 for dim in dims):
                     assert component_dict[x] == component_dict[y]
+
+
+def frame(dim, size):
+    return CondIndepStackFrame(name="iarange_{}".format(size), dim=dim, size=size, counter=0)
+
+
+EXAMPLES = [
+    {
+        'shape_tree': {
+            (): [(2, 3, 1)],
+            (frame(-1, 4),): [(2, 3, 4)],
+        },
+        'sum_dims': [],
+        'target_ordinal': (),
+        'expected_shape': (2, 3, 1),
+    },
+    {
+        'shape_tree': {
+            (): [(2, 3, 1)],
+            (frame(-1, 4),): [(2, 3, 4)],
+        },
+        'sum_dims': [],
+        'target_ordinal': (frame(-1, 4),),
+        'expected_shape': (2, 3, 4),
+    },
+    # ------------------------------------------------------
+    #          z
+    #          | 4    max_iarange_nesting=2
+    #    x     y      w, x, y, z are all enumerated in dims:
+    #   2 \   / 3    -3 -4 -5 -6
+    #       w
+    {
+        'shape_tree': {
+            (): [(2, 1, 1)],  # w
+            (frame(-1, 2),): [(2, 2, 1, 2)],  # x
+            (frame(-1, 3),): [(2, 1, 2, 1, 3)],  # y
+            (frame(-1, 3), frame(-2, 4)): [(2, 2, 1, 1, 4, 3)],  # z
+        },
+        # query for w
+        'sum_dims': [-4, -5, -6],
+        'target_ordinal': (),
+        'expected_shape': (2, 1, 1),
+    },
+    {
+        'shape_tree': {
+            (): [(2, 1, 1)],  # w
+            (frame(-1, 2),): [(2, 2, 1, 2)],  # x
+            (frame(-1, 3),): [(2, 1, 2, 1, 3)],  # y
+            (frame(-1, 3), frame(-2, 4)): [(2, 2, 1, 1, 4, 3)],  # z
+        },
+        # query for x
+        'sum_dims': [-3, -5, -6],
+        'target_ordinal': (frame(-1, 2),),
+        'expected_shape': (2, 1, 1, 2),
+    },
+    {
+        'shape_tree': {
+            (): [(2, 1, 1)],  # w
+            (frame(-1, 2),): [(2, 2, 1, 2)],  # x
+            (frame(-1, 3),): [(2, 1, 2, 1, 3)],  # y
+            (frame(-1, 3), frame(-2, 4)): [(2, 2, 1, 1, 4, 3)],  # z
+        },
+        # query for x
+        'sum_dims': [-3, -4, -6],
+        'target_ordinal': (frame(-1, 3),),
+        'expected_shape': (2, 1, 1, 1, 3),
+    },
+    {
+        'shape_tree': {
+            (): [(2, 1, 1)],  # w
+            (frame(-1, 2),): [(2, 2, 1, 2)],  # x
+            (frame(-1, 3),): [(2, 1, 2, 1, 3)],  # y
+            (frame(-1, 3), frame(-2, 4)): [(2, 2, 1, 1, 4, 3)],  # z
+        },
+        # query for z
+        'sum_dims': [-3, -4, -5],
+        'target_ordinal': (frame(-1, 3), frame(-2, 4)),
+        'expected_shape': (2, 1, 1, 1, 4, 3),
+    },
+]
+
+
+@pytest.mark.parametrize('example', EXAMPLES)
+def test_contract_to_tensor(example):
+    tensor_tree = OrderedDict((frozenset(t), [torch.randn(shape) for shape in shapes])
+                              for t, shapes in example['shape_tree'].items())
+    sum_dims = {x: set(d for d in example['sum_dims'] if -d <= x.dim() and x.shape[d] > 1)
+                for terms in tensor_tree.values()
+                for x in terms}
+    target_ordinal = frozenset(example['target_ordinal'])
+    expected_shape = example['expected_shape']
+
+    actual = contract_to_tensor(tensor_tree, sum_dims, target_ordinal)
+    assert actual.shape == expected_shape


### PR DESCRIPTION
Addresses #915 
Pair coded with @eb8680 

This implements a function `contract_to_tensor(tensor_tree, sum_dims, target_ordinal)` that performs message passing to compute requested marginals at any position in a tensor tree. Whereas `contract_tensor_tree()` contract down the tree to narrow `iarange` contexts for use in computing marginal log likelihood for `Dice` (following the `TraceLogProbEvaluator`'s downward reductions), this new `contract_to_tensor()` can propagate down and up and across the tree.

The motivation is to be able to query marginalized-out sample sites for their marginal distributions, e.g. for predicting document topics in LDA. Much work remains to refactor `_compute_mode_costs()` into a user-facing helper that uses this operation.

@martinjankowiak: Note this is like the batched einsum we discussed, but uses our internal unpacked tensor representation rather than einsum's packed representation of high-dimensional tensors. The packing-unpacking logic lives in [opt_sumproduct](https://github.com/uber/pyro/blob/239ed68/pyro/ops/sumproduct.py#L136), and would have been difficult to factor out.

## Tested

- [x] added unit tests with a hand-constructed example
- [x] this is a refactoring of `_contract_component()` which is covered by test_enum.py