### PR TITLE
Fix warning in gmm tutorial

### DIFF
--- a/tutorial/source/gmm.ipynb
+++ b/tutorial/source/gmm.ipynb
@@ -140,7 +140,7 @@
     "\n",
     "# Register hooks to monitor gradient norms.\n",
     "gradient_norms = defaultdict(list)\n",
-    "inference.loss(model, guide, data)  # Initializes param store.\n",
+    "inference.loss(model, config_enumerate(guide, 'parallel'), data)  # Initializes param store.\n",
     "for name, value in pyro.get_param_store().named_parameters():\n",
     "    value.register_hook(lambda g, name=name: gradient_norms[name].append(g.norm().item()))\n",
     "\n",


### PR DESCRIPTION
This fixes a warning in the GMM tutorial caused by an initial call to `svi.loss(mode, guide, ...)` where `guide` is not wrapped with `config_enumerate`. This initial call was only used to initialize the param store, and was not used in inference; however it did leave a confusing warning message in the cell output.

Thanks to [areshytko](https://forum.pyro.ai/u/areshytko) for reporting this bug.