### PR TITLE
Add dict-like interface to the ParamStore

### DIFF
--- a/docs/source/pyro.params.txt
+++ b/docs/source/pyro.params.txt
@@ -5,3 +5,4 @@ ParamStore
     :members:
     :undoc-members:
     :show-inheritance:
+    :member-order: bysource

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -30,6 +30,9 @@ class ParamStoreDict(object):
     - parameters can be saved and loaded from disk using `save` and `load`.
     """
 
+    # -------------------------------------------------------------------------------
+    # New dict-like interface
+
     def __init__(self):
         """
         initialize ParamStore data structures
@@ -46,18 +49,126 @@ class ParamStoreDict(object):
         self._param_to_name = {}
         self._constraints = {}
 
+    def items(self):
+        """
+        Iterate over ``(name, constrained_param)`` pairs.
+        """
+        for name, unconstrained_value in self.params:
+            constraint = self._constraints[name]
+            constrained_value = transform_to(constraint).inv(unconstrained_value)
+            yield name, constrained_value
+
+    def keys(self):
+        """
+        Iterate over param names.
+        """
+        return self._params.keys()
+
+    def values(self):
+        """
+        Iterate over constrained parameter values.
+        """
+        for name, constrained_param in self.items():
+            yield constrained_param
+
+    def __iter__(self):
+        """
+        Iterate over param names.
+        """
+        return iter(self.keys())
+
+    def __len__(self):
+        return len(self._params)
+
+    def __getitem__(self, name):
+        """
+        Get the constrained value of a named parameter.
+        """
+        unconstrained_value = self._params[name]
+
+        # compute the constrained value
+        constraint = self._constraints[name]
+        constrained_value = transform_to(constraint)(unconstrained_value)
+        constrained_value.unconstrained = weakref.ref(unconstrained_value)
+
+        return constrained_value
+
+    def __delitem__(self, name):
+        """
+        Remove a parameter from the param store.
+        """
+        constrained_value = self._params.pop(name)
+        self._params_to_name.pop(constrained_value)
+        self._constraints.pop(name)
+
+    def __setitem__(self, name, new_constrained_value):
+        """
+        Set the constrained value of an existing parameter, or the value of a
+        new unconstrained parameter. To declare a new parameter with
+        constraint, use :meth:`setdefault`.
+        """
+        # store constraint, defaulting to unconstrained
+        constraint = self._constraints.setdefault(name, constraints.real)
+
+        # store the unconstrained value and constraint
+        with torch.no_grad():
+            unconstrained_value = transform_to(constraint).inv(new_constrained_value)
+        unconstrained_value.requires_grad_(True)
+        self._params[name] = unconstrained_value
+
+        # keep track of each tensor and it's name
+        self._param_to_name[unconstrained_value] = name
+
+    def setdefault(self, name, init_constrained_value, constraint=constraints.real):
+        """
+        Retrieve a constrained parameter value from the if it exists, otherwise
+        set the initial value. Note that this is a little fancier than
+        :meth:`dict.setdefault`.
+
+        If the parameter already exists, ``init_constrained_tensor`` will be ignored. To avoid
+        expensive creation of ``init_constrained_tensor`` you can wrap it in a ``lambda`` that
+        will only be evaluated if the parameter does not already exist::
+
+            param_store.get("foo", lambda: (0.001 * torch.randn(1000, 1000)).exp(),
+                            constraint=constraints.positive)
+
+        :param str name: parameter name
+        :param init_constrained_value: initial tensor
+        :type init_constrained_value: torch.Tensor or callable returning a torch.Tensor
+        :param constraint: torch constraint object
+        :type constraint: torch.distributions.constraints.Constraint
+        :returns: parameter
+        :rtype: torch.Tensor
+        """
+        if name not in self._params:
+            # set the constraint
+            self._constraints[name] = constraint
+
+            # evaluate the lazy value
+            if callable(init_constrained_value):
+                init_constrained_value = init_constrained_value()
+
+            # set the initial value
+            self[name] = init_constrained_value
+
+        # get the param, which is guaranteed to exist
+        return self[name]
+
+    # -------------------------------------------------------------------------------
+    # Old non-dict interface
+
     def named_parameters(self):
         """
-        Returns an iterator over tuples of the form (name, parameter) for each parameter in the ParamStore
+        Returns an iterator over ``(name, unconstrained_value)`` tuples for
+        each parameter in the ParamStore.
         """
-        # TODO consider returing constrained
         return self._params.items()
 
     def get_all_param_names(self):
         """
         Get all parameter names in the ParamStore
         """
-        return self._params.keys()
+        return self.keys()
 
     def replace_param(self, param_name, new_param, old_param):
         """
@@ -71,9 +182,7 @@ class ParamStoreDict(object):
         :type new_param: torch.Tensor
         """
         assert self._params[param_name] is old_param.unconstrained()
-        del self._params[param_name]
-        del self._param_to_name[old_param.unconstrained()]
-        self.get_param(param_name, new_param, constraint=self._constraints[param_name])
+        self[param_name] = new_param
 
     def get_param(self, name, init_tensor=None, constraint=constraints.real):
         """
@@ -90,38 +199,10 @@ class ParamStoreDict(object):
         :returns: parameter
         :rtype: torch.Tensor
         """
-        if name not in self._params:
-            # if not create the init tensor through
-            assert init_tensor is not None,\
-                "cannot initialize a parameter '{}' with None. Did you get the param name right?".format(name)
-
-            # a function
-            if callable(init_tensor):
-                init_tensor = init_tensor()
-
-            # store the unconstrained value and constraint
-            with torch.no_grad():
-                unconstrained_param = transform_to(constraint).inv(init_tensor)
-            unconstrained_param.requires_grad_(True)
-            self._params[name] = unconstrained_param
-            self._constraints[name] = constraint
-
-            # keep track of each tensor and it's name
-            self._param_to_name[unconstrained_param] = name
-
-        elif init_tensor is not None and not callable(init_tensor):
-            if self._params[name].shape != init_tensor.shape:
-                raise ValueError("param {} init tensor shape does not match existing value: {} vs {}".format(
-                    name, init_tensor.shape, self._params[name].shape))
-
-        # get the guaranteed to exist param
-        unconstrained_param = self._params[name]
-
-        # compute the constrained value
-        param = transform_to(self._constraints[name])(unconstrained_param)
-        param.unconstrained = weakref.ref(unconstrained_param)
-
-        return param
+        if init_tensor is None:
+            return self[name]
+        else:
+            return self.setdefault(name, init_tensor, constraint)
 
     def match(self, name):
         """
@@ -132,9 +213,7 @@ class ParamStoreDict(object):
         :returns: dict with key param name and value torch Tensor
         """
         pattern = re.compile(name)
-        params_dict = {key: self.get_param(key) for key in self._params.keys()
-                       if pattern.match(key)}
-        return params_dict
+        return {name: self[name] for name in self if pattern.match(name)}
 
     def param_name(self, p):
         """
@@ -143,10 +222,7 @@ class ParamStoreDict(object):
         :param p: parameter
         :returns: parameter name
         """
-        if p not in self._param_to_name:
-            return None
-
-        return self._param_to_name[p]
+        return self._param_to_name.get(p)
 
     def get_state(self):
         """


### PR DESCRIPTION
Addresses #1234 

This adds a dict-like interface to our `ParamStore`, while preserving all existing methods for backwards compatibility. I think a reasonable refactoring plan is to preserve the old inferface through our 0.2.x releases, and delete it in our 0.3 release.

The one deviation from dict behavior is in the `setdefault` method which:
1. takes an optional `constraint` argument, and
2. allows the value to be a callable for lazy evaluation (a la `defaultdict`)

Note that I've also fixed an arguable bug in param initialization whereby we were forgetting to `.detach()` unconstrained parameters (constrained parameters were correctly detached via `torch.no_grad`). This arguably sketchy functionality was relied on by `test_em_nested_inside_svi`, but the em-inside-svi pattern has been obsoleted by `MixedMultiOptimizer`, so I've merely deleted the old test.

## Tested

- [x] refactored to use the new dict-interface inside old-style methods; covered by existing tests