### PR TITLE
Guess max_plate_nesting if it is not provided

### DIFF
--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -1,11 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
 import warnings
 from abc import ABCMeta, abstractmethod
 
 from six import add_metaclass
 
 import pyro
+import pyro.poutine as poutine
+from pyro.infer.util import is_validation_enabled
+from pyro.poutine.util import prune_subsample_sites
+from pyro.util import check_site_shape
 
 
 @add_metaclass(ABCMeta)
@@ -23,19 +28,20 @@ class ELBO(object):
     :param num_particles: The number of particles/samples used to form the ELBO
         (gradient) estimators.
     :param int max_plate_nesting: Optional bound on max number of nested
-        :func:`pyro.plate` contexts. This is only required to enumerate over
-        sample sites in parallel, e.g. if a site sets
-        ``infer={"enumerate": "parallel"}``.
+        :func:`pyro.plate` contexts. This is only required when enumerating
+        over sample sites in parallel, e.g. if a site sets
+        ``infer={"enumerate": "parallel"}``. If omitted, ELBO may guess a valid
+        value by running the (model,guide) pair once, however this guess may
+        be incorrect if model or guide structure is dynamic.
     :param bool vectorize_particles: Whether to vectorize the ELBO computation
         over `num_particles`. Defaults to False. This requires static structure
-        in model and guide. In addition, this requires specifying a finite
-        value for `max_plate_nesting`.
+        in model and guide.
     :param bool strict_enumeration_warning: Whether to warn about possible
         misuse of enumeration, i.e. that
         :class:`pyro.infer.traceenum_elbo.TraceEnum_ELBO` is used iff there
         are enumerated sample sites.
-    :param bool retain_graph: Whether to retain autograd graph during an SVI step.
-        Defaults to None (False).
+    :param bool retain_graph: Whether to retain autograd graph during an SVI
+        step. Defaults to None (False).
 
     References
 
@@ -62,13 +68,46 @@ class ELBO(object):
         self.max_plate_nesting = max_plate_nesting
         self.vectorize_particles = vectorize_particles
         self.retain_graph = retain_graph
-        if self.vectorize_particles:
-            if self.num_particles > 1:
-                if self.max_plate_nesting == float('inf'):
-                    raise ValueError("Automatic vectorization over num_particles requires " +
-                                     "a finite value for `max_plate_nesting` arg.")
-                self.max_plate_nesting += 1
+        if self.vectorize_particles and self.num_particles > 1:
+            self.max_plate_nesting += 1
         self.strict_enumeration_warning = strict_enumeration_warning
+
+    def _guess_max_plate_nesting(self, model, guide, *args, **kwargs):
+        """
+        Guesses max_plate_nesting by running the (model,guide) pair once
+        without enumeration. This optimistically assumes static model
+        structure.
+        """
+        # Ignore validation to allow model-enumerated sites absent from the guide.
+        with poutine.block():
+            guide_trace = poutine.trace(guide).get_trace(*args, **kwargs)
+            model_trace = poutine.trace(
+                poutine.replay(model, trace=guide_trace)).get_trace(*args, **kwargs)
+        guide_trace = prune_subsample_sites(guide_trace)
+        model_trace = prune_subsample_sites(model_trace)
+        sites = [site
+                 for trace in (model_trace, guide_trace)
+                 for site in trace.nodes.values()
+                 if site["type"] == "sample"]
+
+        # Validate shapes now, since shape constraints will be weaker once
+        # max_plate_nesting is changed from float('inf') to some finite value.
+        # Here we know the traces are not enumerated, but later we'll need to
+        # allow broadcasting of dims to the left of max_plate_nesting.
+        if is_validation_enabled():
+            guide_trace.compute_log_prob()
+            model_trace.compute_log_prob()
+            for site in sites:
+                check_site_shape(site, max_plate_nesting=float('inf'))
+
+        dims = [frame.dim
+                for site in sites
+                for frame in site["cond_indep_stack"]
+                if frame.vectorized]
+        self.max_plate_nesting = -min(dims) if dims else 0
+        if self.vectorize_particles and self.num_particles > 1:
+            self.max_plate_nesting += 1
+        logging.info('Guessed max_plate_nesting = {}'.format(self.max_plate_nesting))
 
     def _vectorized_num_particles(self, fn):
         """

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -15,10 +15,10 @@ import pyro.ops.jit
 import pyro.poutine as poutine
 from pyro.distributions.torch_distribution import ReshapedDistribution
 from pyro.distributions.util import is_identically_zero, scale_and_mask
-from pyro.ops.contract import contract_tensor_tree, contract_to_tensor
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import get_importance_trace, iter_discrete_escape, iter_discrete_extend
 from pyro.infer.util import Dice, is_validation_enabled
+from pyro.ops.contract import contract_tensor_tree, contract_to_tensor
 from pyro.poutine.enumerate_messenger import EnumerateMessenger
 from pyro.util import check_traceenum_requirements, warn_if_nan
 
@@ -256,6 +256,8 @@ class TraceEnum_ELBO(ELBO):
         Runs the guide and runs the model against the guide with
         the result packaged as a trace generator.
         """
+        if self.max_plate_nesting == float('inf'):
+            self._guess_max_plate_nesting(model, guide, *args, **kwargs)
         if self.vectorize_particles:
             guide = self._vectorized_num_particles(guide)
             model = self._vectorized_num_particles(model)

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -201,9 +201,9 @@ def check_model_guide_match(model_trace, guide_trace, max_plate_nesting=float('i
 
             # Allow broadcasting outside of max_plate_nesting.
             if len(model_shape) > max_plate_nesting:
-                model_shape = model_shape[len(model_shape) - max_plate_nesting:]
+                model_shape = model_shape[len(model_shape) - max_plate_nesting - model_site["fn"].event_dim:]
             if len(guide_shape) > max_plate_nesting:
-                guide_shape = guide_shape[len(guide_shape) - max_plate_nesting:]
+                guide_shape = guide_shape[len(guide_shape) - max_plate_nesting - guide_site["fn"].event_dim:]
             if model_shape == guide_shape:
                 continue
             for model_size, guide_size in zip_longest(reversed(model_shape), reversed(guide_shape), fillvalue=1):

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -133,8 +133,7 @@ def test_avoid_nan(enumerate1):
         with pyro.plate("batch", 3):
             pyro.sample("z", UnsafeBernoulli(p))
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=1,
-                          strict_enumeration_warning=any([enumerate1]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1]))
     loss = elbo.loss(model, guide)
     assert not math.isnan(loss), loss
     loss = elbo.differentiable_loss(model, guide)
@@ -223,8 +222,7 @@ def test_svi_step_smoke(model, guide, enumerate1):
 
     guide = config_enumerate(guide, default=enumerate1)
     optimizer = pyro.optim.Adam({"lr": .001})
-    elbo = TraceEnum_ELBO(max_plate_nesting=1,
-                          strict_enumeration_warning=any([enumerate1]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1]))
     inference = SVI(model, guide, optimizer, loss=elbo)
     inference.step(data)
 
@@ -285,8 +283,7 @@ def test_svi_step_guide_uses_grad(enumerate1):
         pyro.sample("loc", dist.Normal(loc, var))
         pyro.sample("b", dist.Bernoulli(p))
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=1,
-                          strict_enumeration_warning=any([enumerate1]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1]))
     inference = SVI(model, guide, pyro.optim.Adam({}), elbo)
     inference.step()
 
@@ -313,8 +310,7 @@ def test_elbo_bern(method, enumerate1, scale):
         with pyro.plate("particles", num_particles):
             pyro.sample("z", dist.Bernoulli(q).expand_by([num_particles]))
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=1,
-                          strict_enumeration_warning=any([enumerate1]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1]))
 
     if method == "loss":
         actual = elbo.loss(model, guide) / num_particles
@@ -356,8 +352,7 @@ def test_elbo_normal(method, enumerate1):
         with pyro.plate("particles", num_particles):
             pyro.sample("z", dist.Normal(q, 1.).expand_by([num_particles]))
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=1,
-                          strict_enumeration_warning=any([enumerate1]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1]))
 
     if method == "loss":
         actual = elbo.loss(model, guide) / num_particles
@@ -420,8 +415,7 @@ def test_elbo_bern_bern(method, enumerate1, enumerate2, num_samples1, num_sample
     expected_loss = kl.item()
     expected_grad = grad(kl, [q])[0]
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=0,
-                          num_particles=num_particles,
+    elbo = TraceEnum_ELBO(num_particles=num_particles,
                           vectorize_particles=True,
                           strict_enumeration_warning=any([enumerate1, enumerate2]))
     if method == "differentiable_loss":
@@ -467,8 +461,7 @@ def test_elbo_berns(method, enumerate1, enumerate2, enumerate3):
     expected_loss = kl.item()
     expected_grad = grad(kl, [q])[0]
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=0,
-                          num_particles=num_particles,
+    elbo = TraceEnum_ELBO(num_particles=num_particles,
                           vectorize_particles=True,
                           strict_enumeration_warning=any([enumerate1, enumerate2, enumerate3]))
     if method == "differentiable_loss":
@@ -559,8 +552,7 @@ def test_elbo_normals(method, enumerate1, enumerate2, enumerate3):
     expected_loss = kl.item()
     expected_grad = grad(kl, [q])[0]
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=0,
-                          num_particles=num_particles,
+    elbo = TraceEnum_ELBO(num_particles=num_particles,
                           vectorize_particles=True,
                           strict_enumeration_warning=any([enumerate1, enumerate2, enumerate3]))
     if method == "differentiable_loss":
@@ -609,8 +601,7 @@ def test_elbo_plate(plate_dim, enumerate1, enumerate2):
     expected_loss = kl.item()
     expected_grad = grad(kl, [q])[0]
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=2,
-                          strict_enumeration_warning=any([enumerate1, enumerate2]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1, enumerate2]))
     actual_loss = elbo.loss_and_grads(model, guide) / num_particles
     actual_grad = pyro.param('q').grad / num_particles
 
@@ -629,7 +620,7 @@ def test_elbo_plate(plate_dim, enumerate1, enumerate2):
 @pytest.mark.parametrize("irange_dim", [1, 2])
 def test_elbo_irange(irange_dim, enumerate1, enumerate2):
     pyro.clear_param_store()
-    num_particles = 1 if all([enumerate1, enumerate2]) else 10000
+    num_particles = 1 if all([enumerate1, enumerate2]) else 20000
     q = pyro.param("q", torch.tensor(0.75, requires_grad=True))
     p = 0.2693204236205713  # for which kl(Bernoulli(q), Bernoulli(p)) = 0.5
 
@@ -652,8 +643,7 @@ def test_elbo_irange(irange_dim, enumerate1, enumerate2):
     expected_loss = kl.item()
     expected_grad = grad(kl, [q])[0]
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=1,
-                          strict_enumeration_warning=any([enumerate1, enumerate2]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1, enumerate2]))
     actual_loss = elbo.loss_and_grads(model, guide) / num_particles
     actual_grad = pyro.param('q').grad / num_particles
 
@@ -708,8 +698,7 @@ def test_elbo_plate_plate(outer_dim, inner_dim, enumerate1, enumerate2, enumerat
     expected_loss = kl.item()
     expected_grad = grad(kl, [q])[0]
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=3,
-                          num_particles=num_particles,
+    elbo = TraceEnum_ELBO(num_particles=num_particles,
                           vectorize_particles=True,
                           strict_enumeration_warning=any([enumerate1, enumerate2, enumerate3]))
     actual_loss = elbo.loss_and_grads(model, guide)
@@ -760,8 +749,7 @@ def test_elbo_plate_irange(outer_dim, inner_dim, enumerate1, enumerate2, enumera
     expected_loss = kl.item()
     expected_grad = grad(kl, [q])[0]
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=2,
-                          strict_enumeration_warning=any([enumerate1, enumerate2, enumerate3]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1, enumerate2, enumerate3]))
     actual_loss = elbo.loss_and_grads(model, guide) / num_particles
     actual_grad = pyro.param('q').grad / num_particles
 
@@ -812,8 +800,7 @@ def test_elbo_irange_plate(outer_dim, inner_dim, enumerate1, enumerate2, enumera
     expected_loss = kl.item()
     expected_grad = grad(kl, [q])[0]
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=2,
-                          strict_enumeration_warning=any([enumerate1, enumerate2, enumerate3]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1, enumerate2, enumerate3]))
     actual_loss = elbo.loss_and_grads(model, guide) / num_particles
     actual_grad = pyro.param('q').grad / num_particles
 
@@ -864,8 +851,7 @@ def test_elbo_irange_irange(outer_dim, inner_dim, enumerate1, enumerate2, enumer
     expected_loss = kl.item()
     expected_grad = grad(kl, [q])[0]
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=1,
-                          strict_enumeration_warning=any([enumerate1, enumerate2, enumerate3]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1, enumerate2, enumerate3]))
     actual_loss = elbo.loss_and_grads(model, guide) / num_particles
     actual_grad = pyro.param('q').grad / num_particles
 
@@ -899,8 +885,7 @@ def test_non_mean_field_bern_bern_elbo_gradient(enumerate1, pi1, pi2):
             pyro.sample("z", dist.Bernoulli(q2 * y + 0.10))
 
     logger.info("Computing gradients using surrogate loss")
-    elbo = TraceEnum_ELBO(max_plate_nesting=1,
-                          strict_enumeration_warning=any([enumerate1]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1]))
     elbo.loss_and_grads(model, config_enumerate(guide, default=enumerate1))
     actual_grad_q1 = pyro.param('q1').grad / num_particles
     actual_grad_q2 = pyro.param('q2').grad / num_particles
@@ -955,8 +940,7 @@ def test_non_mean_field_bern_normal_elbo_gradient(enumerate1, pi1, pi2, pi3, num
                 pyro.sample("z", dist.Normal(q2 * y + 0.10, 1.0))
 
     logger.info("Computing gradients using surrogate loss")
-    elbo = TraceEnum_ELBO(max_plate_nesting=1,
-                          strict_enumeration_warning=any([enumerate1]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1]))
     elbo.loss_and_grads(model, guide)
     actual_grad_q1 = pyro.param('q1').grad / num_particles
     if include_z:
@@ -1018,8 +1002,7 @@ def test_non_mean_field_normal_bern_elbo_gradient(pi1, pi2, pi3):
 
     for ed, num_particles in zip([None, 'parallel', 'sequential'], [30000, 20000, 20000]):
         pyro.clear_param_store()
-        elbo = TraceEnum_ELBO(max_plate_nesting=1,
-                              strict_enumeration_warning=any([ed]))
+        elbo = TraceEnum_ELBO(strict_enumeration_warning=any([ed]))
         elbo.loss_and_grads(model, config_enumerate(guide, default=ed), num_particles)
         results[str(ed)] = {}
         for q in qs:
@@ -1060,8 +1043,7 @@ def test_elbo_rsvi(enumerate1):
             pyro.sample("z", dist.Bernoulli(q).expand_by([num_particles]))
             pyro.sample("y", ShapeAugmentedGamma(a, torch.tensor(1.0)).expand_by([num_particles]))
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=1,
-                          strict_enumeration_warning=any([enumerate1]))
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=any([enumerate1]))
     elbo.loss_and_grads(model, guide)
 
     actual_q = q.grad / num_particles
@@ -1117,7 +1099,7 @@ def test_elbo_hmm_in_model(enumerate1, num_steps, expand):
         for i in range(num_steps):
             pyro.sample("x_{}".format(i), dist.Categorical(mean_field_probs[i]))
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=0)
+    elbo = TraceEnum_ELBO()
     elbo.loss_and_grads(model, guide, data)
 
     expected_unconstrained_grads = {
@@ -1179,7 +1161,7 @@ def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):
             probs = init_probs if x is None else transition_probs[x]
             x = pyro.sample("x_{}".format(i), dist.Categorical(probs))
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=0)
+    elbo = TraceEnum_ELBO()
     elbo.loss_and_grads(model, guide, data)
 
     # These golden values simply test agreement between parallel and sequential.
@@ -1242,7 +1224,7 @@ def test_hmm_enumerate_model(num_steps):
     def guide(data):
         pass
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=0)
+    elbo = TraceEnum_ELBO()
     elbo.differentiable_loss(model, guide, data)
 
 
@@ -1272,7 +1254,7 @@ def test_hmm_enumerate_model_and_guide(num_steps):
         pyro.sample("x", dist.Categorical(init_probs),
                     infer={"enumerate": "parallel"})
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=0)
+    elbo = TraceEnum_ELBO()
     elbo.differentiable_loss(model, guide, data)
 
 
@@ -1332,7 +1314,7 @@ def test_elbo_enumerate_1(scale):
         probs_x = pyro.param("guide_probs_x")
         pyro.sample("x", dist.Categorical(probs_x))
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=0, strict_enumeration_warning=False)
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=False)
     auto_loss = elbo.differentiable_loss(auto_model, guide)
     hand_loss = elbo.differentiable_loss(hand_model, guide)
     _check_loss_and_grads(hand_loss, auto_loss)
@@ -1378,7 +1360,7 @@ def test_elbo_enumerate_2(scale):
         probs_x = pyro.param("guide_probs_x")
         pyro.sample("x", dist.Categorical(probs_x))
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=0, strict_enumeration_warning=False)
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=False)
     auto_loss = elbo.differentiable_loss(auto_model, guide)
     hand_loss = elbo.differentiable_loss(hand_model, guide)
     _check_loss_and_grads(hand_loss, auto_loss)
@@ -1423,7 +1405,7 @@ def test_elbo_enumerate_3(scale):
         probs_x = pyro.param("guide_probs_x")
         pyro.sample("x", dist.Categorical(probs_x))
 
-    elbo = TraceEnum_ELBO(max_plate_nesting=0, strict_enumeration_warning=False)
+    elbo = TraceEnum_ELBO(strict_enumeration_warning=False)
     auto_loss = elbo.differentiable_loss(auto_model, guide)
     hand_loss = elbo.differentiable_loss(hand_model, guide)
     _check_loss_and_grads(hand_loss, auto_loss)

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -117,7 +117,8 @@ def test_plate(Elbo, reparameterized):
         pyro.sample("nuisance_a", Normal(0, 1))
 
     optim = Adam({"lr": 0.1})
-    inference = SVI(model, guide, optim, loss=Elbo(strict_enumeration_warning=False))
+    elbo = Elbo(max_plate_nesting=2, strict_enumeration_warning=False)
+    inference = SVI(model, guide, optim, loss=elbo)
     inference.loss_and_grads(model, guide)
     params = dict(pyro.get_param_store().named_parameters())
     actual_grads = {name: param.grad.detach().cpu().numpy() / num_particles


### PR DESCRIPTION
Resolves #1455 
Blocked by #1464 

This eliminates the need for users to specify the `max_plate_nesting` arg to `ELBO` in cases where model and guide structure are static (or at least max plate nesting is static). The guesswork has low overhead: it runs the (model,guide) pair only on the first SVI.step(), it samples rather than enumerates, it does not use num_particles, and it avoids computing log_prob if validation is disabled. For future JIT compatibility, we may need to later avoid jitting until `max_plate_nesting` is known.

## Tested

- [x] updated test_valid_models.py
- [x] removed `max_plate_nesting` arg from many tests in tests/infer/test_enum.py
- [ ] update tensor shapes tutorial