### PR TITLE
Use outer product instead of matmul in welford algorithm

### DIFF
--- a/pyro/ops/welford.py
+++ b/pyro/ops/welford.py
@@ -29,7 +29,7 @@ class WelfordCovariance(object):
         if self.diagonal:
             self._m2 += delta_pre * delta_post
         else:
-            self._m2 += torch.matmul(delta_post.unsqueeze(-1), delta_pre.unsqueeze(-2))
+            self._m2 += torch.ger(delta_post, delta_pre)
 
     def get_covariance(self, regularize=True):
         if self.n_samples < 2:


### PR DESCRIPTION
Using `torch.ger` is more computationally efficient than `matmul` for computing outer product in the welford scheme, an online algorithm for computing covariance (used in HMC/NUTS for mass matrix estimation).