### PR TITLE
Update importance.py (new features) 

### DIFF
--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 import torch
-import warnings
 import logging
 
 import pyro.poutine as poutine
@@ -8,6 +7,7 @@ import pyro.poutine as poutine
 from .abstract_infer import TracePosterior
 
 logger = logging.getLogger(__name__)
+
 
 class Importance(TracePosterior):
     """
@@ -47,40 +47,42 @@ class Importance(TracePosterior):
 
     def get_log_normalizer(self):
         """
-        Estimator of the normalizing constant of the target distribution. 
+        Estimator of the normalizing constant of the target distribution.
         (mean of the unnormalized weights)
         """
         log_w = torch.tensor(self.log_weights)
         log_num_samples = torch.log(torch.tensor(self.num_samples, dtype=torch.float))
-        return torch.logsumexp(log_w - log_num_samples,0)
+        return torch.logsumexp(log_w - log_num_samples, 0)
     
     def get_normalized_weights(self, log_scale=False):
         """
-        Compute the normalized importance weights. 
+        Compute the normalized importance weights.
         """
         log_w = torch.tensor(self.log_weights)
-        log_w_norm = log_w - torch.logsumexp(log_w,0)
+        log_w_norm = log_w - torch.logsumexp(log_w, 0)
         return log_w_norm if log_scale else torch.exp(log_w_norm)
-   
-    def get_ESS(self): 
+
+    def get_ESS(self):
         """
-        Compute (Importance Sampling) Effective Sample Size (ESS). 
-        """ 
+        Compute (Importance Sampling) Effective Sample Size (ESS).
+        """
         # check to make sure list is not empty
         if self.log_weights:
             log_w_norm = self.get_normalized_weights(log_scale=True)
-            ess = torch.exp(-torch.logsumexp(2*log_w_norm,0))
+            ess = torch.exp(-torch.logsumexp(2*log_w_norm, 0))
         else:
             logger.warn("The log_weights list is empty, effective sample size is zero.")
-            ess = 0 
+            ess = 0
         return ess
-        
-        # tests to make sure it matches with simpler (but 
+
+        # tests to make sure it matches with simpler (but
         # numerically unstable) ways of computing.
-        # Can be removed. 
-       
+        # Can be removed.
         # print("ESS (log-scale computation (main)) {:3f}".format(ess))
         # ess_check1 = (torch.sum(torch.exp(log_w))**2) / (torch.sum(torch.exp(2*log_w)))
         # print("ESS (semi-log-scale computation) {:3f}".format(ess_check1))
         # ess_check2 = (torch.sum(torch.exp(log_w))**2) / (torch.sum(torch.exp(2*log_w)))
         # print("ESS (numerically unstable computation) {:3f}".format(ess_check2))
+       
+
+    

--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -53,7 +53,7 @@ class Importance(TracePosterior):
         log_w = torch.tensor(self.log_weights)
         log_num_samples = torch.log(torch.tensor(self.num_samples, dtype=torch.float))
         return torch.logsumexp(log_w - log_num_samples, 0)
-    
+
     def get_normalized_weights(self, log_scale=False):
         """
         Compute the normalized importance weights.
@@ -74,15 +74,3 @@ class Importance(TracePosterior):
             logger.warn("The log_weights list is empty, effective sample size is zero.")
             ess = 0
         return ess
-
-        # tests to make sure it matches with simpler (but
-        # numerically unstable) ways of computing.
-        # Can be removed.
-        # print("ESS (log-scale computation (main)) {:3f}".format(ess))
-        # ess_check1 = (torch.sum(torch.exp(log_w))**2) / (torch.sum(torch.exp(2*log_w)))
-        # print("ESS (semi-log-scale computation) {:3f}".format(ess_check1))
-        # ess_check2 = (torch.sum(torch.exp(log_w))**2) / (torch.sum(torch.exp(2*log_w)))
-        # print("ESS (numerically unstable computation) {:3f}".format(ess_check2))
-       
-
-    


### PR DESCRIPTION
Added methods for the Importance class that are often used with importance sampling methods. Useful on their own, and for future features such as Sequential Monte Carlo and Annealed Importance Sampling.

In all cases they are computed in a numerically stable manner using the log scale.

1. Estimate the normalizing constant of the target distribution. (this assumes that the log_weights are computed using the normalized density of the guide, otherwise it is an estimator of the ratio of normalizing constants). This is also used at each stage in Sequential Monte Carlo to construct the final normalizing constant estimator, likewise for Annealed Importance Sampling.

2. Compute the normalized sample weights.

3. Compute the (Importance Sampling) effective sample size (which is different to the one used for MCMC). This is useful as a diagnostic for the efficacy of an importance sampling density. It is also used in Sequential Monte Carlo algorithms to determine resampling times.

For further background and an example of where such things are used, see for example: https://www.stats.ox.ac.uk/~doucet/delmoral_doucet_jasra_sequentialmontecarlosamplersJRSSB.pdf
which discusses these aspects in the context of SMC Samplers.