### PR TITLE
Fix non determinism in HMC / NUTS

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -56,7 +56,6 @@ hyper-parameters) of running HMC on different problems.
 logging.basicConfig(format='%(message)s', level=logging.INFO)
 # Enable validation checks
 pyro.enable_validation(True)
-pyro.set_rng_seed(1)
 DATA_URL = "https://d2fefpcigoriu7.cloudfront.net/datasets/EfronMorrisBB.txt"
 
 
@@ -235,6 +234,7 @@ def evaluate_log_predictive_density(model, model_trace_posterior, baseball_datas
 
 
 def main(args):
+    pyro.set_rng_seed(args.rng_seed)
     baseball_dataset = pd.read_csv(DATA_URL, "\t")
     train, _, player_names = train_test_split(baseball_dataset)
     at_bats, hits = train[:, 0], train[:, 1]

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -156,9 +156,9 @@ class HMC(TraceKernel):
     def _kinetic_energy(self, r):
         r_flat = torch.cat([r[site_name].reshape(-1) for site_name in sorted(r)])
         if self.full_mass:
-            return 0.5 * r_flat.dot(self._inverse_mass_matrix.matmul(r_flat))
+            return 0.5 * (r_flat * (self._inverse_mass_matrix.matmul(r_flat))).sum()
         else:
-            return 0.5 * self._inverse_mass_matrix.dot(r_flat ** 2)
+            return 0.5 * (self._inverse_mass_matrix * (r_flat ** 2)).sum()
 
     def _potential_energy(self, z):
         # Since the model is specified in the constrained space, transform the

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -154,6 +154,8 @@ class HMC(TraceKernel):
         return self._trace_prob_evaluator.log_prob(model_trace)
 
     def _kinetic_energy(self, r):
+        # TODO: revert to `torch.dot` in pytorch==1.0
+        # See: https://github.com/uber/pyro/issues/1458
         r_flat = torch.cat([r[site_name].reshape(-1) for site_name in sorted(r)])
         if self.full_mass:
             return 0.5 * (r_flat * (self._inverse_mass_matrix.matmul(r_flat))).sum()


### PR DESCRIPTION
Fixes the non-deterministic results in #1458, and in HMC/NUTS tests in general. The issue is in `torch.dot` which can give very slightly different results on different runs. This seems to be fixed on master but is an issue with `torch==0.4.0`. I am reverting to using element-wise product + sum, which seems to be stable. We can move to using the dot product in pyro==0.3.0.