### PR TITLE
remove numpy usage in main package

### DIFF
--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import math
 import torch
-import numpy as np
 
 import pyro
 from pyro import poutine
@@ -127,7 +127,7 @@ def naive_rainforth_eig(model, design, observation_labels, target_labels=None,
         retrace = poutine.trace(conditional_model).get_trace(reexpanded_design)
         retrace.compute_log_prob()
         conditional_lp = logsumexp(sum(retrace.nodes[l]["log_prob"] for l in observation_labels), 0) \
-            - np.log(M_prime)
+            - math.log(M_prime)
     else:
         # This assumes that y are independent conditional on theta
         # Furthermore assume that there are no other variables besides theta
@@ -142,7 +142,7 @@ def naive_rainforth_eig(model, design, observation_labels, target_labels=None,
     retrace = poutine.trace(conditional_model).get_trace(reexpanded_design)
     retrace.compute_log_prob()
     marginal_lp = logsumexp(sum(retrace.nodes[l]["log_prob"] for l in observation_labels), 0) \
-        - np.log(M)
+        - math.log(M)
 
     return (conditional_lp - marginal_lp).sum(0)/N
 
@@ -298,7 +298,7 @@ def donsker_varadhan_loss(model, T, observation_labels, target_labels):
 
         joint_expectation = T_joint.sum(0)/num_particles
 
-        A = T_independent - np.log(num_particles)
+        A = T_independent - math.log(num_particles)
         s, _ = torch.max(A, dim=0)
         independent_expectation = s + ewma_log((A - s).exp().sum(dim=0), s)
 

--- a/pyro/contrib/oed/util.py
+++ b/pyro/contrib/oed/util.py
@@ -20,10 +20,10 @@ def linear_model_ground_truth(model, design, observation_labels, target_labels, 
     target_posterior_covs = [S[target_indices, :][:, target_indices] for S in posterior_covs]
     if eig:
         prior_entropy = lm_H_prior(model, design, observation_labels, target_labels)
-        return prior_entropy - torch.tensor([0.5*torch.logdet(2 * math.pi * math.e *C)
+        return prior_entropy - torch.tensor([0.5 * torch.logdet(2 * math.pi * math.e * C)
                                              for C in target_posterior_covs])
     else:
-        return torch.tensor([0.5*torch.logdet(2 * math.pi * math.e * C)
+        return torch.tensor([0.5 * torch.logdet(2 * math.pi * math.e * C)
                              for C in target_posterior_covs])
 
 

--- a/pyro/contrib/oed/util.py
+++ b/pyro/contrib/oed/util.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import math
 import torch
-import numpy as np
 
 import pyro
 from pyro.contrib.util import get_indices, lexpand
@@ -20,9 +20,11 @@ def linear_model_ground_truth(model, design, observation_labels, target_labels, 
     target_posterior_covs = [S[target_indices, :][:, target_indices] for S in posterior_covs]
     if eig:
         prior_entropy = lm_H_prior(model, design, observation_labels, target_labels)
-        return prior_entropy - torch.tensor([0.5*torch.logdet(2*np.pi*np.e*C) for C in target_posterior_covs])
+        return prior_entropy - torch.tensor([0.5*torch.logdet(2 * math.pi * math.e *C)
+                                             for C in target_posterior_covs])
     else:
-        return torch.tensor([0.5*torch.logdet(2*np.pi*np.e*C) for C in target_posterior_covs])
+        return torch.tensor([0.5*torch.logdet(2 * math.pi * math.e * C)
+                             for C in target_posterior_covs])
 
 
 def lm_H_prior(model, design, observation_labels, target_labels):
@@ -33,7 +35,7 @@ def lm_H_prior(model, design, observation_labels, target_labels):
     prior_cov = torch.diag(w_sd**2)
     target_indices = get_indices(target_labels, tensors=model.w_sds)
     target_prior_covs = prior_cov[target_indices, :][:, target_indices]
-    return 0.5*torch.logdet(2*np.pi*np.e*target_prior_covs)
+    return 0.5*torch.logdet(2 * math.pi * math.e * target_prior_covs)
 
 
 def mc_H_prior(model, design, observation_labels, target_labels, num_samples=1000):

--- a/pyro/ops/einsum/paths.py
+++ b/pyro/ops/einsum/paths.py
@@ -4,7 +4,7 @@ import heapq
 import itertools
 from collections import defaultdict
 
-import numpy as np
+import torch
 
 
 def ssa_to_linear(ssa_path):
@@ -15,7 +15,7 @@ def ssa_to_linear(ssa_path):
         >>> ssa_to_linear([(0, 3), (2, 4), (1, 5)])
         [(0, 3), (1, 2), (0, 1)]
     """
-    ids = np.arange(1 + max(map(max, ssa_path)), dtype=np.int32)
+    ids = torch.arange(1 + max(map(max, ssa_path)), dtype=torch.long)
     path = []
     for ssa_ids in ssa_path:
         path.append(tuple(int(ids[ssa_id]) for ssa_id in ssa_ids))

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ long_description = '\n'.join(
 EXTRAS_REQUIRE = [
     'jupyter>=1.0.0',
     'matplotlib>=1.3',
+    'numpy>=1.7',
     'observations>=0.1.4',
     'pillow',
     'torchvision',
@@ -80,7 +81,6 @@ setup(
         'contextlib2',
         'graphviz>=0.8',
         'networkx>=2.2',
-        'numpy>=1.7',
         'opt_einsum>=2.2.0',
         'six>=1.10.0',
         'torch==0.4.0',


### PR DESCRIPTION
Given that most numeric calculations can be done with pytorch, we should avoid relying on `numpy` if possible.