### PR TITLE
Use contract_to_tensor in HMC for discrete site enumeration

### DIFF
--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -62,7 +62,10 @@ def _torch_linspace(*args, **kwargs):
 def _einsum(equation, operands):
     # work around torch.einsum performance issues
     # see https://github.com/pytorch/pytorch/issues/10661
-    if equation == 'ac,abc->cb':
+    if equation == 'ac,abc->bc':
+        x, y = operands
+        return (x.unsqueeze(1) * y).sum(0)
+    elif equation == 'ac,abc->cb':
         x, y = operands
         return (x.unsqueeze(1) * y).sum(0).transpose(0, 1)
     elif equation == 'abc,ac->cb':

--- a/pyro/infer/contract.py
+++ b/pyro/infer/contract.py
@@ -126,6 +126,8 @@ def _contract_component(tensor_tree, sum_dims, target_ordinal=None):
     for t, terms in tensor_tree.items():
         dims_tree[t] = set.union(set(), *(sum_dims[term] for term in terms))
 
+    enum_boundary = max(set.union(*sum_dims.values(), {float("-inf")}))
+
     # Recursively combine terms in different iarange contexts.
     while len(tensor_tree) > 1 or any(dims_tree.values()):
         leaf = max(tensor_tree, key=lambda t: len(t ^ target_ordinal))
@@ -153,7 +155,7 @@ def _contract_component(tensor_tree, sum_dims, target_ordinal=None):
                 for dim in dims:
                     shape[dim] = 1
                 shape.reverse()
-                while shape and shape[-1] == 1:
+                while shape and len(shape) >= -enum_boundary and shape[-1] == 1:
                     shape.pop()
                 shape.reverse()
                 shape = tuple(shape)

--- a/pyro/infer/contract.py
+++ b/pyro/infer/contract.py
@@ -126,7 +126,7 @@ def _contract_component(tensor_tree, sum_dims, target_ordinal=None):
     for t, terms in tensor_tree.items():
         dims_tree[t] = set.union(set(), *(sum_dims[term] for term in terms))
 
-    enum_boundary = max(set.union(*sum_dims.values(), {float("-inf")}))
+    enum_boundary = max(set.union({float("-inf")}, *sum_dims.values()))
 
     # Recursively combine terms in different iarange contexts.
     while len(tensor_tree) > 1 or any(dims_tree.values()):

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -11,7 +11,7 @@ import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.infer import config_enumerate
 from pyro.infer.mcmc.trace_kernel import TraceKernel
-from pyro.infer.mcmc.util import EnumTraceProbEvaluator
+from pyro.infer.mcmc.util import TraceEinsumEvaluator, TraceTreeEvaluator
 from pyro.ops.dual_averaging import DualAveraging
 from pyro.ops.integrator import single_step_velocity_verlet, velocity_verlet
 from pyro.primitives import _Subsample
@@ -203,10 +203,10 @@ class HMC(TraceKernel):
         self.num_steps = max(1, int(self.trajectory_length / self.step_size))
 
     def _validate_trace(self, trace):
-        self._trace_prob_evaluator = EnumTraceProbEvaluator(trace,
-                                                            self._has_enumerable_sites,
-                                                            self.max_iarange_nesting,
-                                                            use_einsum=self.use_einsum)
+        trace_eval = TraceTreeEvaluator if self.use_einsum else TraceEinsumEvaluator
+        self._trace_prob_evaluator = trace_eval(trace,
+                                                self._has_enumerable_sites,
+                                                self.max_iarange_nesting)
         trace_log_prob_sum = self._compute_trace_log_prob(trace)
         if torch_isnan(trace_log_prob_sum) or torch_isinf(trace_log_prob_sum):
             raise ValueError("Model specification incorrect - trace log pdf is NaN or Inf.")

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -203,7 +203,7 @@ class HMC(TraceKernel):
         self.num_steps = max(1, int(self.trajectory_length / self.step_size))
 
     def _validate_trace(self, trace):
-        trace_eval = TraceTreeEvaluator if self.use_einsum else TraceEinsumEvaluator
+        trace_eval = TraceEinsumEvaluator if self.use_einsum else TraceTreeEvaluator
         self._trace_prob_evaluator = trace_eval(trace,
                                                 self._has_enumerable_sites,
                                                 self.max_iarange_nesting)

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -209,4 +209,4 @@ class TraceEinsumEvaluator(object):
             log_probs = self._get_log_factors(model_trace)
             sum_dims = {site["log_prob"]: self._enum_dims[name] for name, site in model_trace.nodes.items()
                         if site["type"] == "sample" and not isinstance(site["fn"], _Subsample)}
-            return contract_to_tensor(log_probs, sum_dims, frozenset()).sum()
+            return contract_to_tensor(log_probs, sum_dims, frozenset())

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -1,18 +1,21 @@
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 
 import torch
 from opt_einsum import shared_intermediates
 
 from pyro.distributions.util import logsumexp, broadcast_shape
+from pyro.infer.contract import contract_tensor_tree
 from pyro.infer.util import is_validation_enabled
 from pyro.ops.sumproduct import sumproduct, logsumproductexp
 from pyro.util import check_site_shape
 
 
-class EnumTraceProbEvaluator(object):
+class TraceTreeEvaluator(object):
     """
-    Computes the log probability density of a trace that possibly contains
-    discrete sample sites enumerated in parallel.
+    Computes the log probability density of a trace (of a model with
+    tree structure) that possibly contains discrete sample sites
+    enumerated in parallel. This will be deprecated in favor of
+    :class:`~pyro.infer.mcmc.util.EinsumTraceProbEvaluator`.
 
     :param model_trace: execution trace from a static model.
     :param bool has_enumerable_sites: whether the trace contains any
@@ -23,11 +26,9 @@ class EnumTraceProbEvaluator(object):
     def __init__(self,
                  model_trace,
                  has_enumerable_sites=False,
-                 max_iarange_nesting=float("inf"),
-                 use_einsum=True):
+                 max_iarange_nesting=float("inf")):
         self.has_enumerable_sites = has_enumerable_sites
         self.max_iarange_nesting = max_iarange_nesting
-        self.use_einsum = use_einsum
         # To be populated using the model trace once.
         self._log_probs = defaultdict(list)
         self._log_prob_shapes = defaultdict(tuple)
@@ -103,33 +104,11 @@ class EnumTraceProbEvaluator(object):
         :return: `log_prob` with marginalized `iarange` and `enum`
             dims.
         """
-        if self.use_einsum:
-            return self._reduce_einsum(ordinal, agg_log_prob)
         log_prob = sum(self._log_probs[ordinal]) + agg_log_prob
         for enum_dim in self._enum_dims[ordinal]:
             log_prob = logsumexp(log_prob, dim=enum_dim, keepdim=True)
         for marginal_dim in self._iarange_dims[ordinal]:
             log_prob = log_prob.sum(dim=marginal_dim, keepdim=True)
-        return log_prob
-
-    def _reduce_einsum(self, ordinal, agg_log_prob=0.):
-        """
-        Same operation as `_reduce` except that the tensors are passed to
-        the einsum backend.
-
-        :param ordinal: node (ordinal)
-        :param torch.Tensor agg_log_prob: aggregated `log_prob`
-            terms from the downstream nodes.
-        :return: `log_prob` with marginalized `iarange` and `enum`
-            dims.
-        """
-        shape = broadcast_shape(self._log_prob_shapes[ordinal], agg_log_prob.shape)
-        enum_shape = [shape[i] if -len(shape) + i not in self._enum_dims[ordinal] else 1
-                      for i in range(len(shape))]
-        iarange_shape = [enum_shape[i] if -len(enum_shape) + i not in self._iarange_dims[ordinal] else 1
-                         for i in range(len(enum_shape))]
-        log_prob = logsumproductexp(self._log_probs[ordinal] + [agg_log_prob], target_shape=enum_shape)
-        log_prob = sumproduct([log_prob], target_shape=iarange_shape)
         return log_prob
 
     def _aggregate_log_probs(self, ordinal):
@@ -153,3 +132,73 @@ class EnumTraceProbEvaluator(object):
                 return model_trace.log_prob_sum()
             self._compute_log_prob_terms(model_trace)
             return self._aggregate_log_probs(ordinal=frozenset()).sum()
+
+
+class TraceEinsumEvaluator(object):
+    """
+    Computes the log probability density of a trace (of a model with
+    tree structure) that possibly contains discrete sample sites
+    enumerated in parallel. This uses optimized `einsum` operations
+    to marginalize out the the enumerated dimensions in the trace
+    via :class:`~pyro.infer.contract.contract_tensor_tree`.
+
+    :param model_trace: execution trace from a static model.
+    :param bool has_enumerable_sites: whether the trace contains any
+        discrete enumerable sites.
+    :param int max_iarange_nesting: Optional bound on max number of nested
+        :func:`pyro.iarange` contexts.
+    """
+    def __init__(self,
+                 model_trace,
+                 has_enumerable_sites=False,
+                 max_iarange_nesting=float("inf")):
+        self.has_enumerable_sites = has_enumerable_sites
+        self.max_iarange_nesting = max_iarange_nesting
+        # To be populated using the model trace once.
+        self._enum_dims = {}
+        self._populate_cache(model_trace)
+
+    def _populate_cache(self, model_trace):
+        """
+        Populate the ordinals (set of ``CondIndepStack`` frames)
+        and enum_dims for each sample site.
+        """
+        model_trace.compute_log_prob()
+        self.ordering = {name: frozenset(site["cond_indep_stack"])
+                         for name, site in model_trace.nodes.items()
+                         if site["type"] == "sample"}
+        self._enum_dims = {}
+        for name, site in model_trace.nodes.items():
+            if site["type"] == "sample":
+                if is_validation_enabled():
+                    check_site_shape(site, self.max_iarange_nesting)
+                log_prob_shape = site["log_prob"].shape
+                self._enum_dims[site["name"]] = set((i for i in range(-len(log_prob_shape), -self.max_iarange_nesting)
+                                                     if log_prob_shape[i] > 1))
+
+    def _get_log_factors(self, model_trace):
+        """
+        Aggregates the `log_prob` terms into a list for each
+        ordinal.
+        """
+        model_trace.compute_log_prob()
+        log_probs = OrderedDict()
+        # Collect log prob terms per independence context.
+        for name, site in model_trace.nodes.items():
+            if site["type"] == "sample":
+                if is_validation_enabled():
+                    check_site_shape(site, self.max_iarange_nesting)
+                log_probs.setdefault(self.ordering[name], []).append(site["log_prob"])
+        return log_probs
+
+    def log_prob(self, model_trace):
+        """
+        Returns the log pdf of `model_trace` by appropriately handling
+        enumerated log prob factors.
+
+        :return: log pdf of the trace.
+        """
+        log_probs = self._get_log_factors(model_trace)
+        sum_dims = {site["log_prob"]: self._enum_dims[name] for name, site in model_trace.nodes.items()
+                    if site["type"] == "sample"}
+        return sum(contract_tensor_tree(log_probs, sum_dims)[frozenset()])

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -229,6 +229,7 @@ def test_bernoulli_latent_model():
 @pytest.mark.parametrize("num_steps,use_einsum", [
     (2, False),
     (3, False),
+    (3, True),
     # This will crash without the einsum backend
     pytest.param(30, True,
                  marks=pytest.mark.skip(reason="https://github.com/pytorch/pytorch/issues/10661")),

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -129,24 +129,25 @@ def test_log_prob_eval_iterates_in_correct_order():
 def test_all_discrete_sites_log_prob(Eval):
     p = 0.3
 
-    @poutine.enum(first_available_dim=2)
+    @poutine.enum(first_available_dim=3)
     @config_enumerate(default="parallel")
     @poutine.broadcast
     def model():
         d = dist.Bernoulli(p)
         context1 = pyro.iarange("outer", 2, dim=-1)
-        context2 = pyro.iarange("inner", 1, dim=-2)
+        context2 = pyro.iarange("inner1", 1, dim=-2)
+        context3 = pyro.iarange("inner2", 1, dim=-3)
         pyro.sample("w", d)
         with context1:
             pyro.sample("x", d)
-        with context2:
-            pyro.sample("y", d)
         with context1, context2:
+            pyro.sample("y", d)
+        with context1, context3:
             pyro.sample("z", d)
 
     model_trace = poutine.trace(model).get_trace()
     print_debug_info(model_trace)
-    trace_prob_evaluator = Eval(model_trace, True, 2)
+    trace_prob_evaluator = Eval(model_trace, True, 3)
     # all discrete sites enumerated out.
     assert_equal(trace_prob_evaluator.log_prob(model_trace), torch.tensor(0.))
 

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -8,9 +8,9 @@ import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.infer import config_enumerate
 from pyro.infer.mcmc import HMC, MCMC, NUTS
-from pyro.infer.mcmc.util import EnumTraceProbEvaluator
+from pyro.infer.mcmc.util import TraceTreeEvaluator, TraceEinsumEvaluator
 from pyro.primitives import _Subsample
-from tests.common import assert_equal
+from tests.common import assert_equal, xfail_param
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,8 @@ def print_debug_info(model_trace):
     (HMC, {"adapt_step_size": True, "num_steps": 3}),
     (NUTS, {"adapt_step_size": True}),
 ])
-def test_model_error_stray_batch_dims(kernel, kwargs):
+@pytest.mark.parametrize("use_einsum", [False, True])
+def test_model_error_stray_batch_dims(kernel, kwargs, use_einsum):
 
     @poutine.broadcast
     def gmm():
@@ -53,11 +54,11 @@ def test_model_error_stray_batch_dims(kernel, kwargs):
             pyro.sample("obs", dist.Normal(cluster_means[assignments], 1.), obs=data)
         return cluster_means
 
-    mcmc_kernel = kernel(gmm, **kwargs)
+    mcmc_kernel = kernel(gmm, experimental_use_einsum=use_einsum, **kwargs)
     # Error due to non finite value for `max_iarange_nesting`.
     assert_error(mcmc_kernel)
     # Error due to batch dims not inside iarange.
-    mcmc_kernel = kernel(gmm, max_iarange_nesting=1, **kwargs)
+    mcmc_kernel = kernel(gmm, max_iarange_nesting=1, experimental_use_einsum=use_einsum, **kwargs)
     assert_error(mcmc_kernel)
 
 
@@ -65,7 +66,8 @@ def test_model_error_stray_batch_dims(kernel, kwargs):
     (HMC, {"adapt_step_size": True, "num_steps": 3}),
     (NUTS, {"adapt_step_size": True}),
 ])
-def test_model_error_enum_dim_clash(kernel, kwargs):
+@pytest.mark.parametrize("use_einsum", [False, True])
+def test_model_error_enum_dim_clash(kernel, kwargs, use_einsum):
 
     @poutine.broadcast
     def gmm():
@@ -78,7 +80,8 @@ def test_model_error_enum_dim_clash(kernel, kwargs):
             pyro.sample("obs", dist.Normal(cluster_means[assignments], 1.), obs=data)
         return cluster_means
 
-    mcmc_kernel = kernel(gmm, max_iarange_nesting=0, **kwargs)
+    mcmc_kernel = kernel(gmm, max_iarange_nesting=0,
+                         experimental_use_einsum=use_einsum, **kwargs)
     assert_error(mcmc_kernel)
 
 
@@ -110,7 +113,7 @@ def test_log_prob_eval_iterates_in_correct_order():
                 pyro.sample("obs2", dist.Normal(2 * z2 - 1, 1.), obs=torch.ones(5, 3))
 
     model_trace = poutine.trace(model).get_trace()
-    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 4)
+    trace_prob_evaluator = TraceTreeEvaluator(model_trace, True, 4)
     trace_prob_evaluator.log_prob(model_trace)
     iarange_dims, enum_dims = [], []
     for key in reversed(sorted(trace_prob_evaluator._log_probs.keys(), key=lambda x: (len(x), x))):
@@ -122,7 +125,8 @@ def test_log_prob_eval_iterates_in_correct_order():
     assert enum_dims, [[-8], [-9, -6], [-7], [-5]]
 
 
-def test_all_discrete_sites_log_prob():
+@pytest.mark.parametrize("Eval", [TraceTreeEvaluator, TraceEinsumEvaluator])
+def test_all_discrete_sites_log_prob(Eval):
     p = 0.3
 
     @poutine.enum(first_available_dim=2)
@@ -142,12 +146,14 @@ def test_all_discrete_sites_log_prob():
 
     model_trace = poutine.trace(model).get_trace()
     print_debug_info(model_trace)
-    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 2)
+    trace_prob_evaluator = Eval(model_trace, True, 2)
     # all discrete sites enumerated out.
     assert_equal(trace_prob_evaluator.log_prob(model_trace), torch.tensor(0.))
 
 
-def test_enumeration_in_tree():
+@pytest.mark.parametrize("Eval", [TraceTreeEvaluator,
+                                  xfail_param(TraceEinsumEvaluator, reason="TODO: Debug this failure case.")])
+def test_enumeration_in_tree(Eval):
     @poutine.enum(first_available_dim=4)
     @config_enumerate(default="parallel")
     @poutine.condition(data={"sample1": torch.tensor(0.),
@@ -177,14 +183,14 @@ def test_enumeration_in_tree():
 
     model_trace = poutine.trace(model).get_trace()
     print_debug_info(model_trace)
-    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 4)
+    trace_prob_evaluator = Eval(model_trace, True, 4)
     # p_n(0.) * p_n(2.)^2 * p_n(1.)^6
     assert_equal(trace_prob_evaluator.log_prob(model_trace), torch.tensor(-15.2704), prec=1e-4)
 
 
-@pytest.mark.xfail(reason="Enumeration currently does not work for general DAGs "
-                          "(indep contexts with multiple parents)")
-def test_enumeration_in_dag():
+@pytest.mark.xfail(reason="Enumeration currently does not work for general DAGs")
+@pytest.mark.parametrize("Eval", [TraceTreeEvaluator, TraceEinsumEvaluator])
+def test_enumeration_in_dag(Eval):
     p = 0.3
 
     @poutine.enum(first_available_dim=2)
@@ -207,7 +213,7 @@ def test_enumeration_in_dag():
 
     model_trace = poutine.trace(model).get_trace()
     print_debug_info(model_trace)
-    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 2)
+    trace_prob_evaluator = Eval(model_trace, True, 2)
     assert_equal(trace_prob_evaluator.log_prob(model_trace), torch.tensor(0.16196))  # p_beta(0.3)^3
 
 
@@ -216,7 +222,8 @@ def test_enumeration_in_dag():
     (torch.tensor([0.]), torch.tensor(-1.4189)),
     (torch.tensor([1., 0., 0.]), torch.tensor(-4.1813)),
 ])
-def test_enum_log_prob_continuous_observed(data, expected_log_prob):
+@pytest.mark.parametrize("Eval", [TraceTreeEvaluator, TraceEinsumEvaluator])
+def test_enum_log_prob_continuous_observed(data, expected_log_prob, Eval):
 
     @poutine.enum(first_available_dim=1)
     @config_enumerate(default="parallel")
@@ -233,7 +240,7 @@ def test_enum_log_prob_continuous_observed(data, expected_log_prob):
 
     model_trace = poutine.trace(model).get_trace(data)
     print_debug_info(model_trace)
-    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 1)
+    trace_prob_evaluator = Eval(model_trace, True, 1)
     assert_equal(trace_prob_evaluator.log_prob(model_trace),
                  expected_log_prob,
                  prec=1e-3)
@@ -245,7 +252,8 @@ def test_enum_log_prob_continuous_observed(data, expected_log_prob):
     (torch.tensor([1., 1.]), torch.tensor(-3.9699)),
     (torch.tensor([1., 0., 0.]), torch.tensor(-5.3357)),
 ])
-def test_enum_log_prob_continuous_sampled(data, expected_log_prob):
+@pytest.mark.parametrize("Eval", [TraceTreeEvaluator, TraceEinsumEvaluator])
+def test_enum_log_prob_continuous_sampled(data, expected_log_prob, Eval):
 
     @poutine.enum(first_available_dim=1)
     @config_enumerate(default="parallel")
@@ -262,7 +270,7 @@ def test_enum_log_prob_continuous_sampled(data, expected_log_prob):
 
     model_trace = poutine.trace(model).get_trace(data)
     print_debug_info(model_trace)
-    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 1)
+    trace_prob_evaluator = Eval(model_trace, True, 1)
     assert_equal(trace_prob_evaluator.log_prob(model_trace),
                  expected_log_prob,
                  prec=1e-3)
@@ -273,7 +281,8 @@ def test_enum_log_prob_continuous_sampled(data, expected_log_prob):
     (torch.tensor([1., 1.]), torch.tensor(-0.9808)),
     (torch.tensor([1., 0., 0.]), torch.tensor(-2.3671)),
 ])
-def test_enum_log_prob_discrete_observed(data, expected_log_prob):
+@pytest.mark.parametrize("Eval", [TraceTreeEvaluator, TraceEinsumEvaluator])
+def test_enum_log_prob_discrete_observed(data, expected_log_prob, Eval):
 
     @poutine.enum(first_available_dim=1)
     @config_enumerate(default="parallel")
@@ -288,7 +297,7 @@ def test_enum_log_prob_discrete_observed(data, expected_log_prob):
 
     model_trace = poutine.trace(model).get_trace(data)
     print_debug_info(model_trace)
-    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 1)
+    trace_prob_evaluator = Eval(model_trace, True, 1)
     assert_equal(trace_prob_evaluator.log_prob(model_trace),
                  expected_log_prob,
                  prec=1e-3)
@@ -299,7 +308,8 @@ def test_enum_log_prob_discrete_observed(data, expected_log_prob):
     (torch.tensor([0.]), torch.tensor(-1.46)),
     (torch.tensor([1., 1.]), torch.tensor(-2.1998)),
 ])
-def test_enum_log_prob_multiple_iarange(data, expected_log_prob):
+@pytest.mark.parametrize("Eval", [TraceTreeEvaluator, TraceEinsumEvaluator])
+def test_enum_log_prob_multiple_iarange(data, expected_log_prob, Eval):
 
     @poutine.enum(first_available_dim=1)
     @config_enumerate(default="parallel")
@@ -317,7 +327,7 @@ def test_enum_log_prob_multiple_iarange(data, expected_log_prob):
 
     model_trace = poutine.trace(model).get_trace(data)
     print_debug_info(model_trace)
-    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 1)
+    trace_prob_evaluator = Eval(model_trace, True, 1)
     assert_equal(trace_prob_evaluator.log_prob(model_trace),
                  expected_log_prob,
                  prec=1e-3)
@@ -328,7 +338,8 @@ def test_enum_log_prob_multiple_iarange(data, expected_log_prob):
     (torch.tensor([0.]), torch.tensor(-1.4189)),
     (torch.tensor([1., 0., 0.]), torch.tensor(-4.3857)),
 ])
-def test_enum_log_prob_nested_iarange(data, expected_log_prob):
+@pytest.mark.parametrize("Eval", [TraceTreeEvaluator, TraceEinsumEvaluator])
+def test_enum_log_prob_nested_iarange(data, expected_log_prob, Eval):
 
     @poutine.enum(first_available_dim=2)
     @config_enumerate(default="parallel")
@@ -347,7 +358,7 @@ def test_enum_log_prob_nested_iarange(data, expected_log_prob):
 
     model_trace = poutine.trace(model).get_trace(data)
     print_debug_info(model_trace)
-    trace_prob_evaluator = EnumTraceProbEvaluator(model_trace, True, 2)
+    trace_prob_evaluator = Eval(model_trace, True, 2)
     assert_equal(trace_prob_evaluator.log_prob(model_trace),
                  expected_log_prob,
                  prec=1e-3)


### PR DESCRIPTION
This uses the `contract_tree` operation when `use_einsum=True` to evaluate trace log probability in HMC and NUTS. This is implemented as a separate class `TraceEinsumEvaluator` in addition to the earlier class (now renamed to `TraceTreeEvaluator`).

### Tests:
 - Since this is mostly a refactor, existing tests with `use_einsum=True` should cover this, and all pass.
 - Added the new class to `test_valid_models`, results are identical between the two classes. 