### PR TITLE
Bump networkx version to 2.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ numpy>=1.7
 contextlib2
 cloudpickle>=0.3.1
 graphviz>=0.8
-networkx>=2.2rc1
+networkx>=2.2
 observations>=0.1.4
 opt_einsum>=2.2.0
 tqdm>=4.25

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         # add them to `docs/requirements.txt`
         'contextlib2',
         'graphviz>=0.8',
-        'networkx>=2.2rc1',
+        'networkx>=2.2',
         'numpy>=1.7',
         'opt_einsum>=2.2.0',
         'six>=1.10.0',


### PR DESCRIPTION
This PR bumps the required networkx version from `2.2rc1` to `2.2`