### PR TITLE
Use logging instead of print in tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,4 +3,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 
 # create log handler for tests
-logging.basicConfig(format='%(levelname).1s \t %(message)s', level=logging.DEBUG)
+import os
+
+level = logging.INFO if "CI" in os.environ else logging.DEBUG
+logging.basicConfig(format='%(levelname).1s \t %(message)s', level=level)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
-# create log handler for tests
 import os
 
+# create log handler for tests
 level = logging.INFO if "CI" in os.environ else logging.DEBUG
 logging.basicConfig(format='%(levelname).1s \t %(message)s', level=level)

--- a/tests/contrib/autoname/test_scoping.py
+++ b/tests/contrib/autoname/test_scoping.py
@@ -1,10 +1,13 @@
+import logging
+
 import torch
 
 import pyro
-import pyro.poutine as poutine
 import pyro.distributions.torch as dist
-
+import pyro.poutine as poutine
 from pyro.contrib.autoname import scope
+
+logger = logging.getLogger(__name__)
 
 
 def test_multi_nested():
@@ -36,7 +39,7 @@ def test_multi_nested():
 
     samples = [name for name, node in tr.nodes.items()
                if node["type"] == "sample"]
-    print(samples)
+    logger.debug(samples)
     assert true_samples == samples
 
 
@@ -66,7 +69,7 @@ def test_recur_multi():
 
     samples = [name for name, node in tr.nodes.items()
                if node["type"] == "sample"]
-    print(samples)
+    logger.debug(samples)
     assert true_samples == samples
 
 
@@ -122,7 +125,7 @@ def test_simple_recur():
     prev_name = "x"
     for name, node in poutine.trace(geometric, strict_names=False).get_trace(0.9).nodes.items():
         if node["type"] == "sample":
-            print(name)
+            logger.debug(name)
             assert name == "geometric/" + prev_name
             prev_name = "geometric/" + prev_name
 

--- a/tests/contrib/oed/test_eig.py
+++ b/tests/contrib/oed/test_eig.py
@@ -1,25 +1,28 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
 from collections import namedtuple, OrderedDict
-import torch
-import scipy.special as sc
-import pytest
+
 import numpy as np
+import pytest
+import scipy.special as sc
+import torch
 
 import pyro
 import pyro.distributions as dist
 from pyro import optim
-from pyro.infer import TraceEnum_ELBO
-from pyro.contrib.oed.eig import (
-    vi_ape, naive_rainforth_eig, donsker_varadhan_eig, barber_agakov_ape
-)
-from pyro.contrib.oed.util import linear_model_ground_truth
 from pyro.contrib.glmm import (
     zero_mean_unit_obs_sd_lm, group_assignment_matrix,
     group_linear_model, group_normal_guide
 )
 from pyro.contrib.glmm.guides import LinearModelGuide, GuideDV
+from pyro.contrib.oed.eig import (
+    vi_ape, naive_rainforth_eig, donsker_varadhan_eig, barber_agakov_ape
+)
+from pyro.contrib.oed.util import linear_model_ground_truth
+from pyro.infer import TraceEnum_ELBO
 
+logger = logging.getLogger(__name__)
 
 #########################################################################################
 # Designs
@@ -234,9 +237,8 @@ def test_eig_lm(model, design, observation_labels, target_labels, estimator, arg
         y_true = bernoulli_ground_truth(model, design, observation_labels, target_labels, eig=eig)
     else:
         y_true = linear_model_ground_truth(model, design, observation_labels, target_labels, eig=eig)
-    print()
-    print(estimator.__name__)
-    print(y)
-    print(y_true)
+    logger.debug(estimator.__name__)
+    logger.debug(y)
+    logger.debug(y_true)
     error = torch.max(torch.abs(y - y_true))
     assert error < allow_error

--- a/tests/contrib/tracking/test_assignment.py
+++ b/tests/contrib/tracking/test_assignment.py
@@ -4,12 +4,15 @@ import pytest
 import torch
 from torch.autograd import grad
 
+import logging
+
 import pyro
 import pyro.distributions as dist
 from pyro.contrib.tracking.assignment import MarginalAssignment, MarginalAssignmentPersistent, MarginalAssignmentSparse
 from tests.common import assert_equal
 
 INF = float('inf')
+logger = logging.getLogger(__name__)
 
 
 def assert_finite(tensor, name):
@@ -270,5 +273,5 @@ def test_persistent_exact_5_4_3(e1, e2, e3, bp_iters, bp_momentum):
     actual = MarginalAssignmentPersistent(exists_logits, assign_logits, bp_iters, bp_momentum)
     assert_equal(expected.exists_dist.probs, actual.exists_dist.probs)
     assert_equal(expected.assign_dist.probs, actual.assign_dist.probs)
-    print(actual.exists_dist.probs)
-    print(actual.assign_dist.probs)
+    logger.debug(actual.exists_dist.probs)
+    logger.debug(actual.assign_dist.probs)

--- a/tests/contrib/tracking/test_em.py
+++ b/tests/contrib/tracking/test_em.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
 import math
 
 import pytest
@@ -13,6 +14,9 @@ from pyro.contrib.tracking.assignment import MarginalAssignment
 from pyro.infer import SVI, TraceEnum_ELBO
 from pyro.optim import Adam
 from pyro.optim.multi import MixedMultiOptimizer, Newton
+
+
+logger = logging.getLogger(__name__)
 
 
 def make_args():
@@ -137,7 +141,7 @@ def test_em(assignment_grad):
         objects_loc = pyro.param('objects_loc').detach_().requires_grad_()
         loss = elbo.differentiable_loss(model, guide, detections, args)  # E-step
         newton.step(loss, {'objects_loc': objects_loc})  # M-step
-        print('step {}, loss = {}'.format(step, loss.item()))
+        logger.debug('step {}, loss = {}'.format(step, loss.item()))
 
 
 @pytest.mark.parametrize('assignment_grad', [False, True])
@@ -167,7 +171,7 @@ def test_em_nested_in_svi(assignment_grad):
             pyro.get_param_store().replace_param('objects_loc', updated['objects_loc'], objects_loc)
             assert pyro.param('objects_loc').grad_fn is not None
         loss = svi.step(detections, args)
-        print('step {: >2d}, loss = {:0.6f}, noise_scale = {:0.6f}'.format(
+        logger.debug('step {: >2d}, loss = {:0.6f}, noise_scale = {:0.6f}'.format(
             svi_step, loss, pyro.param('noise_scale').item()))
 
 
@@ -193,5 +197,5 @@ def test_svi_multi():
         params = {name: pyro.param(name).unconstrained()
                   for name in param_capture.trace.nodes.keys()}
         optim.step(loss, params)
-        print('step {: >2d}, loss = {:0.6f}, noise_scale = {:0.6f}'.format(
+        logger.debug('step {: >2d}, loss = {:0.6f}, noise_scale = {:0.6f}'.format(
             svi_step, loss.item(), pyro.param('noise_scale').item()))

--- a/tests/contrib/tracking/test_hashing.py
+++ b/tests/contrib/tracking/test_hashing.py
@@ -1,10 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 import pytest
 import torch
 
 from pyro.contrib.tracking.hashing import LSH, ApproxSet, merge_points
 from tests.common import assert_equal
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize('scale', [-1., 0., -1 * torch.ones(2, 2)])
@@ -140,7 +144,7 @@ def test_merge_points_small():
 def test_merge_points_large(dim, radius):
     points = 10 * torch.randn(200, dim)
     merged_points, groups = merge_points(points, radius)
-    print('merged {} -> {}'.format(len(points), len(merged_points)))
+    logger.debug('merged {} -> {}'.format(len(points), len(merged_points)))
 
     assert merged_points.dim() == 2
     assert merged_points.shape[-1] == dim

--- a/tests/distributions/test_gaussian_mixtures.py
+++ b/tests/distributions/test_gaussian_mixtures.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
 import math
 
 import torch
@@ -8,6 +9,9 @@ import pytest
 from pyro.distributions import MixtureOfDiagNormalsSharedCovariance, GaussianScaleMixture
 from pyro.distributions import MixtureOfDiagNormals
 from tests.common import assert_equal
+
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize('mix_dist', [MixtureOfDiagNormals, MixtureOfDiagNormalsSharedCovariance, GaussianScaleMixture])
@@ -109,7 +113,7 @@ def test_mean_gradient(K, D, flat_logits, cost_function, mix_dist, batch_mode):
     assert_equal(analytic, cost, prec=0.1,
                  msg='bad cost function evaluation for {} test (expected {}, got {})'.format(
                      mix_dist.__name__, analytic.item(), cost.item()))
-    print("analytic_grads_logit", analytic_grads['component_logits'].detach().cpu().numpy())
+    logger.debug("analytic_grads_logit", analytic_grads['component_logits'].detach().cpu().numpy())
 
     for param_name, param in params.items():
         assert_equal(param.grad, analytic_grads[param_name], prec=0.06,

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -28,6 +28,7 @@ try:
 except ImportError:
     from contextlib2 import ExitStack  # python 2
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -1239,7 +1240,7 @@ def test_hmm_enumerate_model(num_steps):
         for t, y in enumerate(data):
             x = pyro.sample("x_{}".format(t), dist.Categorical(transition_probs[x]))
             pyro.sample("y_{}".format(t), dist.Categorical(emission_probs[x]), obs=y)
-            print('{}\t{}'.format(t, tuple(x.shape)))
+            logger.debug('{}\t{}'.format(t, tuple(x.shape)))
 
     def guide(data):
         pass
@@ -1260,12 +1261,12 @@ def test_hmm_enumerate_model_and_guide(num_steps):
                                     torch.tensor([[0.75, 0.25], [0.25, 0.75]]),
                                     constraint=constraints.simplex)
         x = pyro.sample("x", dist.Categorical(torch.tensor([0.5, 0.5])))
-        print('-1\t{}'.format(tuple(x.shape)))
+        logger.debug('-1\t{}'.format(tuple(x.shape)))
         for t, y in enumerate(data):
             x = pyro.sample("x_{}".format(t), dist.Categorical(transition_probs[x]),
                             infer={"enumerate": "parallel"})
             pyro.sample("y_{}".format(t), dist.Categorical(emission_probs[x]), obs=y)
-            print('{}\t{}'.format(t, tuple(x.shape)))
+            logger.debug('{}\t{}'.format(t, tuple(x.shape)))
 
     def guide(data):
         init_probs = pyro.param("init_probs",
@@ -2538,11 +2539,11 @@ def test_elbo_hmm_growth():
     for counts in costs:
         for key, cost in counts.items():
             collated_costs[key].append(cost)
-    print('Growth:')
-    print('sizes = {}'.format(repr(sizes)))
-    print('costs = {}'.format(repr(dict(collated_costs))))
-    print('times1 = {}'.format(repr(times1)))
-    print('times2 = {}'.format(repr(times2)))
+    logger.debug('Growth:')
+    logger.debug('sizes = {}'.format(repr(sizes)))
+    logger.debug('costs = {}'.format(repr(dict(collated_costs))))
+    logger.debug('times1 = {}'.format(repr(times1)))
+    logger.debug('times2 = {}'.format(repr(times2)))
 
     for key, cost in collated_costs.items():
         dt = 3
@@ -2601,11 +2602,11 @@ def test_elbo_dbn_growth():
     for counts in costs:
         for key, cost in counts.items():
             collated_costs[key].append(cost)
-    print('Growth:')
-    print('sizes = {}'.format(repr(sizes)))
-    print('costs = {}'.format(repr(dict(collated_costs))))
-    print('times1 = {}'.format(repr(times1)))
-    print('times2 = {}'.format(repr(times2)))
+    logger.debug('Growth:')
+    logger.debug('sizes = {}'.format(repr(sizes)))
+    logger.debug('costs = {}'.format(repr(dict(collated_costs))))
+    logger.debug('times1 = {}'.format(repr(times1)))
+    logger.debug('times2 = {}'.format(repr(times2)))
 
     for key, cost in collated_costs.items():
         dt = 4

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 import pytest
 import torch
 from torch.autograd import grad
@@ -15,20 +17,23 @@ from pyro.poutine.indep_messenger import CondIndepStackFrame
 from tests.common import assert_equal, xfail_param
 
 
+logger = logging.getLogger(__name__)
+
+
 def test_simple():
     y = torch.ones(2)
 
     @torch.jit.compile(nderivs=0)
     def f(x):
-        print('Inside f')
+        logger.debug('Inside f')
         assert x is y
         return y + 1.0
 
-    print('Calling f(y)')
+    logger.debug('Calling f(y)')
     assert_equal(f(y), y.new_tensor([2, 2]))
-    print('Calling f(y)')
+    logger.debug('Calling f(y)')
     assert_equal(f(y), y.new_tensor([2, 2]))
-    print('Calling f(torch.zeros(2))')
+    logger.debug('Calling f(torch.zeros(2))')
     assert_equal(f(torch.zeros(2)), y.new_tensor([1, 1]))
     with pytest.raises(AssertionError):
         assert_equal(f(torch.ones(5)), y.new_tensor([2, 2, 2, 2, 2]))
@@ -39,15 +44,15 @@ def test_backward():
 
     @torch.jit.compile(nderivs=1)
     def f(x):
-        print('Inside f')
+        logger.debug('Inside f')
         assert x is y
         return (y + 1.0).sum()
 
-    print('Calling f(y)')
+    logger.debug('Calling f(y)')
     f(y).backward()
-    print('Calling f(y)')
+    logger.debug('Calling f(y)')
     f(y)
-    print('Calling f(torch.zeros(2))')
+    logger.debug('Calling f(torch.zeros(2))')
     f(torch.zeros(2, requires_grad=True))
     with pytest.raises(AssertionError):
         f(torch.ones(5, requires_grad=True))
@@ -57,13 +62,13 @@ def test_grad():
 
     @torch.jit.compile(nderivs=0)
     def f(x, y):
-        print('Inside f')
+        logger.debug('Inside f')
         loss = (x - y).pow(2).sum()
         return torch.autograd.grad(loss, [x, y], allow_unused=True)
 
-    print('Invoking f')
+    logger.debug('Invoking f')
     f(torch.zeros(2, requires_grad=True), torch.ones(2, requires_grad=True))
-    print('Invoking f')
+    logger.debug('Invoking f')
     f(torch.zeros(2, requires_grad=True), torch.zeros(2, requires_grad=True))
 
 
@@ -73,13 +78,13 @@ def test_grad_expand():
 
     @torch.jit.compile(nderivs=0)
     def f(x, y):
-        print('Inside f')
+        logger.debug('Inside f')
         loss = (x - y).pow(2).sum()
         return torch.autograd.grad(loss, [x, y], allow_unused=True)
 
-    print('Invoking f')
+    logger.debug('Invoking f')
     f(torch.zeros(2, requires_grad=True), torch.ones(1, requires_grad=True))
-    print('Invoking f')
+    logger.debug('Invoking f')
     f(torch.zeros(2, requires_grad=True), torch.zeros(1, requires_grad=True))
 
 

--- a/tests/ops/test_newton.py
+++ b/tests/ops/test_newton.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import itertools
+import logging
 
 import pytest
 import torch
@@ -8,6 +9,9 @@ from torch.autograd import grad
 
 from pyro.ops.newton import newton_step
 from tests.common import assert_equal
+
+
+logger = logging.getLogger(__name__)
 
 
 def random_inside_unit_circle(shape, requires_grad=False):
@@ -120,6 +124,6 @@ def test_newton_step_converges(trust_radius, dims):
         loss = loss_fn(x)
         x, cov = newton_step(loss, x, trust_radius=trust_radius)
         if ((x - mode).pow(2).sum(-1) < 1e-4).all():
-            print('Newton iteration converged after {} steps'.format(2 + i))
+            logger.debug('Newton iteration converged after {} steps'.format(2 + i))
             return
     pytest.fail('Newton iteration did not converge')

--- a/tests/ops/test_sumproduct.py
+++ b/tests/ops/test_sumproduct.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
 import numbers
 import operator
 import timeit
@@ -14,6 +15,9 @@ from pyro.infer.util import torch_exp
 from pyro.ops.einsum import contract
 from pyro.ops.sumproduct import logsumproductexp, sumproduct, zip_align_right
 from tests.common import assert_equal
+
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize('xs,ys,expected', [
@@ -135,4 +139,4 @@ def test_einsum_speed(equation, shapes, backend):
     for _ in range(1000):
         contract(equation, *operands, backend=backend)
     elapsed = timeit.default_timer() - start_time
-    print('{} {}: {}'.format(backend, equation, elapsed))
+    logger.debug('{} {}: {}'.format(backend, equation, elapsed))

--- a/tests/poutine/test_nesting.py
+++ b/tests/poutine/test_nesting.py
@@ -1,7 +1,12 @@
+import logging
+
 import pyro
 import pyro.poutine as poutine
 import pyro.distributions as dist
 import pyro.poutine.runtime
+
+
+logger = logging.getLogger(__name__)
 
 
 def test_nested_reset():
@@ -20,6 +25,6 @@ def test_nested_reset():
                     nested_model()
                 except poutine.NonlocalExit as site_container:
                     site_container.reset_stack()
-                    print(pyro.poutine.runtime._PYRO_STACK)
+                    logger.debug(pyro.poutine.runtime._PYRO_STACK)
                     assert "internal1" not in t1.trace
                     assert "internal1" in t2.trace


### PR DESCRIPTION
Addresses #1397.

 - Changes print to use `logger.debug`.
 - Changes logging level of tests to `info` when in travis to control the size of the log. This shouldn't impact local runs.