### PR TITLE
Small fix tutorial svi_part_iii

### DIFF
--- a/tutorial/source/svi_part_iii.ipynb
+++ b/tutorial/source/svi_part_iii.ipynb
@@ -305,7 +305,7 @@
     "        self.beta0 = 10.0\n",
     "        # the dataset consists of six 1s and four 0s\n",
     "        self.data = torch.zeros(10)\n",
-    "        self.data[0:6].data = torch.ones(6)\n",
+    "        self.data[0:6] = torch.ones(6)\n",
     "        self.n_data = self.data.size(0)\n",
     "        # compute the alpha parameter of the exact beta posterior\n",
     "        self.alpha_n = self.data.sum() + self.alpha0\n",
@@ -440,7 +440,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Original implementation generates a tensor with 10 zeros for `self.data`: 
```
data = torch.zeros(10)
data[0:6].data = torch.ones(6)
print(data)
# tensor([0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])
```

Updated implementation generates a tensor with 6 ones and 4 zeros for `self.data`:
```
data = torch.zeros(10)
data[0:6] = torch.ones(6)
print(data)
# tensor([1., 1., 1., 1., 1., 1., 0., 0., 0., 0.])
```