### PR TITLE
Override hash and eq for CondIndepStackFrame

### DIFF
--- a/pyro/poutine/indep_messenger.py
+++ b/pyro/poutine/indep_messenger.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 from collections import namedtuple
 
+import torch
+
 from .messenger import Messenger
 
 
@@ -9,6 +11,19 @@ class CondIndepStackFrame(namedtuple("CondIndepStackFrame", ["name", "dim", "siz
     @property
     def vectorized(self):
         return self.dim is not None
+
+    def _key(self):
+        size = self.size.item() if isinstance(self.size, torch.Tensor) else self.size
+        return self.name, self.dim, size, self.counter
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self._key() == other._key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._key())
 
 
 class IndepMessenger(Messenger):

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -11,6 +11,7 @@ from pyro.infer import (SVI, JitTrace_ELBO, JitTraceEnum_ELBO, JitTraceGraph_ELB
                         Trace_ELBO, TraceEnum_ELBO,
                         TraceGraph_ELBO)
 from pyro.optim import Adam
+from pyro.poutine.indep_messenger import CondIndepStackFrame
 from tests.common import assert_equal, xfail_param
 
 
@@ -233,3 +234,13 @@ def test_dirichlet_bernoulli(Elbo, vectorized):
     svi = SVI(model, guide, optim, elbo)
     for step in range(40):
         svi.step(data)
+
+
+@pytest.mark.parametrize("x,y", [
+    (CondIndepStackFrame("a", -1, torch.tensor(2000), 2), CondIndepStackFrame("a", -1, 2000, 2)),
+    (CondIndepStackFrame("a", -1, 1, 2), CondIndepStackFrame("a", -1, torch.tensor(1), 2)),
+])
+def test_cond_indep_equality(x, y):
+    assert x == y
+    assert not x != y
+    assert hash(x) == hash(y)


### PR DESCRIPTION
This overrides the `__eq__`, `__hash__` for `CondIndepStackFrame` so that the size arg can be either a PyTorch scalar or a python int type. 

**Use case:** Allows us to use data-structures that depend on `CondIndepStackFrame` in the JIT, e.g. in `TraceLogProbEvaluator` or `TraceEnum_ELBO`. 

Consider a model which has a data dependent iarange like `pyro.iarange("data", size=data.shape[0])`. When this is JITed, the `size` arg in the tuple will not be a python int but rather a PyTorch scalar. Since these are used to form keys that index into the different log prob terms per independence context, this either gives rise to an unrelated failure downstream, or a subtle bug (e.g. when the data structure keyed on these ordinals is using a `defaultdict`).