### PR TITLE
Fix RNG seed for all doctest runs

### DIFF
--- a/tests/doctest_fixtures.py
+++ b/tests/doctest_fixtures.py
@@ -12,6 +12,10 @@ from pyro.infer.mcmc import HMC, MCMC, NUTS
 from pyro.params import param_with_module_name
 
 
+# Fix seed for all doctest runs.
+pyro.set_rng_seed(0)
+
+
 @pytest.fixture(autouse=True)
 def add_imports(doctest_namespace):
     doctest_namespace['dist'] = dist


### PR DESCRIPTION
As pointed out by @fritzo in #1458, our doctest stage is randomly failing on CI ([example](https://travis-ci.org/uber/pyro/jobs/443805194)). This is to make our doctest suite deterministic, by fixing the seed before each doctest invocation.