### PR TITLE
Modify turning condition for nuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ all: docs test
 install: FORCE
 	pip install -e .[dev,profile]
 
-uninstall: FORCE
-	pip uninstall pyro-ppl
+reinstall: FORCE
+	pip uninstall -y pyro-ppl && pip install . --no-deps
 
 docs: FORCE
 	$(MAKE) -C docs html

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ all: docs test
 install: FORCE
 	pip install -e .[dev,profile]
 
+uninstall: FORCE
+	pip uninstall pyro-ppl
+
 docs: FORCE
 	$(MAKE) -C docs html
 

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,6 @@ all: docs test
 install: FORCE
 	pip install -e .[dev,profile]
 
-reinstall: FORCE
-	pip uninstall -y pyro-ppl && pip install . --no-deps
-
 docs: FORCE
 	$(MAKE) -C docs html
 

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -199,7 +199,7 @@ class HMC(TraceKernel):
         # We are going to find a step_size which make accept_prob (Metropolis correction)
         # near the target_accept_prob. If accept_prob:=exp(-delta_energy) is small,
         # then we have to decrease step_size; otherwise, increase step_size.
-        r = self._sample_r(name="r_presample")
+        r, _ = self._sample_r(name="r_presample")
         energy_current = self._energy(z, r)
         z_new, r_new, z_grads, potential_energy = single_step_velocity_verlet(
             z, r, self._potential_energy, self._inverse_mass_matrix, step_size)
@@ -322,7 +322,7 @@ class HMC(TraceKernel):
             r[name] = r_flat[pos:next_pos].reshape(self._r_shapes[name])
             pos = next_pos
         assert pos == r_flat.size(0)
-        return r
+        return r, r_flat
 
     def _validate_trace(self, trace):
         trace_eval = TraceEinsumEvaluator if self.use_einsum else TraceTreeEvaluator
@@ -378,7 +378,7 @@ class HMC(TraceKernel):
         for name, transform in self.transforms.items():
             z[name] = transform(z[name])
 
-        r = self._sample_r(name="r_t={}".format(self._t))
+        r, _ = self._sample_r(name="r_t={}".format(self._t))
 
         # Temporarily disable distributions args checking as
         # NaNs are expected during step size adaptation

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -127,14 +127,15 @@ class NUTS(HMC):
         r_right_flat = torch.cat([r_right[site_name].reshape(-1) for site_name in sorted(r_right)])
         # TODO: change to torch.dot for pytorch 1.0
         if self.full_mass:
-            if ((r_sum - r_left_flat) * (self._inverse_mass_matrix.matmul(r_left_flat))).sum() > 0:
-                if ((r_sum - r_right_flat) * (self._inverse_mass_matrix.matmul(r_right_flat))) \
-                        .sum() > 0:
-                    return False
+            if (((r_sum - r_left_flat) * (self._inverse_mass_matrix.matmul(r_left_flat)))
+                    .sum() > 0 and
+                    ((r_sum - r_right_flat) * (self._inverse_mass_matrix.matmul(r_right_flat)))
+                    .sum() > 0):
+                return False
         else:
-            if (self._inverse_mass_matrix * (r_sum - r_left_flat) * r_left_flat).sum() > 0:
-                if (self._inverse_mass_matrix * (r_sum - r_right_flat) * r_right_flat).sum() > 0:
-                    return False
+            if ((self._inverse_mass_matrix * (r_sum - r_left_flat) * r_left_flat).sum() > 0 and
+                    (self._inverse_mass_matrix * (r_sum - r_right_flat) * r_right_flat).sum() > 0):
+                return False
         return True
 
     def _build_basetree(self, z, r, z_grads, log_slice, direction, energy_current):

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -240,8 +240,8 @@ class NUTS(HMC):
         #     (z, r) ~ Uniform({(z', r') in trajectory | p(z', r') >= u}).
         #
         # For more information about slice sampling method, see [3].
-        # For another version of NUTS which uses multinomial sampling instead of slice sampling, see
-        # [2].
+        # For another version of NUTS which uses multinomial sampling instead of slice sampling,
+        # see [2].
 
         # Rather than sampling the slice variable from `Uniform(0, exp(-energy))`, we can
         # sample log_slice directly using `energy`, so as to avoid potential underflow or

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -299,7 +299,7 @@ class NUTS(HMC):
                     accepted = True
                     z = new_tree.z_proposal
 
-                r_sum += new_tree.r_sum
+                r_sum = r_sum + new_tree.r_sum
                 if self._is_turning(r_left, r_right, r_sum):  # stop doubling
                     break
                 else:  # update tree_size

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -127,10 +127,10 @@ class NUTS(HMC):
         r_right_flat = torch.cat([r_right[site_name].reshape(-1) for site_name in sorted(r_right)])
         if self.full_mass:
             return (r_sum - r_left_flat).dot(self._inverse_mass_matrix.matmul(r_left_flat)) <= 0 \
-                and (r_sum - r_right_flat).dot(self._inverse_mass_matrix.matmul(r_right_flat)) <= 0
+                or (r_sum - r_right_flat).dot(self._inverse_mass_matrix.matmul(r_right_flat)) <= 0
         else:
             return self._inverse_mass_matrix.dot((r_sum - r_left_flat) * r_left_flat) <= 0 \
-                and self._inverse_mass_matrix.dot((r_sum - r_right_flat) * r_right_flat) <= 0
+                or self._inverse_mass_matrix.dot((r_sum - r_right_flat) * r_right_flat) <= 0
 
     def _build_basetree(self, z, r, z_grads, log_slice, direction, energy_current):
         step_size = self.step_size if direction == 1 else -self.step_size

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -90,8 +90,8 @@ def test_logistic_regression():
 @pytest.mark.parametrize(
     "step_size, adapt_step_size, adapt_mass_matrix, full_mass",
     [
-        (0.02, False, False, False),
-        (0.02, False, True, False),
+        (0.03, False, False, False),
+        (0.03, False, True, False),
         (None, True, False, False),
         (None, True, True, False),
         (None, True, True, True),
@@ -154,7 +154,7 @@ def test_gamma_beta():
     true_beta = torch.tensor(1.)
     data = dist.Beta(concentration1=true_alpha, concentration0=true_beta).sample(torch.Size((5000,)))
     nuts_kernel = NUTS(model)
-    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=200).run(data)
+    mcmc_run = MCMC(nuts_kernel, num_samples=600, warmup_steps=200).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites=['alpha', 'beta'])
     assert_equal(posterior.mean, torch.stack([true_alpha, true_beta]), prec=0.05)
 
@@ -177,7 +177,7 @@ def test_gaussian_mixture_model():
     cluster_assignments = dist.Categorical(true_mix_proportions).sample(torch.Size((N,)))
     data = dist.Normal(true_cluster_means[cluster_assignments], 1.0).sample()
     nuts_kernel = NUTS(gmm, max_iarange_nesting=1)
-    mcmc_run = MCMC(nuts_kernel, num_samples=300, warmup_steps=100).run(data)
+    mcmc_run = MCMC(nuts_kernel, num_samples=400, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites=["phi", "cluster_means"]).mean.sort()[0]
     assert_equal(posterior[0], true_mix_proportions, prec=0.05)
     assert_equal(posterior[1], true_cluster_means, prec=0.2)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -14,19 +14,57 @@ from pyro.infer.mcmc.nuts import NUTS
 import pyro.poutine as poutine
 from tests.common import assert_equal
 
-from .test_hmc import TEST_CASES, TEST_IDS, T, rmse
+from .test_hmc import GaussianChain, T, rmse
 
 logger = logging.getLogger(__name__)
 
-T2 = T(*TEST_CASES[2].values)._replace(num_samples=800, warmup_steps=200)
-TEST_CASES[2] = pytest.param(*T2, marks=pytest.mark.skipif(
-    'CI' in os.environ or 'CUDA_TEST' in os.environ,
-    reason='Slow test - skip on CI/CUDA'))
-T3 = T(*TEST_CASES[3].values)._replace(num_samples=1000, warmup_steps=200)
-TEST_CASES[3] = pytest.param(*T3, marks=[
-    pytest.mark.skipif('CI' in os.environ or 'CUDA_TEST' in os.environ,
-                       reason='Slow test - skip on CI/CUDA')]
-)
+TEST_CASES = [
+    T(
+        GaussianChain(dim=10, chain_len=3, num_obs=1),
+        num_samples=800,
+        warmup_steps=200,
+        hmc_params=None,
+        expected_means=[0.25, 0.50, 0.75],
+        expected_precs=[1.33, 1, 1.33],
+        mean_tol=0.06,
+        std_tol=0.06,
+    ),
+    T(
+        GaussianChain(dim=10, chain_len=4, num_obs=1),
+        num_samples=800,
+        warmup_steps=200,
+        hmc_params=None,
+        expected_means=[0.20, 0.40, 0.60, 0.80],
+        expected_precs=[1.25, 0.83, 0.83, 1.25],
+        mean_tol=0.06,
+        std_tol=0.06,
+    ),
+    pytest.param(*T(
+        GaussianChain(dim=5, chain_len=2, num_obs=10000),
+        num_samples=800,
+        warmup_steps=200,
+        hmc_params=None,
+        expected_means=[0.5, 1.0],
+        expected_precs=[2.0, 10000],
+        mean_tol=0.04,
+        std_tol=0.04,
+    ), marks=[pytest.mark.skipif('CI' in os.environ or 'CUDA_TEST' in os.environ,
+                                 reason='Slow test - skip on CI/CUDA')]),
+    pytest.param(*T(
+        GaussianChain(dim=5, chain_len=9, num_obs=1),
+        num_samples=1200,
+        warmup_steps=200,
+        hmc_params=None,
+        expected_means=[0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90],
+        expected_precs=[1.11, 0.63, 0.48, 0.42, 0.4, 0.42, 0.48, 0.63, 1.11],
+        mean_tol=0.07,
+        std_tol=0.07,
+    ), marks=[pytest.mark.skipif('CI' in os.environ or 'CUDA_TEST' in os.environ,
+                                 reason='Slow test - skip on CI/CUDA')])
+]
+
+TEST_IDS = [t[0].id_fn() if type(t).__name__ == 'TestExample'
+            else t[0][0].id_fn() for t in TEST_CASES]
 
 
 @pytest.mark.parametrize(
@@ -44,7 +82,7 @@ def test_nuts_conjugate_gaussian(fixture,
                                  mean_tol,
                                  std_tol):
     pyro.get_param_store().clear()
-    nuts_kernel = NUTS(fixture.model, hmc_params['step_size'])
+    nuts_kernel = NUTS(fixture.model)
     mcmc_run = MCMC(nuts_kernel, num_samples, warmup_steps).run(fixture.data)
     for i in range(1, fixture.chain_len + 1):
         param_name = 'loc_' + str(i)
@@ -90,8 +128,8 @@ def test_logistic_regression():
 @pytest.mark.parametrize(
     "step_size, adapt_step_size, adapt_mass_matrix, full_mass",
     [
-        (0.03, False, False, False),
-        (0.03, False, True, False),
+        (0.1, False, False, False),
+        (0.1, False, True, False),
         (None, True, False, False),
         (None, True, True, False),
         (None, True, True, True),
@@ -177,7 +215,7 @@ def test_gaussian_mixture_model():
     cluster_assignments = dist.Categorical(true_mix_proportions).sample(torch.Size((N,)))
     data = dist.Normal(true_cluster_means[cluster_assignments], 1.0).sample()
     nuts_kernel = NUTS(gmm, max_iarange_nesting=1)
-    mcmc_run = MCMC(nuts_kernel, num_samples=400, warmup_steps=100).run(data)
+    mcmc_run = MCMC(nuts_kernel, num_samples=300, warmup_steps=100).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites=["phi", "cluster_means"]).mean.sort()[0]
     assert_equal(posterior[0], true_mix_proportions, prec=0.05)
     assert_equal(posterior[1], true_cluster_means, prec=0.2)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -192,7 +192,7 @@ def test_gamma_beta():
     true_beta = torch.tensor(1.)
     data = dist.Beta(concentration1=true_alpha, concentration0=true_beta).sample(torch.Size((5000,)))
     nuts_kernel = NUTS(model)
-    mcmc_run = MCMC(nuts_kernel, num_samples=600, warmup_steps=200).run(data)
+    mcmc_run = MCMC(nuts_kernel, num_samples=500, warmup_steps=200).run(data)
     posterior = EmpiricalMarginal(mcmc_run, sites=['alpha', 'beta'])
     assert_equal(posterior.mean, torch.stack([true_alpha, true_beta]), prec=0.05)
 


### PR DESCRIPTION
With the introduction of mass matrix, we have to modify the turning condition. It seems not straightforward, as discussed in section A.4.2. of [A Conceptual Introduction to
Hamiltonian Monte Carlo](https://arxiv.org/abs/1701.02434). I will follow that section for the implementation (and compare the current implementation in Stan).

- [x] Add a flag to eliminate starting point from candidates of a trajectory
- [x] Implement new turning condition
- [x] Test
- [x] Debug the slowness (or why stepsize is so small when adapting)
- [x] Debug: gaussian conjugate tests fail

It would be fun btw. After this, I will add the multinomial sampling option for nuts. Hope that it would not be so complicated. ^^