### PR TITLE
Return a deterministic trace generator when using HMC with parallel chains

### DIFF
--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -35,7 +35,7 @@ def logger_thread(log_queue, warmup_steps, num_samples, num_chains):
     try:
         while True:
             try:
-                record = log_queue.get_nowait()
+                record = log_queue.get(1)
             except queue.Empty:
                 continue
             if record is None:
@@ -154,7 +154,7 @@ class _ParallelSampler(TracePosterior):
                 w.start()
             while active_workers:
                 try:
-                    chain_id, val = self.result_queue.get_nowait()
+                    chain_id, val = self.result_queue.get(1)
                 # This can happen when the worker process has terminated.
                 # See https://github.com/pytorch/pytorch/pull/5380 for motivation.
                 except socket.error as e:

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -35,7 +35,7 @@ def logger_thread(log_queue, warmup_steps, num_samples, num_chains):
     try:
         while True:
             try:
-                record = log_queue.get(1)
+                record = log_queue.get_nowait()
             except queue.Empty:
                 continue
             if record is None:
@@ -154,7 +154,7 @@ class _ParallelSampler(TracePosterior):
                 w.start()
             while active_workers:
                 try:
-                    chain_id, val = self.result_queue.get(1)
+                    chain_id, val = self.result_queue.get_nowait()
                 # This can happen when the worker process has terminated.
                 # See https://github.com/pytorch/pytorch/pull/5380 for motivation.
                 except socket.error as e:


### PR DESCRIPTION
Fixes #1505. 

While each of the workers in `mcmc._ParallelSampler` returns deterministic outputs, the order of the traces returned by `_ParallelSampler._traces` generator is non-deterministic (it depends on how fast/slow each of the workers is). This gives deterministic stats on the latents, but non-deterministic results when the `TracePosterior` object is consumed by `TracePredictive`.

As a solution, we are yielding traces from each of the chains in a round-robin fashion and using a queue to hold the intermediate traces from the workers. 

Note that this is not a final interface and may need a slight refactoring (or more design discussion) when we would like to compute and provide diagnostics that need chain information. In that case, we may have to provide an optional chain id to the parent `TracePosterior` class.