### PR TITLE
Refactor sum_dims to be a set rather than dict

### DIFF
--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -66,7 +66,7 @@ class TraceTreeEvaluator(object):
         enum_dims = set((i for i in range(-len(log_prob_shape), -self.max_plate_nesting)
                          if log_prob_shape[i] > 1))
         self._plate_dims[ordinal] = plate_dims
-        self._enum_dims[ordinal] = sorted(enum_dims - parent_enum_dims)
+        self._enum_dims[ordinal] = set(enum_dims - parent_enum_dims)
         for c in self._children[ordinal]:
             self._populate_cache(c, ordinal, enum_dims)
 
@@ -205,5 +205,5 @@ class TraceEinsumEvaluator(object):
             return model_trace.log_prob_sum()
         with shared_intermediates():
             log_probs = self._get_log_factors(model_trace)
-            sum_dims = {model_trace.nodes[name]["log_prob"]: dims for name, dims in self._enum_dims.items()}
+            sum_dims = set.union(*self._enum_dims.values())
             return contract_to_tensor(log_probs, sum_dims, frozenset())

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -198,9 +198,7 @@ EXAMPLES = [
 def test_contract_to_tensor(example):
     tensor_tree = OrderedDict((frozenset(t), [torch.randn(shape) for shape in shapes])
                               for t, shapes in example['shape_tree'].items())
-    sum_dims = {x: set(d for d in example['sum_dims'] if -d <= x.dim() and x.shape[d] > 1)
-                for terms in tensor_tree.values()
-                for x in terms}
+    sum_dims = set(example['sum_dims'])
     target_ordinal = frozenset(example['target_ordinal'])
     expected_shape = example['expected_shape']
 
@@ -212,9 +210,7 @@ def test_contract_to_tensor(example):
 def test_contract_tensor_tree(example):
     tensor_tree = OrderedDict((frozenset(t), [torch.randn(shape) for shape in shapes])
                               for t, shapes in example['shape_tree'].items())
-    sum_dims = {x: set(d for d in example['sum_dims'] if -d <= x.dim() and x.shape[d] > 1)
-                for terms in tensor_tree.values()
-                for x in terms}
+    sum_dims = set(example['sum_dims'])
 
     actual = assert_immutable(contract_tensor_tree)(tensor_tree, sum_dims)
     assert actual
@@ -235,7 +231,7 @@ def test_contract_to_tensor_sizes(a, b, c, d):
     tensor_tree = OrderedDict([(frozenset([frame(-2, c)]), [X]),
                                (frozenset(), [Y]),
                                (frozenset([frame(-1, d)]), [Z])])
-    sum_dims = {X: {-4}, Y: {-4, -3}, Z: {-3}}
+    sum_dims = {-4, -3}
 
     target_ordinal = frozenset()
     actual = contract_to_tensor(tensor_tree, sum_dims, target_ordinal)


### PR DESCRIPTION
This pure-refactoring PR prepares for #1460.
- Before this PR, `sum_dims` was a dict mapping each tensor to the set of dims in that tensor that should be sum-contracted out.
- After this PR, `sum_dims` is simply the set of all dims to be sum-contracted out.

@eb8680 this will conflict with your [collapse-messenger](https://github.com/uber/pyro/compare/collapse-messenger) branch; you should be able to resolve easily by looking at the changes to `BackwardSampleMessenger`.

## Tested

- refactoring is exercised by existing tests