### PR TITLE
Warn if a prior name is misspelled in random_module

### DIFF
--- a/pyro/poutine/lift_messenger.py
+++ b/pyro/poutine/lift_messenger.py
@@ -37,7 +37,6 @@ class LiftMessenger(Messenger):
 
     def __exit__(self, *args, **kwargs):
         if is_validation_enabled() and isinstance(self.prior, dict):
-            print('DEBUG {}'.format(self._param_hits))
             extra = set(self.prior) - self._param_hits
             if extra:
                 warnings.warn(

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -455,6 +455,7 @@ def enable_validation(is_validate=True):
     """
     dist.enable_validation(is_validate)
     infer.enable_validation(is_validate)
+    poutine.enable_validation(is_validate)
 
 
 @contextmanager


### PR DESCRIPTION
Fixes #1399 

This also fixes a bug whereby `poutine.enable_validation()` was not being called by `pyro.enable_validation()`.

## Tested

- added a warning test