### PR TITLE
add `retain graph` option to elbo

### DIFF
--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -50,10 +50,12 @@ class ELBO(object):
                  num_particles=1,
                  max_iarange_nesting=float('inf'),
                  vectorize_particles=False,
-                 strict_enumeration_warning=True):
+                 strict_enumeration_warning=True,
+                 retain_graph=False):
         self.num_particles = num_particles
         self.max_iarange_nesting = max_iarange_nesting
         self.vectorize_particles = vectorize_particles
+        self.retain_graph = retain_graph
         if self.vectorize_particles:
             if self.num_particles > 1:
                 if self.max_iarange_nesting == float('inf'):

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -133,7 +133,7 @@ class Trace_ELBO(ELBO):
 
             if trainable_params and getattr(surrogate_loss_particle, 'requires_grad', False):
                 surrogate_loss_particle = surrogate_loss_particle / self.num_particles
-                surrogate_loss_particle.backward()
+                surrogate_loss_particle.backward(retain_graph=self.retain_graph)
 
         warn_if_nan(loss, "loss")
         return loss

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -246,7 +246,7 @@ class TraceGraph_ELBO(ELBO):
 
         if trainable_params:
             surrogate_loss = -surrogate_elbo
-            torch_backward(weight * (surrogate_loss + baseline_loss))
+            torch_backward(weight * (surrogate_loss + baseline_loss), retain_graph=self.retain_graph)
 
         loss = -torch_item(elbo)
         warn_if_nan(loss, "loss")

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -35,13 +35,13 @@ def torch_item(x):
     return x if isinstance(x, numbers.Number) else x.item()
 
 
-def torch_backward(x):
+def torch_backward(x, retain_graph=False):
     """
     Like ``x.backward()`` for a :class:`~torch.Tensor`, but also accepts
     numbers (a no-op if given a number).
     """
     if torch.is_tensor(x):
-        x.backward()
+        x.backward(retain_graph=retain_graph)
 
 
 def torch_exp(x):


### PR DESCRIPTION
### Overview
this adds a `retain_graph` kwarg to `*Elbo` classes.  The motivation for this is #1394 where the user needs to retain the graph if they cache any intermediate variables. Not a breaking change.

### Tests
None, this is for discussion atm.