### PR TITLE
Minor testing related fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ scrub: FORCE
 	find tutorial -name "*.ipynb" | xargs python tutorial/source/cleannb.py
 
 doctest: FORCE
-	python -m pytest --doctest-modules -p tests.doctest_fixtures -p no:warnings pyro
+	pytest -p tests.doctest_fixtures --doctest-modules -o filterwarnings=ignore pyro
 
 format: FORCE
 	isort --recursive *.py pyro/ examples/ tests/ profiler/*.py docs/source/conf.py
@@ -54,8 +54,8 @@ test-all: lint FORCE
 	  | xargs pytest -vx --nbval-lax
 
 test-cuda: lint FORCE
-	CUDA_TEST=1 PYRO_TENSOR_TYPE=torch.cuda.DoubleTensor pytest -vx -n 4 --stage unit
-	CUDA_TEST=1 pytest -vx -n 4 tests/test_examples.py::test_cuda
+	CUDA_TEST=1 PYRO_TENSOR_TYPE=torch.cuda.DoubleTensor pytest -vx --stage unit
+	CUDA_TEST=1 pytest -vx tests/test_examples.py::test_cuda
 
 clean: FORCE
 	git clean -dfx -e pyro-egg.info

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -156,8 +156,8 @@ def train_test_split(pd_dataframe):
     Training data - 45 initial at-bats and hits for each player.
     Validation data - Full season at-bats and hits for each player.
     """
-    train_data = torch.tensor(pd_dataframe.as_matrix(["At-Bats", "Hits"]), dtype=torch.float)
-    test_data = torch.tensor(pd_dataframe.as_matrix(["SeasonAt-Bats", "SeasonHits"]), dtype=torch.float)
+    train_data = torch.tensor(pd_dataframe[["At-Bats", "Hits"]].values, dtype=torch.float)
+    test_data = torch.tensor(pd_dataframe[["SeasonAt-Bats", "SeasonHits"]].values, dtype=torch.float)
     first_name = pd_dataframe["FirstName"].values
     last_name = pd_dataframe["LastName"].values
     player_names = [" ".join([first, last]) for first, last in zip(first_name, last_name)]

--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -88,7 +88,7 @@ def initialize_progbar(warmup_steps, num_samples, min_width=100, max_width=120, 
     total_steps = warmup_steps + num_samples
     # Disable progress bar in "CI"
     # (see https://github.com/travis-ci/travis-ci/issues/1337).
-    disable = "CI" in os.environ
+    disable = "CI" in os.environ or "PYTEST_XDIST_WORKER" in os.environ
     progress_bar = tqdm(total=total_steps, desc=description,
                         position=pos, file=sys.stderr, disable=disable)
 

--- a/pyro/ops/einsum/__init__.py
+++ b/pyro/ops/einsum/__init__.py
@@ -45,7 +45,13 @@ def cached_paths(filename):
     """
     if os.path.exists(filename):
         with open(filename, 'rb') as f:
-            _PATH_CACHE.update(pickle.load(f))
+            try:
+                cache = pickle.load(f)
+                _PATH_CACHE.update(cache)
+            # Lower version of python errors when trying to read the cache
+            # file dumped using a higher protocol (later version of python).
+            except ValueError:
+                pass
     try:
         yield
     finally:


### PR DESCRIPTION
Addresses #1397. 
 - Remove warnings from doctest.
 - Cuda tests run in a single process. Many of our tests construct fairly big tensors which results in OOM errors otherwise, besides not being any faster.
 - Disable progress bar in HMC when pytest-xdist is used.
 - Remove deprecated `pandas.DataFrame.as_matrix` method.
 - Do not throw error if the cached path in einsum was dumped using a higher protocol.
