### PR TITLE
Allow for device kwarg in sumproduct

### DIFF
--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -257,7 +257,7 @@ class Dice(object):
             for ordinal, cost_terms in costs:
                 factors = factors_table.get(ordinal, [])
                 for cost in cost_terms:
-                    prob = sumproduct(factors, cost.shape)
+                    prob = sumproduct(factors, cost.shape, device=cost.device)
                     mask = prob > 0
                     if torch.is_tensor(mask) and not mask.all():
                         cost, prob, mask = broadcast_all(cost, prob, mask)

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -44,7 +44,7 @@ def memoized_sum_keepdim(tensor, dim):
     return result
 
 
-def sumproduct(factors, target_shape=(), optimize=True):
+def sumproduct(factors, target_shape=(), optimize=True, device="cpu"):
     """
     Compute product of factors; then sum down extra dims and broadcast up
     missing dims so that result has shape ``target_shape``.
@@ -53,6 +53,8 @@ def sumproduct(factors, target_shape=(), optimize=True):
     :param torch.Size target_shape: An optional shape of the result.
         If missing, all dimensions will be summed out.
     :param bool optimize: Whether to use the :mod:`opt_einsum` backend.
+    :param str device: optional argument to set device on which to create
+        any new tensors.
     :return: A tensor of shape ``target_shape``.
     """
     # Handle numbers and trivial cases.
@@ -62,7 +64,7 @@ def sumproduct(factors, target_shape=(), optimize=True):
         (numbers if isinstance(t, Number) else tensors).append(t)
     if not tensors:
         return torch.tensor(float(reduce(operator.mul, numbers, 1.)),
-                            device=torch.Tensor().device).expand(target_shape)
+                            device=device).expand(target_shape)
     if numbers:
         number_part = reduce(operator.mul, numbers, 1.)
         tensor_part = sumproduct(tensors, target_shape, optimize=optimize)

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -44,7 +44,7 @@ def memoized_sum_keepdim(tensor, dim):
     return result
 
 
-def sumproduct(factors, target_shape=(), optimize=True, device="cpu"):
+def sumproduct(factors, target_shape=(), optimize=True, device=None):
     """
     Compute product of factors; then sum down extra dims and broadcast up
     missing dims so that result has shape ``target_shape``.
@@ -75,7 +75,7 @@ def sumproduct(factors, target_shape=(), optimize=True, device="cpu"):
         return naive_sumproduct(tensors, target_shape)
 
 
-def logsumproductexp(log_factors, target_shape=(), optimize=True):
+def logsumproductexp(log_factors, target_shape=(), optimize=True, device=None):
     """
     Compute sum of log factors; then log_sum_exp down extra dims and broadcast
     up missing dims so that result has shape ``target_shape``.
@@ -85,6 +85,8 @@ def logsumproductexp(log_factors, target_shape=(), optimize=True):
     :param torch.Size target_shape: An optional shape of the result.
         If missing, all dimensions will be summed out.
     :param bool optimize: Whether to use the :mod:`opt_einsum` backend.
+    :param str device: optional argument to set device on which to create
+        any new tensors.
     :return: A tensor of shape ``target_shape``.
     """
     # Handle numbers and trivial cases.
@@ -93,10 +95,11 @@ def logsumproductexp(log_factors, target_shape=(), optimize=True):
     for t in log_factors:
         (numbers if isinstance(t, Number) else tensors).append(t)
     if not tensors:
-        return torch.tensor(float(sum(numbers))).expand(target_shape)
+        return torch.tensor(float(sum(numbers)),
+                            device=device).expand(target_shape)
     if numbers:
         number_part = sum(numbers)
-        tensor_part = logsumproductexp(tensors, target_shape)
+        tensor_part = logsumproductexp(tensors, target_shape, device=device)
         return tensor_part + number_part
     if optimize:
         return opt_sumproduct(tensors, target_shape,

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -61,7 +61,8 @@ def sumproduct(factors, target_shape=(), optimize=True):
     for t in factors:
         (numbers if isinstance(t, Number) else tensors).append(t)
     if not tensors:
-        return torch.tensor(float(reduce(operator.mul, numbers, 1.))).expand(target_shape)
+        return torch.tensor(float(reduce(operator.mul, numbers, 1.)),
+                            device=torch.Tensor().device).expand(target_shape)
     if numbers:
         number_part = reduce(operator.mul, numbers, 1.)
         tensor_part = sumproduct(tensors, target_shape, optimize=optimize)


### PR DESCRIPTION
Needed to run examples on CUDA - sometimes prob is a CPU tensor and cost is a CUDA tensor in `Dice.compute_expectation()` e.g. in `ss-vae`. This fix is wrt the current PyTorch release, and can be safely merged.