### PR TITLE
Add RSA tutorials to website

### DIFF
--- a/tutorial/source/RSA-hyperbole.ipynb
+++ b/tutorial/source/RSA-hyperbole.ipynb
@@ -285,7 +285,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Pragmatic Halo\n",
+    "## Pragmatic Halo\n",
     "\n",
     "\"It cost fifty dollars\" is often interpretted as costing *around* 50 -- plausibly 51; yet \"it cost fiftyone dollars\" is interpretted as 51 and definitely not 50. This assymetric imprecision is often called the pragmatic halo or pragmatic slack.\n",
     "\n",
@@ -426,7 +426,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Irony and More Complex Affect\n",
+    "## Irony and More Complex Affect\n",
     "\n",
     "In the above hyperbole model we assumed a very simple model of affect: a single dimension with two values (high and low arousal). Actual affect is best represented as a two-dimensional space corresponding to valence and arousal. Kao and Goodman (2015) showed that extending the affect space to these two dimensions immediately introduces a new usage of numbers: verbal irony in which an utterance corresponding to a high-arousal positive valence state is used to convey a high-arousal but negative valence (or vice versa). "
    ]

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -26,8 +26,6 @@ Welcome to Pyro Examples and Tutorials!
    dmm
    air
    ss-vae
-   RSA-implicature
-   RSA-hyperbole
 
 .. toctree::
    :maxdepth: 2
@@ -37,6 +35,8 @@ Welcome to Pyro Examples and Tutorials!
    gp
    bo
    tracking_1d
+   RSA-implicature
+   RSA-hyperbole
 
 
 Indices and tables

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -26,6 +26,8 @@ Welcome to Pyro Examples and Tutorials!
    dmm
    air
    ss-vae
+   RSA-implicature
+   RSA-hyperbole
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This PR adds the two RSA tutorial notebooks to `tutorials/source/index.rst` so that they'll be displayed along with the other examples.