### PR TITLE
Add plate magic for autoname and subsampling

### DIFF
--- a/tests/infer/test_plate.py
+++ b/tests/infer/test_plate.py
@@ -30,18 +30,18 @@ def test_no_plate():
         scale = pyro.param("prior_scale", torch.tensor(1.))
         assert scale.shape == ()
         for i in range(len(data)):
-            loc = pyro.param("prior_loc_{}".format(i), torch.tensor(0.))
-            z = pyro.sample("z_{}".format(i), dist.Normal(loc, 1.0))
-            x = pyro.sample("x_{}".format(i), dist.Normal(z, scale), obs=data[i])
+            loc = pyro.param("prior_loc", torch.tensor(0.))
+            z = pyro.sample("z", dist.Normal(loc, 1.0))
+            x = pyro.sample("x", dist.Normal(z, scale), obs=data[i])
             assert loc.shape == ()
             assert z.shape == ()
             assert x.shape == ()
 
     def guide():
         for i in range(len(data)):
-            loc = pyro.param("post_loc_{}".format(i), torch.tensor(0.))
-            scale = pyro.param("post_scale_{}".format(i), torch.tensor(1.))
-            z = pyro.sample("z_{}".format(i), dist.Normal(loc, scale))
+            loc = pyro.param("post_loc", torch.tensor(0.))
+            scale = pyro.param("post_scale", torch.tensor(1.))
+            z = pyro.sample("z", dist.Normal(loc, scale))
             assert loc.shape == ()
             assert scale.shape == ()
             assert z.shape == ()
@@ -55,18 +55,18 @@ def test_plate_sequential():
         scale = pyro.param("prior_scale", torch.tensor(1.))
         assert scale.shape == ()
         for i in pyro.plate("plate", len(data)):
-            loc = pyro.param("prior_loc_{}".format(i), torch.tensor(0.))
-            z = pyro.sample("z_{}".format(i), dist.Normal(loc, 1.0))
-            x = pyro.sample("x_{}".format(i), dist.Normal(z, scale), obs=data[i])
+            loc = pyro.param("prior_loc", torch.tensor(0.))
+            z = pyro.sample("z", dist.Normal(loc, 1.0))
+            x = pyro.sample("x", dist.Normal(z, scale), obs=data[i])
             assert loc.shape == ()
             assert z.shape == ()
             assert x.shape == ()
 
     def guide():
         for i in pyro.plate("plate", len(data)):
-            loc = pyro.param("post_loc_{}".format(i), torch.tensor(0.))
-            scale = pyro.param("post_scale_{}".format(i), torch.tensor(1.))
-            z = pyro.sample("z_{}".format(i), dist.Normal(loc, scale))
+            loc = pyro.param("post_loc", torch.tensor(0.))
+            scale = pyro.param("post_scale", torch.tensor(1.))
+            z = pyro.sample("z", dist.Normal(loc, scale))
             assert loc.shape == ()
             assert scale.shape == ()
             assert z.shape == ()
@@ -80,18 +80,18 @@ def test_plate_sequential_subsample(subsample_size=2):
         scale = pyro.param("prior_scale", torch.tensor(1.))
         assert scale.shape == ()
         for i in pyro.plate("plate", len(data)):
-            loc = pyro.param("prior_loc_{}".format(i), torch.tensor(0.))
-            z = pyro.sample("z_{}".format(i), dist.Normal(loc, 1.0))
-            x = pyro.sample("x_{}".format(i), dist.Normal(z, scale), obs=data[i])
+            loc = pyro.param("prior_loc", torch.tensor(0.))
+            z = pyro.sample("z", dist.Normal(loc, 1.0))
+            x = pyro.sample("x", dist.Normal(z, scale), obs=data[i])
             assert loc.shape == ()
             assert z.shape == ()
             assert x.shape == ()
 
     def guide():
         for i in pyro.plate("plate", len(data), subsample_size=subsample_size):
-            loc = pyro.param("post_loc_{}".format(i), torch.tensor(0.))
-            scale = pyro.param("post_scale_{}".format(i), torch.tensor(1.))
-            z = pyro.sample("z_{}".format(i), dist.Normal(loc, scale))
+            loc = pyro.param("post_loc", torch.tensor(0.))
+            scale = pyro.param("post_scale", torch.tensor(1.))
+            z = pyro.sample("z", dist.Normal(loc, scale))
             assert loc.shape == ()
             assert scale.shape == ()
             assert z.shape == ()
@@ -105,7 +105,7 @@ def test_plate_parallel():
         scale = pyro.param("prior_scale", torch.tensor(1.))
         assert scale.shape == ()
         with pyro.plate("plate", len(data)):
-            loc = pyro.param("prior_loc", torch.tensor(0.).expand(len(data)))
+            loc = pyro.param("prior_loc", torch.tensor(0.))
             z = pyro.sample("z", dist.Normal(loc, scale))
             x = pyro.sample("x", dist.Normal(z, scale), obs=data)
             assert loc.shape == (len(data),)
@@ -114,8 +114,8 @@ def test_plate_parallel():
 
     def guide():
         with pyro.plate("plate", len(data)):
-            scale = pyro.param("post_scale", torch.tensor(1.).expand(len(data)))
-            loc = pyro.param("post_loc", torch.tensor(0.).expand(len(data)))
+            scale = pyro.param("post_scale", torch.tensor(1.))
+            loc = pyro.param("post_loc", torch.tensor(0.))
             z = pyro.sample("z", dist.Normal(loc, scale))
             assert scale.shape == (len(data),)
             assert loc.shape == (len(data),)
@@ -130,7 +130,7 @@ def test_plate_parallel_subsample(subsample_size=2):
         scale = pyro.param("prior_scale", torch.tensor(1.))
         assert scale.shape == ()
         with pyro.plate("plate", len(data)) as ind:
-            loc = pyro.param("prior_loc", torch.tensor(0.).expand(len(data)))[ind]
+            loc = pyro.param("prior_loc", torch.tensor(0.))
             z = pyro.sample("z", dist.Normal(loc, scale))
             x = pyro.sample("x", dist.Normal(z, scale), obs=data[ind])
             assert loc.shape == (subsample_size,)
@@ -138,9 +138,9 @@ def test_plate_parallel_subsample(subsample_size=2):
             assert x.shape == (subsample_size,)
 
     def guide():
-        with pyro.plate("plate", len(data), subsample_size=2) as ind:
-            scale = pyro.param("post_scale", torch.tensor(1.).expand(len(data)))[ind]
-            loc = pyro.param("post_loc", torch.tensor(0.).expand(len(data)))[ind]
+        with pyro.plate("plate", len(data), subsample_size=2):
+            scale = pyro.param("post_scale", torch.tensor(1.))
+            loc = pyro.param("post_loc", torch.tensor(0.))
             z = pyro.sample("z", dist.Normal(loc, scale))
             assert scale.shape == (subsample_size,)
             assert loc.shape == (subsample_size,)
@@ -155,7 +155,7 @@ def test_plate_parallel_autoguide():
         scale = pyro.param("prior_scale", torch.tensor(1.))
         assert scale.shape == ()
         with pyro.plate("plate", len(data)):
-            loc = pyro.param("prior_loc", torch.tensor(0.).expand(len(data)))
+            loc = pyro.param("prior_loc", torch.tensor(0.))
             z = pyro.sample("z", dist.Normal(loc, scale))
             x = pyro.sample("x", dist.Normal(z, scale), obs=data)
             assert loc.shape == (len(data),)
@@ -205,12 +205,12 @@ def test_plate_sequential_nested():
         x_plate = pyro.plate("x_plate", x_size)
         y_plate = pyro.plate("y_plate", y_size)
         for i in x_plate:
-            pyro.sample("x_{}".format(i), dist.Normal(0., scale), obs=x_data[i])
+            pyro.sample("x", dist.Normal(0., scale), obs=x_data[i])
         for j in y_plate:
-            pyro.sample("y_{}".format(j), dist.Normal(0., scale), obs=y_data[j])
+            pyro.sample("y", dist.Normal(0., scale), obs=y_data[j])
         for i in x_plate:
             for j in y_plate:
-                pyro.sample("z_{}_{}".format(i, j), dist.Normal(0., scale), obs=xy_data[i, j])
+                pyro.sample("z", dist.Normal(0., scale), obs=xy_data[i, j])
 
     def guide():
         pass


### PR DESCRIPTION
DO NOT MERGE - for discussion only
Addresses discussion arising from #238 #1465, based on #1486 

This PR demonstrates possible syntax changes to `plate`. I have not implemented the changes, only update tests to see what the new syntax would look like.

## Questions for reviewers

- [ ] Is this the syntax we want?
- [ ] What potential issues might arise?

## Tasks

- [x] Update plate tests
- [ ] Update all other tests
- [ ] Implement autoname behavior for `param`
- [ ] Implement autoname behavior for `sample`
- [ ] Implement subsample behavior for `param`