### PR TITLE
Add site information for possible exception thrown when calculating logp

### DIFF
--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
+import sys
+import six
+
 import collections
 
 import networkx
@@ -158,8 +161,11 @@ class Trace(networkx.DiGraph):
                             warn_if_nan(site["log_prob_sum"], "log_prob_sum at site '{}'".format(name))
                             warn_if_inf(site["log_prob_sum"], "log_prob_sum at site '{}'".format(name),
                                         allow_neginf=True)
-                    except ValueError as e:
-                        raise ValueError("Error while computing log_prob at site '{}'".format(name)) from e
+                    except ValueError:
+                        et, ev, traceback = sys.exc_info()
+                        six.reraise(ValueError,
+                                    ValueError("Error while computing log_prob at site '{}': {}".format(name, ev)),
+                                    traceback)
 
     def compute_score_parts(self):
         """

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -148,9 +148,9 @@ class Trace(networkx.DiGraph):
         """
         for name, site in self.nodes.items():
             if site["type"] == "sample" and site_filter(name, site):
-                try:
+                if "log_prob" in site:
                     site["log_prob"]
-                except KeyError:
+                else:
                     try:
                         log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
                         site["unscaled_log_prob"] = log_p

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -130,15 +130,9 @@ class Trace(networkx.DiGraph):
                 if "log_prob_sum" in site:
                     log_p = site["log_prob_sum"]
                 else:
-                    try:
-                        log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
-                        log_p = scale_and_mask(log_p, site["scale"], site["mask"]).sum()
-                        site["log_prob_sum"] = log_p
-                    except ValueError:
-                        et, ev, traceback = sys.exc_info()
-                        six.reraise(ValueError,
-                                    ValueError("Error while computing log_prob_sum at site '{}': {}".format(name, ev)),
-                                    traceback)
+                    log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
+                    log_p = scale_and_mask(log_p, site["scale"], site["mask"]).sum()
+                    site["log_prob_sum"] = log_p
                     if is_validation_enabled():
                         warn_if_nan(log_p, "log_prob_sum at site '{}'".format(name))
                         warn_if_inf(log_p, "log_prob_sum at site '{}'".format(name), allow_neginf=True)

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -835,6 +835,7 @@ def test_trace_log_prob_err_msg():
     with pytest.raises(ValueError, match=exp_msg):
         tr.compute_log_prob()
 
+
 def test_trace_log_prob_sum_err_msg():
     def model(v):
         pyro.sample("test_site", dist.Beta(1., 1.), obs=v)

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -823,3 +823,35 @@ def test_method_decorator_interface_condition():
     assert isinstance(tr, poutine.Trace)
     assert tr.graph_type == "flat"
     assert tr.nodes["b"]["is_observed"] and tr.nodes["b"]["value"].item() == 1.
+
+
+def test_trace_log_prob_err_msg():
+    def model(v):
+        pyro.sample("test_site", dist.Beta(1., 1.), obs=v)
+
+    tr = poutine.trace(model).get_trace(torch.tensor(2.))
+    exp_msg = "Error while computing log_prob at site 'test_site': " \
+              "The value argument must be within the support"
+    with pytest.raises(ValueError, match=exp_msg):
+        tr.compute_log_prob()
+
+def test_trace_log_prob_sum_err_msg():
+    def model(v):
+        pyro.sample("test_site", dist.Beta(1., 1.), obs=v)
+
+    tr = poutine.trace(model).get_trace(torch.tensor(2.))
+    exp_msg = "Error while computing log_prob_sum at site 'test_site': " \
+              "The value argument must be within the support"
+    with pytest.raises(ValueError, match=exp_msg):
+        tr.log_prob_sum()
+
+
+def test_trace_score_parts_err_msg():
+    def guide(v):
+        pyro.sample("test_site", dist.Beta(1., 1.), obs=v)
+
+    tr = poutine.trace(guide).get_trace(torch.tensor(2.))
+    exp_msg = "Error while computing score_parts at site 'test_site': " \
+              "The value argument must be within the support"
+    with pytest.raises(ValueError, match=exp_msg):
+        tr.compute_score_parts()


### PR DESCRIPTION
This allows easier debugging of errors that happen because of e.g. validation checks.
For example:
```
Traceback (most recent call last):
  File "...\pyro\poutine\trace_struct.py", line 152, in compute_log_prob
    log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
  File "...\torch\distributions\categorical.py", line 94, in log_prob
    self._validate_sample(value)
  File "...\torch\distributions\distribution.py", line 221, in _validate_sample
    raise ValueError('The value argument must be within the support')
ValueError: The value argument must be within the support

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File ".../pyro_debug_enum.py", line 130, in <module>
    main(sys.argv)
  File ".../pyro_debug_enum.py", line 123, in main
    params = infer(dataloader)
  File ".../pyro_debug_enum.py", line 72, in infer
    total_epoch_loss_train = _train(svi, dataloader)
  File ".../pyro_debug_enum.py", line 59, in _train
    epoch_loss += svi.step(data)
  File "...\pyro\infer\svi.py", line 96, in step
    loss = self.loss_and_grads(self.model, self.guide, *args, **kwargs)
  File "...\pyro\infer\traceenum_elbo.py", line 340, in loss_and_grads
    for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
  File "...\pyro\infer\traceenum_elbo.py", line 283, in _get_traces
    yield self._get_trace(model, guide, *args, **kwargs)
  File "...\pyro\infer\traceenum_elbo.py", line 237, in _get_trace
    "flat", self.max_plate_nesting, model, guide, *args, **kwargs)
  File "...\pyro\infer\enum.py", line 47, in get_importance_trace
    model_trace.compute_log_prob()
  File "...\pyro\poutine\trace_struct.py", line 154, in compute_log_prob
    raise ValueError("Error while computing log_prob of {}".format(site["name"])) from e
ValueError: Error while computing log_prob of obs
```

where originally, it just stated `ValueError: The value argument must be within the support` which made it hard to debug which RV that caused the error.

I have tagged it WIP since I would like to add a test, and I was wondering whether you could kindly assist me with this?

Thanks!