### PR TITLE
Fix AIR example bugs.

### DIFF
--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -282,7 +282,7 @@ class AIR(nn.Module):
         if self.baseline_scalar is not None:
             bl_value = bl_value * self.baseline_scalar
 
-        infer_dict = dict(baseline_value=bl_value.squeeze(-1))
+        infer_dict = dict(baseline=dict(baseline_value=bl_value.squeeze(-1)))
         return infer_dict, bl_h, bl_c
 
 

--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -194,8 +194,11 @@ def main(**kwargs):
         z, x = air.prior(5, z_pres_prior_p=partial(z_pres_prior_p, 0))
         vis.images(draw_many(x, tensor_to_objs(latents_to_tensor(z))))
 
+    def isBaselineParam(module_name, param_name):
+        return 'bl_' in module_name or 'bl_' in param_name
+
     def per_param_optim_args(module_name, param_name):
-        lr = args.baseline_learning_rate if 'bl_' in param_name else args.learning_rate
+        lr = args.baseline_learning_rate if isBaselineParam(module_name, param_name) else args.learning_rate
         return {'lr': lr}
 
     adam = optim.Adam(per_param_optim_args)


### PR DESCRIPTION
This PR includes the fix already mentioned in #1374 as well as a fix for what appears to be a second regression in the AIR example. I've run inference a few times and am now regularly seeing a count accuracy of ~90% after ~6K steps,  suggesting that the problem reported in #1374 is fixed. (That issue reported count accuracy never getting above 80%.)