### PR TITLE
Fix remaining issues in ubersum

### DIFF
--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -206,4 +206,4 @@ class TraceEinsumEvaluator(object):
         with shared_intermediates():
             log_probs = self._get_log_factors(model_trace)
             sum_dims = set.union(*self._enum_dims.values())
-            return contract_to_tensor(log_probs, sum_dims, frozenset())
+            return contract_to_tensor(log_probs, sum_dims)

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -151,9 +151,9 @@ def _compute_marginals(model_trace, guide_trace):
                 continue
 
             enum_dim = site["fn"].event_dim - site["value"].dim()
-            site_sum_dims = sum_dims - {enum_dim}
             ordinal = frozenset(f for f in site["cond_indep_stack"] if f.vectorized)
-            logits = contract_to_tensor(log_factors, site_sum_dims, ordinal, cache=cache)
+            logits = contract_to_tensor(log_factors, sum_dims,
+                                        target_ordinal=ordinal, target_dims={enum_dim}, cache=cache)
             logits = logits.unsqueeze(-1).transpose(-1, enum_dim - 1)
             while logits.shape[0] == 1:
                 logits.squeeze_(0)
@@ -188,10 +188,10 @@ class BackwardSampleMessenger(pyro.poutine.messenger.Messenger):
         if enum_dim is not None:
             msg["infer"]["_enumerate_dim"] = enum_dim
             assert enum_dim < 0, "{} {}".format(msg["name"], enum_dim)
-            self.sum_dims.discard(enum_dim)
             with shared_intermediates(self.cache) as cache:
                 ordinal = frozenset(f for f in msg["cond_indep_stack"] if f.vectorized)
-                logits = contract_to_tensor(self.log_factors, self.sum_dims, ordinal, cache=cache)
+                logits = contract_to_tensor(self.log_factors, self.sum_dims,
+                                            target_ordinal=ordinal, target_dims={enum_dim}, cache=cache)
                 logits = logits.unsqueeze(-1).transpose(-1, enum_dim - 1)
                 while logits.shape[0] == 1:
                     logits.squeeze_(0)
@@ -208,6 +208,7 @@ class BackwardSampleMessenger(pyro.poutine.messenger.Messenger):
                             value_ = value_.index_select(enum_dim, value_.new_tensor([0], dtype=torch.long))
                             sampled_term = term_.gather(enum_dim, value_.long())
                             terms[i] = sampled_term
+                self.sum_dims.discard(enum_dim)
 
 
 class TraceEnum_ELBO(ELBO):

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -512,32 +512,32 @@ def ubersum(equation, *operands, **kwargs):
     To illustrate batched inputs, note that the following are equivalent::
 
         assert len(x) == 3 and len(y) == 3
-        z = ubersum('c,abc,acd->bd', w, x, y, batch_dims='a')
+        z = ubersum('ab,ai,bi->b', w, x, y, batch_dims='i')
 
-        z = contract('c,bc,bc,bc,cd,cd,cd->bd', w, *x, *y, backend=backend)
+        z = contract('ab,a,a,a,b,b,b->b', w, *x, *y, backend=backend)
 
-    When a non-batch dimension `i` always appears with a batch dimension `a`,
-    then `i` corresponds to a distinct symbol for each slice of `a`. Thus
+    When a sum dimension `a` always appears with a batch dimension `i`,
+    then `a` corresponds to a distinct symbol for each slice of `a`. Thus
     the following are equivalent::
 
         assert len(x) == 3 and len(y) == 3
-        z = ubersum('abi,abi->', x, y, batch_dims='a')
+        z = ubersum('ai,ai->', x, y, batch_dims='i')
 
-        z = contract('bi,bj,bk,bi,bj,bk->', *x, *y, backend=backend)
+        z = contract('a,b,c,a,b,c->', *x, *y, backend=backend)
 
-    When such a non-batched dimension appears in the output, it must be
+    When such a sum dimension appears in the output, it must be
     accompanied by all of its batch dimensions, e.g. the following are
     equivalent::
 
         assert len(x) == 3 and len(y) == 3
-        z = ubersum('abi,abi->ai', x, y, batch_dims='a')
+        z = ubersum('abi,abi->bi', x, y, batch_dims='i')
 
-        z0 = contract('bi,bj,bk,bi,bj,bk->i', *x, *y, backend=backend)
-        z1 = contract('bi,bj,bk,bi,bj,bk->j', *x, *y, backend=backend)
-        z2 = contract('bi,bj,bk,bi,bj,bk->k', *x, *y, backend=backend)
+        z0 = contract('ab,ac,ad,ab,ac,ad->b', *x, *y, backend=backend)
+        z1 = contract('ab,ac,ad,ab,ac,ad->c', *x, *y, backend=backend)
+        z2 = contract('ab,ac,ad,ab,ac,ad->d', *x, *y, backend=backend)
         z = torch.stack([z0, z1, z2])
 
-    Among all valid inputs, some computations are polynomial in the sizes of
+    Among all valid equations, some computations are polynomial in the sizes of
     the input tensors and other computations are exponential in the sizes of
     the input tensors. This function raises :py:class:`NotImplementedError`
     whenever the computation is exponential.

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -327,27 +327,14 @@ def _contract_component(ring, tensor_tree, sum_dims, target_dims):
         in the result.
     """
     assert target_dims <= sum_dims
-
-    # First close the set of ordinals under intersection (greatest lower bound),
-    # ensuring that the ordinals are arranged in a tree structure.
     target_ordinal = frozenset.intersection(*tensor_tree)
-    tensor_tree.setdefault(target_ordinal, [])
-    pending = list(tensor_tree)
-    while pending:
-        t = pending.pop()
-        for u in list(tensor_tree):
-            tu = t & u
-            if tu not in tensor_tree:
-                tensor_tree[tu] = []
-                pending.append(tu)
 
     # Collect contraction dimensions by ordinal.
     dim_to_ordinal = {}
     for t, terms in tensor_tree.items():
         for term in terms:
-            for dim in ring.dims(term):
-                if dim in sum_dims:
-                    dim_to_ordinal[dim] = dim_to_ordinal.get(dim, t) & t
+            for dim in sum_dims.intersection(ring.dims(term)):
+                dim_to_ordinal[dim] = dim_to_ordinal.get(dim, t) & t
     dims_tree = defaultdict(set)
     for dim, t in dim_to_ordinal.items():
         dims_tree[t].add(dim)

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -113,6 +113,8 @@ class TensorRing(object):
         :param dims: an iterable of sum dims to contract
         :param frozenset ordinal: an ordinal specifying batch dims to contract
         """
+        if not dims:
+            return self.product(term, ordinal)
         key = 'inclusion_exclusion', id(term), frozenset(dims), ordinal
         if key not in self._cache:
             term_sum = self.sumproduct([term], dims)
@@ -369,11 +371,7 @@ def _contract_component(ring, tensor_tree, sum_dims, target_dims):
                         "exponential cost in the size of that irange)"
                         .format(', '.join(getattr(f, 'name', str(f)) for f in leaf)))
                 contract_frames = leaf - parent
-                inclusion_exclusion_dims = dims & target_dims
-                if inclusion_exclusion_dims:
-                    term = ring.inclusion_exclusion(term, inclusion_exclusion_dims, contract_frames)
-                else:
-                    term = ring.product(term, contract_frames)
+                term = ring.inclusion_exclusion(term, dims & target_dims, contract_frames)
 
             tensor_tree.setdefault(parent, []).append(term)
 

--- a/pyro/ops/sumproduct.py
+++ b/pyro/ops/sumproduct.py
@@ -125,7 +125,7 @@ def opt_sumproduct(factors, target_shape, backend='torch'):
             smaller_shape = smaller_shape[1:]
         smaller_shape = tuple(smaller_shape)
         result = opt_sumproduct(factors, smaller_shape, backend=backend)
-        return result.expand(target_shape)
+        return result.expand(target_shape)  # TODO memoize in sharing cache
 
     # Construct low-dimensional tensors with symbolic names.
     num_symbols = max(len(target_shape), max(len(t.shape) for t in factors))
@@ -151,4 +151,4 @@ def opt_sumproduct(factors, target_shape, backend='torch'):
     packed_result = contract(expr, *packed_factors, backend=backend)
 
     # Unpack result.
-    return packed_result.reshape(target_shape)
+    return packed_result.reshape(target_shape)  # TODO memoize in sharing cache

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -13,7 +13,7 @@ from pyro.ops.contract import (UnpackedLogRing, _partition_terms, contract_tenso
                                naive_ubersum, ubersum)
 from pyro.poutine.indep_messenger import CondIndepStackFrame
 from pyro.util import optional
-from tests.common import assert_equal, xfail_param
+from tests.common import assert_equal
 
 
 def deep_copy(x):
@@ -354,7 +354,6 @@ def test_naive_ubersum(equation, batch_dims):
                              output, expected_part.detach().cpu(), actual_part.detach().cpu()))
 
 
-@pytest.mark.xfail(reason='improper handling of batched output')
 @pytest.mark.parametrize('equation,batch_dims', UBERSUM_EXAMPLES)
 def test_ubersum(equation, batch_dims):
     inputs, outputs, operands, sizes = make_example(equation)
@@ -444,10 +443,7 @@ def test_ubersum_3(impl):
     assert_equal(actual, expected)
 
 
-@pytest.mark.parametrize('impl', [
-    naive_ubersum,
-    xfail_param(ubersum, reason='incorrect forward-backward implementation'),
-])
+@pytest.mark.parametrize('impl', [naive_ubersum, ubersum])
 def test_ubersum_4(impl):
     # x,y {b}  <--- target
     #      |
@@ -566,10 +562,7 @@ UBERSUM_BATCH_ERRORS = [
 
 
 @pytest.mark.parametrize('equation,batch_dims', UBERSUM_BATCH_ERRORS)
-@pytest.mark.parametrize('impl', [
-    naive_ubersum,
-    xfail_param(ubersum, reason='does not detect senseless batch output'),
-])
+@pytest.mark.parametrize('impl', [naive_ubersum, ubersum])
 def test_ubersum_batch_error(impl, equation, batch_dims):
     inputs, outputs = equation.split('->')
     operands = [torch.randn(torch.Size((2,) * len(input_)))

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -341,9 +341,9 @@ UBERSUM_EXAMPLES = [
 ]
 
 
-def make_example(equation, fill=None):
+def make_example(equation, fill=None, sizes=(2, 3, 4)):
     symbols = sorted(set(equation) - set(',->'))
-    sizes = {dim: size for dim, size in zip(symbols, itertools.cycle([2, 3, 4]))}
+    sizes = {dim: size for dim, size in zip(symbols, itertools.cycle(sizes))}
     inputs, outputs = equation.split('->')
     inputs = inputs.split(',')
     outputs = outputs.split(',')
@@ -397,6 +397,9 @@ def test_ubersum(equation, batch_dims):
     ('i->i', 'i'),
     (',i->', 'i'),
     (',i->i', 'i'),
+    ('a,ai,bij->bij', 'ij'),
+    ('a,ai,abij->bij', 'ij'),
+    (',ai,abij->aij', 'ij'),
     ('a,abi,bcij->a', 'ij'),
     ('a,abi,bcij->bi', 'ij'),
     ('a,abi,bcij->bij', 'ij'),
@@ -404,7 +407,7 @@ def test_ubersum(equation, batch_dims):
     ('ab,bcdi,deij->eij', 'ij'),
 ])
 def test_ubersum_total(equation, batch_dims):
-    inputs, outputs, operands, sizes = make_example(equation, fill=1)
+    inputs, outputs, operands, sizes = make_example(equation, fill=1, sizes=(2,))
 
     expected = naive_ubersum(equation, *operands, batch_dims=batch_dims)[0]
     actual = ubersum(equation, *operands, batch_dims=batch_dims)[0]

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -300,12 +300,32 @@ UBERSUM_EXAMPLES = [
     #   a\   /a
     #     {i}      {}
     (',ia,ija,ika->,i,j,k,ij,ik,ijk,ia,ija,ika,ijka', 'ijk'),
-    # {ij} a
-    #   |b
     #  {i} c
+    #   |b
+    #  {} a
+    ('ab,bci->,a,b,ab,i,ai,bi,ci,abi,bci,abci', 'i'),
+    #  {ij} c
+    #   |b
+    #  {} a
+    ('ab,bcij->,a,b,ab,i,j,ij,ai,aj,aij,bi,bj,aij,bij,cij,abij,acij,bcij,abcij', 'ij'),
+    #  {ij} c
+    #   |b
+    #  {i} a
+    ('abi,bcij->,i,ai,bi,abi,j,ij,aij,bij,cij,abij,bcij,abcij', 'ij'),
+    # {ij} e
     #   |d
-    #  {} e
-    ('abij,bcdi,de->,e,ci,bi,bci,aij', 'ij'),
+    #  {i} c
+    #   |b
+    #  {} a
+    ('ab,bcdi,deij->,a,b,ci,di,eij', 'ij'),
+    # {ijk} g
+    #   |f
+    # {ij} e
+    #   |d
+    #  {i} c
+    #   |b
+    #  {} a
+    ('ab,bcdi,defij,fgijk->,a,b,ci,di,eij,fij,gijk', 'ijk'),
     # {ik}  {ij}   {ij}
     #   a\   /b    /e
     #     {i}    {j}
@@ -377,6 +397,11 @@ def test_ubersum(equation, batch_dims):
     ('i->i', 'i'),
     (',i->', 'i'),
     (',i->i', 'i'),
+    ('a,abi,bcij->a', 'ij'),
+    ('a,abi,bcij->bi', 'ij'),
+    ('a,abi,bcij->bij', 'ij'),
+    ('a,abi,bcij->cij', 'ij'),
+    ('ab,bcdi,deij->eij', 'ij'),
 ])
 def test_ubersum_total(equation, batch_dims):
     inputs, outputs, operands, sizes = make_example(equation, fill=1)


### PR DESCRIPTION
Resolves #1460 

This fixes all known isses with `ubersum()`, `contract_to_tensor()`, and `contract_tensor_tree()`. The main issue was that we were simply broadcasting rather than performing forward-backward message passing up and down the plate tree. This PR completes our implementation of tensor message passing.

One subtle issue is that whereas `ubersum()` naturally aggregates across all batch slices (so that each batch of the output depends on all batches of the input), tensor message passing can avoid passing messages among batches that are not connected by an "upstream variable" (e.g. as a result of vectorized particles). To bridge this behavior gap, I've added an `modulo_total=True` flag to `ubersum()` to perform the cheaper tensor message passing algorithm. Thus users need to opt-in to this slightly subtle behavior.

## Tested

- [x] added lots of new tests to test_contract.py
- [x] refactored `contract_to_tensor()` and `contract_tensor()` are exercised by test_enum.py