### PR TITLE
Refactor towards packed tensor representations

### DIFF
--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -1,8 +1,11 @@
 Miscellaneous Ops
 =================
 
-The ``pyro.ops`` module implements high-level utilities
+The ``pyro.ops`` module implements tensor utilities
 that are mostly independent of the rest of Pyro.
+
+Utilities for HMC
+-----------------
 
 .. automodule:: pyro.ops.dual_averaging
     :members:
@@ -16,11 +19,17 @@ that are mostly independent of the rest of Pyro.
     :show-inheritance:
     :member-order: bysource
 
+Newton Optimizers
+-----------------
+
 .. automodule:: pyro.ops.newton
     :members:
     :undoc-members:
     :show-inheritance:
     :member-order: bysource
+
+Tensor Contraction
+------------------
 
 .. automodule:: pyro.ops.einsum
     :members:

--- a/pyro/infer/contract.py
+++ b/pyro/infer/contract.py
@@ -1,11 +1,140 @@
 from __future__ import absolute_import, division, print_function
 
+from abc import ABCMeta, abstractmethod
 from collections import OrderedDict, defaultdict
 
 import torch
+from opt_einsum import shared_intermediates
+from six import add_metaclass
 
 from pyro.distributions.util import broadcast_shape
-from pyro.ops.sumproduct import logsumproductexp, memoized_sum_keepdim
+from pyro.ops.einsum import contract
+from pyro.ops.sumproduct import logsumproductexp
+
+
+@add_metaclass(ABCMeta)
+class TensorRing(object):
+    @abstractmethod
+    def dims(self, term):
+        raise NotImplementedError
+
+    @abstractmethod
+    def sumproduct(self, terms, dims):
+        raise NotImplementedError
+
+    @abstractmethod
+    def product(self, term, ordinal):
+        raise NotImplementedError
+
+    @abstractmethod
+    def broadcast(self, tensor, ordinal):
+        raise NotImplementedError
+
+
+class UnpackedLogRing(TensorRing):
+    def __init__(self, cache=None):
+        if cache is None:
+            cache = {}
+        self._cache = cache
+
+    def dims(self, term):
+        for dim in range(-term.dim(), 0):
+            if term.shape[dim] > 1:
+                yield dim
+
+    def sumproduct(self, terms, dims):
+        if not dims:
+            return sum(terms)
+        shape = list(broadcast_shape(*set(x.shape for x in terms)))
+        for dim in dims:
+            shape[dim] = 1
+        shape.reverse()
+        while shape and shape[-1] == 1:
+            shape.pop()
+        shape.reverse()
+        shape = tuple(shape)
+        return logsumproductexp(terms, shape)
+
+    def product(self, term, ordinal):
+        for frame in sorted(ordinal, key=lambda f: -f.dim):
+            if term.shape[frame.dim] != 1:
+                key = 'product', id(term), frame.dim
+                if key in self._cache:
+                    term = self._cache[key]
+                else:
+                    term = term.sum(frame.dim, keepdim=True)
+                    self._cache[key] = term
+        return term
+
+    def broadcast(self, term, ordinal):
+        shape = list(term.shape)
+        for frame in ordinal:
+            shape = [1] * (-frame.dim - len(shape)) + shape
+            shape[frame.dim] = frame.size
+        shape = torch.Size(shape)
+        if term.shape == shape:
+            return term
+        key = 'expand', id(term), shape
+        if key in self._cache:
+            return self._cache[key]
+        term = term.expand(shape)
+        self._cache[key] = term
+        return term
+
+
+class PackedLogRing(TensorRing):
+    def __init__(self, inputs, operands, cache=None):
+        if cache is None:
+            cache = {}
+        self._batch_size = {}
+        for dims, term in zip(inputs, operands):
+            cache['tensor', id(term)] = term
+            cache['dims', id(term)] = dims
+            for dim, size in zip(dims, term.shape):
+                self._batch_size[dim] = size
+        self._cache = cache
+
+    def dims(self, term):
+        return self._cache['dims', id(term)]
+
+    def sumproduct(self, terms, dims):
+        inputs = [self.dims(term) for term in terms]
+        output = ''.join(sorted(set(sum(inputs)) - set(dims)))
+        equation = ''.join(inputs) + '->' + output
+        term = contract(equation, *terms, backend='pyro.ops.einsum.torch_log')
+        self._cache['tensor', id(term)] = term
+        self._cache['dims', id(term)] = output
+        return term
+
+    def product(self, term, ordinal):
+        dims = self.dims(term)
+        for dim in sorted(ordinal, reverse=True):
+            pos = dims.find(dim)
+            if pos != -1:
+                key = 'product', id(term), dim
+                if key in self._cache:
+                    term = self._cache[key]
+                else:
+                    term = term.sum(pos)
+                    dims = dims.replace(dim, '')
+                    self._cache[key] = term
+                    self._cache['dim', id(term)] = dims
+        return term
+
+    def broadcast(self, term, ordinal):
+        dims = self.dims(term)
+        missing_dims = ''.join(sorted(set(ordinal) - set(dims)))
+        if missing_dims:
+            key = 'broadcast', id(term), missing_dims
+            if key in self._cache:
+                term = self._cache[key]
+            else:
+                missing_shape = tuple(self._batch_size[dim] for dim in missing_dims)
+                term = term.expand(missing_shape + term.shape)
+                dims = missing_dims + dims
+                self._cache[key] = term
+                self._cache['dims', id(term)] = dims
+        return term
 
 
 def _check_tree_structure(tensor_tree):
@@ -45,8 +174,8 @@ def _check_tree_structure(tensor_tree):
                     continue
                 if u <= v or v <= u:
                     continue
-                left = ', '.join(sorted(f.name for f in u - v))
-                right = ', '.join(sorted(f.name for f in v - u))
+                left = ', '.join(sorted(getattr(f, 'name', str(f)) for f in u - v))
+                right = ', '.join(sorted(getattr(f, 'name', str(f)) for f in v - u))
                 raise ValueError("Expected tree-structured iarange nesting, but found "
                                  "dependencies on independent iarange sets [{}] and [{}]. "
                                  "Try converting one of the iaranges to an irange (but beware "
@@ -54,7 +183,7 @@ def _check_tree_structure(tensor_tree):
                                  .format(left, right))
 
 
-def _partition_terms(terms, dims):
+def _partition_terms(ring, terms, dims):
     """
     Given a list of terms and a set of contraction dims, partitions the terms
     up into sets that must be contracted together. By separating these
@@ -66,8 +195,8 @@ def _partition_terms(terms, dims):
     # are enumerated. This conflates terms and dims (tensors and ints).
     neighbors = OrderedDict([(t, []) for t in terms] + [(d, []) for d in dims])
     for term in terms:
-        for dim in range(-term.dim(), 0):
-            if dim in dims and term.shape[dim] > 1:
+        for dim in ring.dims(term):
+            if dim in dims:
                 neighbors[term].append(dim)
                 neighbors[dim].append(term)
 
@@ -90,14 +219,16 @@ def _partition_terms(terms, dims):
         yield component_terms, component_dims
 
 
-def _contract_component(tensor_tree, sum_dims, target_ordinal=None):
+def _contract_component(ring, tensor_tree, sum_dims, target_ordinal=None):
     """
     Contract out ``sum_dims`` in a tree of tensors in-place, via message
     passing. This reduces all tensors down to a single iarange context
     ``target_ordinal``, by default the minimum shared iarange context.
 
     This function should be deterministic.
+    This function has side-effects: it modifies ``tensor_tree`` in-place.
 
+    :param TensorRing ring: an algebraic ring defining tensor operations.
     :param OrderedDict tensor_tree: a dictionary mapping ordinals to lists of
         tensors. An ordinal is a frozenset of ``CondIndepStack`` frames.
     :param dict sum_dims: a dictionary mapping tensors to sets of dimensions
@@ -145,32 +276,26 @@ def _contract_component(tensor_tree, sum_dims, target_ordinal=None):
         dims_tree[parent] |= leaf_dims & remaining_dims
         tensor_tree.setdefault(parent, [])
 
-        for terms, dims in _partition_terms(leaf_terms, contract_dims):
+        # Split the current node into connected components.
+        for terms, dims in _partition_terms(ring, leaf_terms, contract_dims):
 
-            # Eliminate any enumeration dims via a logsumproductexp() contraction.
+            # Eliminate any enumeration dims via a sumproduct contraction.
             if dims:
-                shape = list(broadcast_shape(*set(x.shape for x in terms)))
-                for dim in dims:
-                    shape[dim] = 1
-                shape.reverse()
-                while shape and shape[-1] == 1:
-                    shape.pop()
-                shape.reverse()
-                shape = tuple(shape)
-                terms = [logsumproductexp(terms, shape)]
+                terms = [ring.sumproduct(terms, dims)]
 
             for term in terms:
-                # Eliminate extra iarange dims via .sum() contractions.
-                for frame in sorted(contract_frames, key=lambda f: -f.dim):
-                    term = memoized_sum_keepdim(term, frame.dim)
-
+                if contract_frames:
+                    # Eliminate extra iarange dims via product contractions.
+                    term = ring.product(term, contract_frames)
+                elif broadcast_frames:
+                    # Broadcast to any missing iaranges via .expand().
+                    term = ring.broadcast(term, broadcast_frames)
                 tensor_tree[parent].append(term)
 
 
-def contract_tensor_tree(tensor_tree, sum_dims):
+def contract_tensor_tree(tensor_tree, sum_dims, ring=None, cache=None):
     """
-    Contract out ``sum_dims`` in a tree of tensors in-place, via
-    message passing.
+    Contract out ``sum_dims`` in a tree of tensors via message passing.
 
     This function should be deterministic and free of side effects.
 
@@ -178,11 +303,17 @@ def contract_tensor_tree(tensor_tree, sum_dims):
         tensors. An ordinal is a frozenset of ``CondIndepStack`` frames.
     :param dict sum_dims: a dictionary mapping tensors to sets of dimensions
         (indexed from the right) that should be summed out.
-    :returns: A contracted version of ``tensor_tree`
+    :param TensorRing ring: an algebraic ring defining tensor operations.
+    :param dict cache: an optional :func:`~opt_einsum.shared_intermediates`
+        cache.
+    :returns: A contracted version of ``tensor_tree``
     :rtype: OrderedDict
     """
+    if ring is None:
+        ring = UnpackedLogRing(cache=cache)
     assert isinstance(tensor_tree, OrderedDict)
     assert isinstance(sum_dims, dict)
+    assert isinstance(ring, TensorRing)
 
     ordinals = {term: t for t, terms in tensor_tree.items() for term in terms}
     all_terms = [term for terms in tensor_tree.values() for term in terms]
@@ -190,13 +321,13 @@ def contract_tensor_tree(tensor_tree, sum_dims):
     contracted_tree = OrderedDict()
 
     # Split this tensor tree into connected components.
-    for terms, dims in _partition_terms(all_terms, all_dims):
+    for terms, dims in _partition_terms(ring, all_terms, all_dims):
         component = OrderedDict()
         for term in terms:
             component.setdefault(ordinals[term], []).append(term)
 
         # Contract this connected component down to a single tensor.
-        _contract_component(component, sum_dims)
+        _contract_component(ring, component, sum_dims)
         assert len(component) == 1
         assert len(next(iter(component.values()))) == 1
         for t, terms in component.items():
@@ -205,7 +336,7 @@ def contract_tensor_tree(tensor_tree, sum_dims):
     return contracted_tree
 
 
-def contract_to_tensor(tensor_tree, sum_dims, target_ordinal):
+def contract_to_tensor(tensor_tree, sum_dims, target_ordinal, ring=None, cache=None):
     """
     Contract out ``sum_dims`` in a tree of tensors, via message
     passing. This reduces all terms down to a single tensor in the iarange
@@ -219,26 +350,73 @@ def contract_to_tensor(tensor_tree, sum_dims, target_ordinal):
         (indexed from the right) that should be summed out.
     :param frozendset target_ordinal: An optional ordinal to which results will
         be contracted or broadcasted.
+    :param TensorRing ring: an algebraic ring defining tensor operations.
+    :param dict cache: an optional :func:`~opt_einsum.shared_intermediates`
+        cache.
     :returns: a single tensor
     :rtype: torch.Tensor
     """
+    if ring is None:
+        ring = UnpackedLogRing(cache=cache)
     assert isinstance(tensor_tree, OrderedDict)
     assert isinstance(sum_dims, dict)
     assert isinstance(target_ordinal, frozenset)
+    assert isinstance(ring, TensorRing)
 
     contracted_tree = OrderedDict((t, terms[:]) for t, terms in tensor_tree.items())
-    _contract_component(contracted_tree, sum_dims, target_ordinal)
+    _contract_component(ring, contracted_tree, sum_dims, target_ordinal)
     t, terms = contracted_tree.popitem()
     assert t == target_ordinal
-    term = sum(terms)
+    return ring.sumproduct(terms, {})
 
-    # Broadcast to any missing iaranges via .expand().
-    shape = list(term.shape)
-    for frame in target_ordinal:
-        shape = [1] * (-frame.dim - len(shape)) + shape
-        shape[frame.dim] = frame.size
-    shape = torch.Size(shape)
-    if term.shape != shape:
-        term = term.expand(shape)
 
-    return term
+def ubersum(equation, *operands, **kwargs):
+    """
+    Generalized batched einsum via tensor message passing.
+
+    :param str equation: an einsum equation, optionally with multuple outputs.
+    :param torch.Tensor operands: a collection of tensors
+    :param str batch_dims: a string of batch dims.
+    :param dict cache: an optional :func:`~opt_einsum.shared_intermediates`
+        cache.
+    :return: a tuple of tensors of requested shape.
+    :rtype: tuple
+    """
+    # Extract kwargs.
+    cache = kwargs.pop('cache', None)
+    batch_dims = kwargs.pop('batch_dims', '')
+    backend = kwargs.pop('backend', 'pyro.ops.einsum.torch_log')
+    if backend != 'pyro.ops.einsum.torch_log':
+        raise NotImplementedError
+
+    # Parse generalized einsum equation.
+    if '.' in equation:
+        raise NotImplementedError('ubsersum does not yet support ellipsis notation')
+    inputs, outputs = equation.split('->')
+    inputs = inputs.split(',')
+    outputs = outputs.split(',')
+    assert len(inputs) == len(outputs)
+    assert all(isinstance(x, torch.Tensor) for x in operands)
+
+    # Construct a tensor tree shared by all outputs.
+    tensor_tree = OrderedDict()
+    max_ordinal = frozenset(batch_dims)
+    for dims, term in zip(inputs, operands):
+        assert len(dims) == term.dim()
+        ordinal = frozenset(dims) & max_ordinal
+        tensor_tree.setdefault(ordinal, []).append(term)
+
+    # Compute outputs, sharing intermediate computations.
+    results = []
+    with shared_intermediates(cache) as cache:
+        ring = PackedLogRing(inputs, operands, cache=cache)
+        for output in outputs:
+            nosum_dims = set(batch_dims + output)
+            sum_dims = {term: set(dims) - nosum_dims for dims, term in zip(inputs, operands)}
+            target_ordinal = frozenset(output) & max_ordinal
+            term = contract_to_tensor(tensor_tree, sum_dims, target_ordinal, ring=ring)
+            dims = ring.dims(term)
+            if dims != output:
+                term = term.permute(*map(dims.index, output))
+            results.append(term)
+    return tuple(results)

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -140,7 +140,7 @@ def _compute_marginals(model_trace, guide_trace):
     marginal_costs, log_factors, ordering, sum_dims, scale = args
 
     marginal_dists = OrderedDict()
-    with shared_intermediates():
+    with shared_intermediates() as cache:
         for name, site in model_trace.nodes.items():
             if (site["type"] != "sample" or
                     name in guide_trace.nodes or
@@ -150,7 +150,7 @@ def _compute_marginals(model_trace, guide_trace):
             enum_dim = site["fn"].event_dim - site["value"].dim()
             site_sum_dims = {term: dims - {enum_dim} for term, dims in sum_dims.items()}
             ordinal = frozenset(f for f in site["cond_indep_stack"] if f.vectorized)
-            logits = contract_to_tensor(log_factors, site_sum_dims, ordinal)
+            logits = contract_to_tensor(log_factors, site_sum_dims, ordinal, cache=cache)
             logits = logits.unsqueeze(-1).transpose(-1, enum_dim - 1)
             while logits.shape[0] == 1:
                 logits.squeeze_(0)
@@ -187,9 +187,9 @@ class BackwardSampleMessenger(pyro.poutine.messenger.Messenger):
             assert enum_dim < 0, "{} {}".format(msg["name"], enum_dim)
             for value in self.sum_dims.values():
                 value.discard(enum_dim)
-            with shared_intermediates(self.cache):
+            with shared_intermediates(self.cache) as cache:
                 ordinal = frozenset(f for f in msg["cond_indep_stack"] if f.vectorized)
-                logits = contract_to_tensor(self.log_factors, self.sum_dims, ordinal)
+                logits = contract_to_tensor(self.log_factors, self.sum_dims, ordinal, cache=cache)
                 logits = logits.unsqueeze(-1).transpose(-1, enum_dim - 1)
                 while logits.shape[0] == 1:
                     logits.squeeze_(0)

--- a/pyro/ops/einsum/__init__.py
+++ b/pyro/ops/einsum/__init__.py
@@ -11,8 +11,7 @@ _PATH_CACHE = {}
 
 def contract(equation, *operands, **kwargs):
     """
-    Like :func:`opt_einsum.contract` but works with
-    :func:`~opt_einsum.shared_intermediates` contexts.
+    Wrpper around :func:`opt_einsum.contract` that caches contraction paths.
 
     :param bool cache_path: whether to cache the contraction path.
         Defaults to True.

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -28,22 +28,6 @@ def memoized_squeeze(tensor):
     return result
 
 
-def memoized_sum_keepdim(tensor, dim):
-    """
-    Computes ``tensor.sum(dim, keepdim=True)`` memoizing the result for the
-    lifetime of ``tensor``. This enables sharing when used inside
-    :func:`~opt_einsum.shared_intermediates`.
-    """
-    if dim < 0:
-        dim += tensor.dim()
-    name = '_pyro_memoized_sum_keepdim_{}'.format(dim)
-    if hasattr(tensor, name):
-        return getattr(tensor, name)
-    result = tensor.sum(dim, keepdim=True)
-    setattr(tensor, name, result)
-    return result
-
-
 def sumproduct(factors, target_shape=(), optimize=True, device=None):
     """
     Compute product of factors; then sum down extra dims and broadcast up

--- a/pyro/poutine/indep_messenger.py
+++ b/pyro/poutine/indep_messenger.py
@@ -25,6 +25,9 @@ class CondIndepStackFrame(namedtuple("CondIndepStackFrame", ["name", "dim", "siz
     def __hash__(self):
         return hash(self._key())
 
+    def __str__(self):
+        return self.name
+
 
 class IndepMessenger(Messenger):
     """

--- a/tests/infer/test_contract.py
+++ b/tests/infer/test_contract.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 import pytest
 import torch
 
-from pyro.infer.contract import _partition_terms, contract_tensor_tree, contract_to_tensor
+from pyro.infer.contract import UnpackedLogRing, _partition_terms, contract_tensor_tree, contract_to_tensor
 from pyro.poutine.indep_messenger import CondIndepStackFrame
 
 
@@ -84,9 +84,10 @@ def assert_immutable(fn):
     ([(4, 1, 1), (4, 3, 1), (1, 3, 2), (1, 1, 2)], set([-1, -3]), 2),
     ([(4, 1, 1), (4, 3, 1), (1, 3, 2), (1, 1, 2)], set([-1, -2, -3]), 1),
 ])
-def test_partition_terms(shapes, dims, expected_num_components):
+def test_partition_terms_unpacked(shapes, dims, expected_num_components):
+    ring = UnpackedLogRing()
     tensors = [torch.randn(shape) for shape in shapes]
-    components = list(_partition_terms(tensors, dims))
+    components = list(_partition_terms(ring, tensors, dims))
 
     # Check that result is a partition.
     expected_terms = sorted(tensors, key=id)


### PR DESCRIPTION
Addresses #1380, #1391 

This refactoring mostly shuffles around logic in `_contract_component()` and `contract_to_tensor()` so those two functions can work with both packed and unpacked tensors. This achieved by moving operations into a new `TensorRing` abstract base class with two implementations: `Packed` and `Unpacked`.

I've also refactored `contract_to_tensor()` by moving broadcasting logic out of `_contract_component()` and into `contract_to_tensor()`. This allows `contract_to_tensor()` to perform connected components decomposition before summing out enumeration dims (the decomposition was already done by `contract_tensor_tree()`).

## Tested

- [x] refactoring is exercised by existing unit tests
- [x] tests for ubersum-as-einsum
- [x] tests for ubersum with multiple outputs
- [x] tests for ubersum with batch dims and product reductions
- [x] tests for `iarange`s of size=1
- [x] death tests for non-tree structure