### PR TITLE
Add device keyword for iarange and irange

### DIFF
--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -163,7 +163,7 @@ class AIR(nn.Module):
 
     def model(self, data, batch_size, **kwargs):
         pyro.module("decode", self.decode)
-        with pyro.iarange('data', data.size(0), use_cuda=self.use_cuda) as ix:
+        with pyro.iarange('data', data.size(0), device=data.device) as ix:
             batch = data[ix]
             n = batch.size(0)
             (z_where, z_pres), x = self.prior(n, **kwargs)
@@ -189,7 +189,7 @@ class AIR(nn.Module):
         pyro.param('bl_h_init', self.bl_h_init)
         pyro.param('bl_c_init', self.bl_c_init)
 
-        with pyro.iarange('data', data.size(0), subsample_size=batch_size, use_cuda=self.use_cuda) as ix:
+        with pyro.iarange('data', data.size(0), subsample_size=batch_size, device=data.device) as ix:
             batch = data[ix]
             n = batch.size(0)
 

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -200,9 +200,8 @@ class iarange(object):
         right. If not specified, ``dim`` is set to the rightmost dim that is
         left of all enclosing ``iarange`` contexts.
     :param bool use_cuda: Optional bool specifying whether to use cuda tensors
-        for `subsample` and `log_prob`. Defaults to `torch.Tensor.is_cuda`.
-        .. note:: This will be deprecated in `version=0.3`. Please use the
-        ``device`` arg instead.
+        for `subsample` and `log_prob`. Defaults to ``torch.Tensor.is_cuda``.
+        **Note:** Deprecated in 0.2.2. Use the `device` arg instead.
     :param str device: Optional keyword specifying which device to place
         the results of `subsample` and `log_prob` on. By default, results
         are placed on the same device as the default tensor.
@@ -284,9 +283,8 @@ class irange(object):
         ``len(subsample)``.
     :type subsample: Anything supporting ``len()``.
     :param bool use_cuda: Optional bool specifying whether to use cuda tensors
-        for `subsample` and `log_prob`. Defaults to `torch.Tensor.is_cuda`.
-        .. note:: This will be deprecated in `version=0.3`. Please use the
-        ``device`` arg instead.
+        for `subsample` and `log_prob`. Defaults to ``torch.Tensor.is_cuda``.
+        **Note:** Deprecated in 0.2.2. Use the `device` arg instead.
     :param str device: Optional keyword specifying which device to place
         the results of `subsample` and `log_prob` on. By default, results
         are placed on the same device as the default tensor.

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -119,9 +119,10 @@ class _Subsample(Distribution):
         if subsample_size is None or subsample_size > self.size:
             subsample_size = self.size
         if subsample_size >= self.size:
-            result = torch.arange(int(self.size)).to(self.device)
+            result = torch.arange(self.size, dtype=torch.long).to(self.device)
         else:
-            result = torch.multinomial(torch.ones(self.size), self.subsample_size, replacement=False).to(self.device)
+            result = torch.multinomial(torch.ones(self.size), self.subsample_size,
+                                       replacement=False).to(self.device)
         return result.cuda() if self.use_cuda else result
 
     def log_prob(self, x):

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -92,15 +92,21 @@ class _Subsample(Distribution):
     Internal use only. This should only be used by `iarange`.
     """
 
-    def __init__(self, size, subsample_size, use_cuda=None):
+    def __init__(self, size, subsample_size, use_cuda=None, device=None):
         """
         :param int size: the size of the range to subsample from
         :param int subsample_size: the size of the returned subsample
         :param bool use_cuda: whether to use cuda tensors
+        :param str device: device to place the `sample` and `log_prob`
+            results on.
         """
         self.size = size
         self.subsample_size = subsample_size
-        self.use_cuda = torch.Tensor().is_cuda if use_cuda is None else use_cuda
+        self.use_cuda = use_cuda
+        if self.use_cuda and device == "cpu":
+            raise ValueError("Incompatible arg values use_cuda={}, device={}."
+                             .format(use_cuda, device))
+        self.device = torch.Tensor().device if not device else device
 
     def sample(self, sample_shape=torch.Size()):
         """
@@ -112,21 +118,20 @@ class _Subsample(Distribution):
         subsample_size = self.subsample_size
         if subsample_size is None or subsample_size > self.size:
             subsample_size = self.size
-        if subsample_size == self.size:
-            result = torch.LongTensor(list(range(self.size)))
+        if subsample_size >= self.size:
+            result = torch.arange(int(self.size)).to(self.device)
         else:
-            # torch.randperm does not have a CUDA implementation
-            result = torch.randperm(self.size, device=torch.device('cpu'))[:self.subsample_size]
+            result = torch.multinomial(torch.ones(self.size), self.subsample_size, replacement=False).to(self.device)
         return result.cuda() if self.use_cuda else result
 
     def log_prob(self, x):
         # This is zero so that iarange can provide an unbiased estimate of
         # the non-subsampled log_prob.
-        result = torch.zeros(1)
+        result = torch.tensor(0., device=self.device)
         return result.cuda() if self.use_cuda else result
 
 
-def _subsample(name, size=None, subsample_size=None, subsample=None, use_cuda=None):
+def _subsample(name, size=None, subsample_size=None, subsample=None, use_cuda=None, device=None):
     """
     Helper function for iarange and irange. See their docstrings for details.
     """
@@ -136,7 +141,7 @@ def _subsample(name, size=None, subsample_size=None, subsample=None, use_cuda=No
         size = -1  # This is PyTorch convention for "arbitrary size"
         subsample_size = -1
     elif subsample is None:
-        subsample = sample(name, _Subsample(size, subsample_size, use_cuda))
+        subsample = sample(name, _Subsample(size, subsample_size, use_cuda=use_cuda, device=device))
 
     if subsample_size is None:
         subsample_size = len(subsample)
@@ -196,6 +201,11 @@ class iarange(object):
         left of all enclosing ``iarange`` contexts.
     :param bool use_cuda: Optional bool specifying whether to use cuda tensors
         for `subsample` and `log_prob`. Defaults to `torch.Tensor.is_cuda`.
+        .. note:: This will be deprecated in `version=0.3`. Please use the
+        ``device`` arg instead.
+    :param str device: Optional keyword specifying which device to place
+        the results of `subsample` and `log_prob` on. By default, results
+        are placed on the same device as the default tensor.
     :return: A reusabe context manager yielding a single 1-dimensional
         :class:`torch.Tensor` of indices.
 
@@ -233,10 +243,11 @@ class iarange(object):
     See `SVI Part II <http://pyro.ai/examples/svi_part_ii.html>`_ for an
     extended discussion.
     """
-    def __init__(self, name, size=None, subsample_size=None, subsample=None, dim=None, use_cuda=None):
+    def __init__(self, name, size=None, subsample_size=None, subsample=None, dim=None, use_cuda=None, device=None):
         self.name = name
         self.dim = dim
-        self.size, self.subsample_size, self.subsample = _subsample(name, size, subsample_size, subsample, use_cuda)
+        self.size, self.subsample_size, self.subsample = _subsample(name, size, subsample_size, subsample,
+                                                                    use_cuda=use_cuda, device=device)
 
     def __enter__(self):
         self._wrapped = am_i_wrapped()
@@ -273,8 +284,12 @@ class irange(object):
         ``len(subsample)``.
     :type subsample: Anything supporting ``len()``.
     :param bool use_cuda: Optional bool specifying whether to use cuda tensors
-        for internal ``log_prob`` computations. Defaults to
-        ``torch.Tensor.is_cuda``.
+        for `subsample` and `log_prob`. Defaults to `torch.Tensor.is_cuda`.
+        .. note:: This will be deprecated in `version=0.3`. Please use the
+        ``device`` arg instead.
+    :param str device: Optional keyword specifying which device to place
+        the results of `subsample` and `log_prob` on. By default, results
+        are placed on the same device as the default tensor.
     :return: A reusable iterator yielding a sequence of integers.
 
     Examples:
@@ -292,9 +307,10 @@ class irange(object):
 
     See `SVI Part II <http://pyro.ai/examples/svi_part_ii.html>`_ for an extended discussion.
     """
-    def __init__(self, name, size, subsample_size=None, subsample=None, use_cuda=None):
+    def __init__(self, name, size, subsample_size=None, subsample=None, use_cuda=None, device=None):
         self.name = name
-        self.size, self.subsample_size, self.subsample = _subsample(name, size, subsample_size, subsample, use_cuda)
+        self.size, self.subsample_size, self.subsample = _subsample(name, size, subsample_size, subsample,
+                                                                    use_cuda=use_cuda, device=device)
 
     def __iter__(self):
         if not am_i_wrapped():

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -96,7 +96,8 @@ class _Subsample(Distribution):
         """
         :param int size: the size of the range to subsample from
         :param int subsample_size: the size of the returned subsample
-        :param bool use_cuda: whether to use cuda tensors
+        :param bool use_cuda: DEPRECATED, use the `device` arg instead.
+            Whether to use cuda tensors.
         :param str device: device to place the `sample` and `log_prob`
             results on.
         """
@@ -201,9 +202,9 @@ class iarange(object):
         If specified, ``dim`` should be negative, i.e. should index from the
         right. If not specified, ``dim`` is set to the rightmost dim that is
         left of all enclosing ``iarange`` contexts.
-    :param bool use_cuda: Optional bool specifying whether to use cuda tensors
-        for `subsample` and `log_prob`. Defaults to ``torch.Tensor.is_cuda``.
-        **Note:** Deprecated in 0.2.2. Use the `device` arg instead.
+    :param bool use_cuda: DEPRECATED, use the `device` arg instead.
+        Optional bool specifying whether to use cuda tensors for `subsample`
+        and `log_prob`. Defaults to ``torch.Tensor.is_cuda``.
     :param str device: Optional keyword specifying which device to place
         the results of `subsample` and `log_prob` on. By default, results
         are placed on the same device as the default tensor.
@@ -284,9 +285,9 @@ class irange(object):
         schemes. If specified, then ``subsample_size`` will be set to
         ``len(subsample)``.
     :type subsample: Anything supporting ``len()``.
-    :param bool use_cuda: Optional bool specifying whether to use cuda tensors
-        for `subsample` and `log_prob`. Defaults to ``torch.Tensor.is_cuda``.
-        **Note:** Deprecated in 0.2.2. Use the `device` arg instead.
+    :param bool use_cuda: DEPRECATED, use the `device` arg instead.
+        Optional bool specifying whether to use cuda tensors for `subsample`
+        and `log_prob`. Defaults to ``torch.Tensor.is_cuda``.
     :param str device: Optional keyword specifying which device to place
         the results of `subsample` and `log_prob` on. By default, results
         are placed on the same device as the default tensor.

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -103,9 +103,10 @@ class _Subsample(Distribution):
         self.size = size
         self.subsample_size = subsample_size
         self.use_cuda = use_cuda
-        if self.use_cuda and device == "cpu":
-            raise ValueError("Incompatible arg values use_cuda={}, device={}."
-                             .format(use_cuda, device))
+        if self.use_cuda is not None:
+            if self.use_cuda ^ (device != "cpu"):
+                raise ValueError("Incompatible arg values use_cuda={}, device={}."
+                                 .format(use_cuda, device))
         self.device = torch.Tensor().device if not device else device
 
     def sample(self, sample_shape=torch.Size()):

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -120,14 +120,14 @@ def test_custom_subsample(model):
 def iarange_cuda_model(subsample_size):
     loc = torch.zeros(20).cuda()
     scale = torch.ones(20).cuda()
-    with pyro.iarange("data", 20, subsample_size, use_cuda=True) as batch:
+    with pyro.iarange("data", 20, subsample_size, device=loc.device) as batch:
         pyro.sample("x", dist.Normal(loc[batch], scale[batch]))
 
 
 def irange_cuda_model(subsample_size):
     loc = torch.zeros(20).cuda()
     scale = torch.ones(20).cuda()
-    for i in pyro.irange("data", 20, subsample_size, use_cuda=True):
+    for i in pyro.irange("data", 20, subsample_size, device=loc.device):
         pyro.sample("x_{}".format(i), dist.Normal(loc[i], scale[i]))
 
 


### PR DESCRIPTION
Addresses #1393. The deprecated `use_cuda` arg will be removed in the next major release.