### PR TITLE
Fix incompatible dependency between jupyter-console and ipython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
             'pytest==3.7',
             'pytest-cov',
             'scipy>=0.19.0',
+            'ipython<=6.5.0',  # https://github.com/jupyter/jupyter_console/issues/158
         ],
         'profile': ['prettytable', 'pytest-benchmark', 'snakeviz'],
         'dev': EXTRAS_REQUIRE + [
@@ -105,6 +106,7 @@ setup(
             'pypandoc',
             'pytest==3.7',
             'pytest-xdist',
+            'ipython<=6.5.0',  # https://github.com/jupyter/jupyter_console/issues/158
             'scipy>=0.19.0',
             'sphinx',
             'sphinx_rtd_theme',


### PR DESCRIPTION
Recent release of ipython>=0.7 is incompatible with jupyter-console. Temporary fix until https://github.com/jupyter/jupyter_console/issues/158 is resolved. 