### PR TITLE
Cache potential energy and gradient of last trace in HMC/NUTS

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -15,7 +15,7 @@ from pyro.infer import config_enumerate
 from pyro.infer.mcmc.trace_kernel import TraceKernel
 from pyro.infer.mcmc.util import TraceEinsumEvaluator, TraceTreeEvaluator
 from pyro.ops.dual_averaging import DualAveraging
-from pyro.ops.integrator import single_step_velocity_verlet, velocity_verlet
+from pyro.ops.integrator import velocity_verlet
 from pyro.ops.welford import WelfordCovariance
 from pyro.poutine.subsample_messenger import _Subsample
 from pyro.util import optional, torch_isinf, torch_isnan
@@ -209,7 +209,7 @@ class HMC(TraceKernel):
         # then we have to decrease step_size; otherwise, increase step_size.
         r, _ = self._sample_r(name="r_presample")
         energy_current = self._energy(z, r)
-        z_new, r_new, z_grads, potential_energy = single_step_velocity_verlet(
+        z_new, r_new, z_grads, potential_energy = velocity_verlet(
             z, r, self._potential_energy, self._inverse_mass_matrix, step_size)
         energy_new = potential_energy + self._kinetic_energy(r_new)
         delta_energy = energy_new - energy_current
@@ -226,7 +226,7 @@ class HMC(TraceKernel):
         # TODO: make thresholds for too small step_size or too large step_size
         while direction_new == direction:
             step_size = step_size_scale * step_size
-            z_new, r_new, z_grads, potential_energy = single_step_velocity_verlet(
+            z_new, r_new, z_grads, potential_energy = velocity_verlet(
                 z, r, self._potential_energy, self._inverse_mass_matrix, step_size)
             energy_new = potential_energy + self._kinetic_energy(r_new)
             delta_energy = energy_new - energy_current

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import math
 import warnings
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict
 
 import torch
 from torch.distributions import biject_to, constraints

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -9,7 +9,7 @@ import pyro
 import pyro.distributions as dist
 from pyro.distributions.util import logsumexp
 from pyro.infer.mcmc.hmc import HMC
-from pyro.ops.integrator import single_step_velocity_verlet
+from pyro.ops.integrator import velocity_verlet
 from pyro.util import optional, torch_isnan
 
 # sum_accept_probs and num_proposals are used to calculate
@@ -156,7 +156,7 @@ class NUTS(HMC):
 
     def _build_basetree(self, z, r, z_grads, log_slice, direction, energy_current):
         step_size = self.step_size if direction == 1 else -self.step_size
-        z_new, r_new, z_grads, potential_energy = single_step_velocity_verlet(
+        z_new, r_new, z_grads, potential_energy = velocity_verlet(
             z, r, self._potential_energy, self._inverse_mass_matrix, step_size, z_grads=z_grads)
         r_new_flat = torch.cat([r_new[site_name].reshape(-1) for site_name in sorted(r_new)])
         energy_new = potential_energy + self._kinetic_energy(r_new)

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -21,35 +21,23 @@ def velocity_verlet(z, r, potential_fn, inverse_mass_matrix, step_size, num_step
         Here :math:`M` can be a 1D tensor (diagonal matrix) or a 2D tensor (dense matrix).
     :param float step_size: step size for each time step iteration.
     :param int num_steps: number of discrete time steps over which to integrate.
-    :return tuple (z_next, r_next): final position and momenta, having same types as (z, r).
-    """
-    z_next = z.copy()
-    r_next = r.copy()
-    for _ in range(num_steps):
-        z_next, r_next, z_grads, potential_energy = _single_step_inplace_verlet(z_next,
-                                                                                r_next,
-                                                                                potential_fn,
-                                                                                inverse_mass_matrix,
-                                                                                step_size,
-                                                                                z_grads)
-    return z_next, r_next, z_grads, potential_energy
-
-
-def single_step_velocity_verlet(z, r, potential_fn, inverse_mass_matrix, step_size, z_grads=None):
-    r"""
-    A special case of ``velocity_verlet`` integrator where ``num_steps=1``. It is particular
-    helpful for NUTS kernel.
-
     :param torch.Tensor z_grads: optional gradients of potential energy at current ``z``.
     :return tuple (z_next, r_next, z_grads, potential_energy): next position and momenta,
         together with the potential energy and its gradient w.r.t. ``z_next``.
     """
     z_next = z.copy()
     r_next = r.copy()
-    return _single_step_inplace_verlet(z_next, r_next, potential_fn, inverse_mass_matrix, step_size, z_grads)
+    for _ in range(num_steps):
+        z_next, r_next, z_grads, potential_energy = _single_step_verlet(z_next,
+                                                                        r_next,
+                                                                        potential_fn,
+                                                                        inverse_mass_matrix,
+                                                                        step_size,
+                                                                        z_grads)
+    return z_next, r_next, z_grads, potential_energy
 
 
-def _single_step_inplace_verlet(z, r, potential_fn, inverse_mass_matrix, step_size, z_grads=None):
+def _single_step_verlet(z, r, potential_fn, inverse_mass_matrix, step_size, z_grads=None):
     r"""
     Single step velocity verlet that modifies the `z`, `r` dicts in place.
     """

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -4,7 +4,7 @@ import torch
 from torch.autograd import grad
 
 
-def velocity_verlet(z, r, potential_fn, inverse_mass_matrix, step_size, num_steps=1):
+def velocity_verlet(z, r, potential_fn, inverse_mass_matrix, step_size, num_steps=1, z_grads=None):
     r"""
     Second order symplectic integrator that uses the velocity verlet algorithm.
 
@@ -25,28 +25,18 @@ def velocity_verlet(z, r, potential_fn, inverse_mass_matrix, step_size, num_step
     """
     z_next = z.copy()
     r_next = r.copy()
-    z_grads, _ = _potential_grad(potential_fn, z_next)
-
     for _ in range(num_steps):
-        for site_name in r_next:
-            # r(n+1/2)
-            r_next[site_name] = r_next[site_name] + 0.5 * step_size * (-z_grads[site_name])
-
-        r_grads = _kinetic_grad(inverse_mass_matrix, r_next)
-        for site_name in z_next:
-            # z(n+1)
-            z_next[site_name] = z_next[site_name] + step_size * r_grads[site_name]
-
-        z_grads, _ = _potential_grad(potential_fn, z_next)
-        for site_name in r_next:
-            # r(n+1)
-            r_next[site_name] = r_next[site_name] + 0.5 * step_size * (-z_grads[site_name])
-
-    return z_next, r_next
+        z_next, r_next, z_grads, potential_energy = _single_step_inplace_verlet(z_next,
+                                                                                r_next,
+                                                                                potential_fn,
+                                                                                inverse_mass_matrix,
+                                                                                step_size,
+                                                                                z_grads)
+    return z_next, r_next, z_grads, potential_energy
 
 
 def single_step_velocity_verlet(z, r, potential_fn, inverse_mass_matrix, step_size, z_grads=None):
-    """
+    r"""
     A special case of ``velocity_verlet`` integrator where ``num_steps=1``. It is particular
     helpful for NUTS kernel.
 
@@ -56,30 +46,38 @@ def single_step_velocity_verlet(z, r, potential_fn, inverse_mass_matrix, step_si
     """
     z_next = z.copy()
     r_next = r.copy()
-    z_grads = _potential_grad(potential_fn, z_next)[0] if z_grads is None else z_grads
+    return _single_step_inplace_verlet(z_next, r_next, potential_fn, inverse_mass_matrix, step_size, z_grads)
 
-    for site_name in r_next:
-        r_next[site_name] = r_next[site_name] + 0.5 * step_size * (-z_grads[site_name])
 
-    r_grads = _kinetic_grad(inverse_mass_matrix, r_next)
-    for site_name in z_next:
-        z_next[site_name] = z_next[site_name] + step_size * r_grads[site_name]
+def _single_step_inplace_verlet(z, r, potential_fn, inverse_mass_matrix, step_size, z_grads=None):
+    r"""
+    Single step velocity verlet that modifies the `z`, `r` dicts in place.
+    """
 
-    z_grads, potential_energy = _potential_grad(potential_fn, z_next)
-    for site_name in r_next:
-        r_next[site_name] = r_next[site_name] + 0.5 * step_size * (-z_grads[site_name])
+    z_grads = _potential_grad(potential_fn, z)[0] if z_grads is None else z_grads
 
-    return z_next, r_next, z_grads, potential_energy
+    for site_name in r:
+        r[site_name] = r[site_name] + 0.5 * step_size * (-z_grads[site_name])  # r(n+1/2)
+
+    r_grads = _kinetic_grad(inverse_mass_matrix, r)
+    for site_name in z:
+        z[site_name] = z[site_name] + step_size * r_grads[site_name]  # z(n+1)
+
+    z_grads, potential_energy = _potential_grad(potential_fn, z)
+    for site_name in r:
+        r[site_name] = r[site_name] + 0.5 * step_size * (-z_grads[site_name])  # r(n+1)
+
+    return z, r, z_grads, potential_energy
 
 
 def _potential_grad(potential_fn, z):
     z_keys, z_nodes = zip(*z.items())
     for node in z_nodes:
-        node.requires_grad = True
+        node.requires_grad_(True)
     potential_energy = potential_fn(z)
     grads = grad(potential_energy, z_nodes)
     for node in z_nodes:
-        node.requires_grad = False
+        node.requires_grad_(False)
     return dict(zip(z_keys, grads)), potential_energy
 
 

--- a/tests/ops/test_integrator.py
+++ b/tests/ops/test_integrator.py
@@ -105,12 +105,12 @@ class QuarticOscillator(object):
 @pytest.mark.parametrize('example', TEST_EXAMPLES, ids=EXAMPLE_IDS)
 def test_trajectory(example):
     model, args = example
-    q_f, p_f = velocity_verlet(args.q_i,
-                               args.p_i,
-                               model.potential_fn,
-                               model.inverse_mass_matrix,
-                               args.step_size,
-                               args.num_steps)
+    q_f, p_f, _, _ = velocity_verlet(args.q_i,
+                                     args.p_i,
+                                     model.potential_fn,
+                                     model.inverse_mass_matrix,
+                                     args.step_size,
+                                     args.num_steps)
     logger.info("initial q: {}".format(args.q_i))
     logger.info("final q: {}".format(q_f))
     assert_equal(q_f, args.q_f, args.prec)
@@ -120,12 +120,12 @@ def test_trajectory(example):
 @pytest.mark.parametrize('example', TEST_EXAMPLES, ids=EXAMPLE_IDS)
 def test_energy_conservation(example):
     model, args = example
-    q_f, p_f = velocity_verlet(args.q_i,
-                               args.p_i,
-                               model.potential_fn,
-                               model.inverse_mass_matrix,
-                               args.step_size,
-                               args.num_steps)
+    q_f, p_f, _, _ = velocity_verlet(args.q_i,
+                                     args.p_i,
+                                     model.potential_fn,
+                                     model.inverse_mass_matrix,
+                                     args.step_size,
+                                     args.num_steps)
     energy_initial = model.energy(args.q_i, args.p_i)
     energy_final = model.energy(q_f, p_f)
     logger.info("initial energy: {}".format(energy_initial.item()))
@@ -136,17 +136,17 @@ def test_energy_conservation(example):
 @pytest.mark.parametrize('example', TEST_EXAMPLES, ids=EXAMPLE_IDS)
 def test_time_reversibility(example):
     model, args = example
-    q_forward, p_forward = velocity_verlet(args.q_i,
-                                           args.p_i,
-                                           model.potential_fn,
-                                           model.inverse_mass_matrix,
-                                           args.step_size,
-                                           args.num_steps)
+    q_forward, p_forward, _, _ = velocity_verlet(args.q_i,
+                                                 args.p_i,
+                                                 model.potential_fn,
+                                                 model.inverse_mass_matrix,
+                                                 args.step_size,
+                                                 args.num_steps)
     p_reverse = {key: -val for key, val in p_forward.items()}
-    q_f, p_f = velocity_verlet(q_forward,
-                               p_reverse,
-                               model.potential_fn,
-                               model.inverse_mass_matrix,
-                               args.step_size,
-                               args.num_steps)
+    q_f, p_f, _, _ = velocity_verlet(q_forward,
+                                     p_reverse,
+                                     model.potential_fn,
+                                     model.inverse_mass_matrix,
+                                     args.step_size,
+                                     args.num_steps)
     assert_equal(q_f, args.q_i, 1e-5)


### PR DESCRIPTION
Minor optimization as a result of investigating #1511. 

Since the log density and gradient computation can take much longer with traces containing discrete sites, it is best to avoid it whenever possible. This includes a minor optimization - i.e. caching the potential energy and grads of the last seen trace (we already do caching within the same kernel `sample` step but not across steps).

**Perf Impact:**
The benefits are typically higher for HMC than NUTS, because NUTS tends to build longer chains and therefore the impact of caching the potential energy and gradient values for the beginning of the chain can be small. On the HMM example with 30 time steps with NUTS, this results in a reduction in runtime from 3min 28 seconds to 3min 19 seconds. 

