### PR TITLE
Add naive_ubersum reference implementation + tests

### DIFF
--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -579,7 +579,6 @@ def naive_ubersum(equation, *operands, **kwargs):
         result = opt_einsum.contract(equation, *operands, backend='pyro.ops.einsum.torch_log')
         return (result,)
     output_dims = set(output)
-    keep_dims = output_dims - batch_dims
 
     # Collect sizes of all dimensions.
     sizes = {}
@@ -597,7 +596,7 @@ def naive_ubersum(equation, *operands, **kwargs):
         ordinal = dims & batch_dims
         for dim in dims - batch_dims:
             dim_to_ordinal[dim] = dim_to_ordinal.get(dim, ordinal) & ordinal
-    for dim in keep_dims:
+    for dim in output_dims - batch_dims:
         missing_dims = dim_to_ordinal[dim] - output_dims
         if missing_dims:
             raise ValueError(u"It is nonsensical to preserve a batched dim without preserving "

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -443,6 +443,32 @@ def ubersum(equation, *operands, **kwargs):
         z = w + sum(contract('bc,cd->bd', xi, yi, backend=backend)
                     for xi, yi in zip(x, y))
 
+    When a non-batch dimension `i` always appears with a batch dimension `a`,
+    then `i` corresponds to a distinct symbol for each slice of `a`. Thus
+    the following are equivalent::
+
+        assert len(x) == 3
+        z = ubersum('abi,abi->', x, y, batch_dims='a')
+
+        z = contract('bi,bj,bk,bi,bj,bk->', *x, *y, backend=backend)
+
+    When such a non-batched dimension appears in the output, it must be
+    accompanied by all of its batch dimensions, e.g. the following are
+    equivalent::
+
+        assert len(x) == 3
+        z = ubersum('abi,abi->ai', x, y, batch_dims='a')
+
+        z0 = contract('bi,bj,bk,bi,bj,bk->i', *x, *y, backend=backend)
+        z1 = contract('bi,bj,bk,bi,bj,bk->j', *x, *y, backend=backend)
+        z2 = contract('bi,bj,bk,bi,bj,bk->k', *x, *y, backend=backend)
+        z = torch.stack([z0, z1, z2])
+
+    Among all valid inputs, some computations are polynomial in the sizes of
+    the input tensors and other computations are exponential in the sizes of
+    the input tensors. This function raises `NotImplementedError` whenever the
+    computation is exponential.
+
     :param str equation: an einsum equation, optionally with multiple outputs.
     :param torch.Tensor operands: a collection of tensors
     :param str batch_dims: an optional string of batch dims.

--- a/pyro/ops/einsum/__init__.py
+++ b/pyro/ops/einsum/__init__.py
@@ -11,7 +11,7 @@ _PATH_CACHE = {}
 
 def contract(equation, *operands, **kwargs):
     """
-    Wrpper around :func:`opt_einsum.contract` that caches contraction paths.
+    Wrapper around :func:`opt_einsum.contract` that caches contraction paths.
 
     :param bool cache_path: whether to cache the contraction path.
         Defaults to True.

--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -32,11 +32,12 @@ def einsum(equation, *operands):
         exp_operands.append((operand - shift).exp())
 
         # permute shift to match output
-        shift = shift.squeeze()
-        dims = [dim for dim in dims if dim in output]
-        dims = [dim for dim in output if dim not in dims] + dims
-        shift = shift.reshape((1,) * (len(output) - len(shift.shape)) + shift.shape)
-        if dims:
+        shift = shift.reshape(torch.Size(size for size, dim in zip(operand.shape, dims)
+                                         if dim in output))
+        if shift.dim():
+            shift = shift.reshape((1,) * (len(output) - shift.dim()) + shift.shape)
+            dims = [dim for dim in dims if dim in output]
+            dims = [dim for dim in output if dim not in dims] + dims
             shift = shift.permute(*(dims.index(dim) for dim in output))
         shifts.append(shift)
 

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -2325,7 +2325,7 @@ def test_elbo_enumerate_iaranges_6(scale):
 
     # But promoting both to iaranges should result in an error.
     elbo = TraceEnum_ELBO(max_iarange_nesting=2)
-    with pytest.raises(ValueError, match="Expected tree-structured iarange nesting.*"):
+    with pytest.raises(NotImplementedError, match="Expected tree-structured iarange nesting.*"):
         elbo.differentiable_loss(model_iarange_iarange, guide, data)
 
 

--- a/tests/ops/einsum/test_torch_log.py
+++ b/tests/ops/einsum/test_torch_log.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import itertools
+
 import pytest
 import torch
 
@@ -9,6 +11,7 @@ from pyro.ops.sumproduct import logsumproductexp, sumproduct
 from tests.common import assert_equal
 
 
+@pytest.mark.parametrize('min_size', [1, 2])
 @pytest.mark.parametrize('equation', [
     ',ab->ab',
     'ab,,bc->a',
@@ -30,12 +33,13 @@ from tests.common import assert_equal
     'ab,bc,cd->ac',
     'ab,bc,cd->ad',
     'ab,bc,cd->bc',
+    'a,a,ab,b,b,b,b->a',
 ])
-def test_einsum(equation):
+def test_einsum(equation, min_size):
     inputs, output = equation.split('->')
     inputs = inputs.split(',')
     symbols = sorted(set(equation) - set(',->'))
-    sizes = dict(zip(symbols, range(2, 2 + len(symbols))))
+    sizes = dict(zip(symbols, itertools.count(min_size)))
     shapes = [torch.Size(tuple(sizes[dim] for dim in dims))
               for dims in inputs]
     operands = [torch.randn(shape) for shape in shapes]


### PR DESCRIPTION
Addresses #1391
Fixes #1414

This clarifies the semantics of `ubersum()` by adding a simple reference implementation. The `naive_ubersum()` reference implementation is slow but handles both polynomial-time and exponential-time contractions, whereas `ubersum()` currently raises `NotImplementedError` for exponential-time contractions. It's actually very very slow; it is good for testing but wouldn't be able to serve as a fallback implementation for `ubersum()`'s NotImplemented cases.

This PR also fixes a shape bug in the `torch_log` backend (causing #1414) and adds regression tests.

## Tested

- [x] add test for agreement between `contract()` and `naive_ubersum()`
- [x] add test for agreement between `ubersum()` and `naive_ubersum()`
- [x] parametrize existing tests to also test `naive_ubersum()`
- [x] add tests for preserved batched dimensions
- [x] mark `ubersum()` discrepancies as xfail