### PR TITLE
Move einsum character remapping upstream

### DIFF
--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -56,11 +56,6 @@ def _einsum(equation, operands):
         y, x = operands
         return (x.unsqueeze(1) * y).sum(0).transpose(0, 1)
 
-    # work around torch.einsum's limitation to 26 letters
-    symbols = sorted(set(equation) - set(',->'))
-    rename = dict(zip(symbols, 'abcdefghijklmnopqrstuvwxyz'))
-    equation = ''.join(rename.get(s, s) for s in equation)
-
     # this workaround can be deleted after this issue is fixed in release:
     # https://github.com/pytorch/pytorch/issues/7763
     operands = [t.clone() for t in operands]

--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import torch
 
-
 EINSUM_SYMBOLS_BASE = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 
@@ -14,6 +13,12 @@ def einsum(equation, *operands):
     """
     Log-sum-exp implementation of einsum.
     """
+    # rename symbols to support PyTorch 0.4.1 and earlier,
+    # which allow only symbols a-z.
+    symbols = sorted(set(equation) - set(',->'))
+    rename = dict(zip(symbols, 'abcdefghijklmnopqrstuvwxyz'))
+    equation = ''.join(rename.get(s, s) for s in equation)
+
     inputs, output = equation.split('->')
     inputs = inputs.split(',')
 


### PR DESCRIPTION
This simplifies our patch to `torch.einsum` now that the character remapping logic has moved upstream ([here](https://github.com/dgasmith/opt_einsum/blob/3d72bba/opt_einsum/parser.py#L88) and [here](https://github.com/dgasmith/opt_einsum/blob/3d72bba4087a56411b19ce30c1a68a70773113dd/opt_einsum/backends/torch.py#L41)). Hopefully we will be able to entirely remove the patch in #1376. Thanks @neerajprad for pointing out that we still need some remapping (in our `torch_log` backend).