### PR TITLE
Move pyro.infer.contract into pyro.ops

### DIFF
--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -36,3 +36,5 @@ Tensor Contraction
     :undoc-members:
     :show-inheritance:
     :member-order: bysource
+
+.. autofunction:: pyro.ops.contract.ubersum

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -4,7 +4,7 @@ import torch
 from opt_einsum import shared_intermediates
 
 from pyro.distributions.util import logsumexp, broadcast_shape
-from pyro.infer.contract import contract_to_tensor
+from pyro.ops.contract import contract_to_tensor
 from pyro.infer.util import is_validation_enabled
 from pyro.primitives import _Subsample
 from pyro.util import check_site_shape
@@ -140,7 +140,7 @@ class TraceEinsumEvaluator(object):
     tree structure) that possibly contains discrete sample sites
     enumerated in parallel. This uses optimized `einsum` operations
     to marginalize out the the enumerated dimensions in the trace
-    via :class:`~pyro.infer.contract.contract_to_tensor`.
+    via :class:`~pyro.ops.contract.contract_to_tensor`.
 
     :param model_trace: execution trace from a static model.
     :param bool has_enumerable_sites: whether the trace contains any

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -15,7 +15,7 @@ import pyro.ops.jit
 import pyro.poutine as poutine
 from pyro.distributions.torch_distribution import ReshapedDistribution
 from pyro.distributions.util import is_identically_zero, scale_and_mask
-from pyro.infer.contract import contract_tensor_tree, contract_to_tensor
+from pyro.ops.contract import contract_tensor_tree, contract_to_tensor
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import get_importance_trace, iter_discrete_escape, iter_discrete_extend
 from pyro.infer.util import Dice, is_validation_enabled

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -417,10 +417,11 @@ def ubersum(equation, *operands, **kwargs):
     """
     Generalized batched einsum via tensor message passing.
 
-    This generalizes :func:``~opt_einsum.contract`` in two ways:
-    1. multiple outputs are allowed, and intermediate results can be shared.
-    2. inputs and outputs can be batched along symbols given in ``batch_dims``;
-        reductions along ``batch_dim``s are product reductions.
+    This generalizes :func:`~pyro.ops.einsum.contract` in two ways:
+
+    1.  Multiple outputs are allowed, and intermediate results can be shared.
+    2.  Inputs and outputs can be batched along symbols given in ``batch_dims``;
+        reductions along ``batch_dims`` are product reductions.
 
     To illustrate multiple outputs, note that the following are equivalent::
 
@@ -440,7 +441,7 @@ def ubersum(equation, *operands, **kwargs):
 
     :param str equation: an einsum equation, optionally with multiple outputs.
     :param torch.Tensor operands: a collection of tensors
-    :param str batch_dims: a string of batch dims.
+    :param str batch_dims: an optional string of batch dims.
     :param dict cache: an optional :func:`~opt_einsum.shared_intermediates`
         cache.
     :return: a tuple of tensors of requested shape, one entry per output.

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 
 from pyro.distributions.util import logsumexp
-from pyro.infer.contract import UnpackedLogRing, _partition_terms, contract_tensor_tree, contract_to_tensor, ubersum
+from pyro.ops.contract import UnpackedLogRing, _partition_terms, contract_tensor_tree, contract_to_tensor, ubersum
 from pyro.poutine.indep_messenger import CondIndepStackFrame
 from tests.common import assert_equal
 


### PR DESCRIPTION
This moves pyro.infer.contract -> pyro.ops.contract, and adds `ubersum` to our sphinx docs.

The motivation is to eventually move `pyro.ops.contract` upstream to `opt_einsum` or PyTorch. This PR introduces a tiny bit of interface leakage where pyro.ops is not completely independent of the rest of pyro: one error message in pyro.ops mentions `iarange`. However this is minor and can be resolved when we settle on terminology.