### PR TITLE
Abstract out HMC adaptation into its own class

### DIFF
--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -1,0 +1,163 @@
+import math
+import torch
+from collections import namedtuple
+
+import pyro.distributions as dist
+from pyro.ops.dual_averaging import DualAveraging
+from pyro.ops.welford import WelfordCovariance
+
+adapt_window = namedtuple("adapt_window", ["start", "end"])
+
+
+class WarmupAdapter(object):
+    r"""
+    Adapts tunable parameters, namely step size and mass matrix, during the
+    warmup phase. This class provides lookup properties to read the latest
+    values of ``step_size`` and ``inverse_mass_matrix``. These values are
+    periodically updated when adaptation is engaged.
+    """
+
+    def __init__(self,
+                 step_size,
+                 adapt_step_size=False,
+                 target_accept_prob=0.8,
+                 adapt_mass_matrix=False,
+                 is_diag_mass=True):
+        self.adapt_step_size = adapt_step_size
+        self.adapt_mass_matrix = adapt_mass_matrix
+        self.target_accept_prob = target_accept_prob
+        self.is_diag_mass = is_diag_mass
+        self._step_size = step_size if step_size is not None else 1
+        self._adaptation_disabled = not (adapt_step_size or adapt_mass_matrix)
+        if adapt_step_size:
+            self._step_size_adapt_scheme = DualAveraging()
+        if adapt_mass_matrix:
+            self._mass_matrix_adapt_scheme = WelfordCovariance(diagonal=is_diag_mass)
+
+        # We separate warmup_steps into windows:
+        #   start_buffer + window 1 + window 2 + window 3 + ... + end_buffer
+        # where the length of each window will be doubled for the next window.
+        # We won't adapt mass matrix during start and end buffers; and mass
+        # matrix will be updated at the end of each window. This is helpful
+        # for dealing with the intense computation of sampling momentum from the
+        # inverse of mass matrix.
+        self._adapt_start_buffer = 75  # from Stan
+        self._adapt_end_buffer = 50  # from Stan
+        self._adapt_initial_window = 25  # from Stan
+        self._current_window = 0  # starting window index
+
+        # configured later on setup
+        self._warmup_steps = None
+        self._inverse_mass_matrix = None
+        self._r_dist = None
+        self._adaptation_schedule = []
+
+    def _build_adaptation_schedule(self):
+        adaptation_schedule = []
+        # from Stan, for small warmup_steps < 20
+        if self._warmup_steps <= 20:
+            adaptation_schedule.append(adapt_window(0, self._warmup_steps - 1))
+            return adaptation_schedule
+
+        start_buffer_size = self._adapt_start_buffer
+        end_buffer_size = self._adapt_end_buffer
+        init_window_size = self._adapt_initial_window
+        if (self._adapt_start_buffer + self._adapt_end_buffer
+                + self._adapt_initial_window > self._warmup_steps):
+            start_buffer_size = int(0.15 * self._warmup_steps)
+            end_buffer_size = int(0.1 * self._warmup_steps)
+            init_window_size = self._warmup_steps - start_buffer_size - end_buffer_size
+        adaptation_schedule.append(adapt_window(start=0, end=start_buffer_size - 1))
+        end_window_start = self._warmup_steps - end_buffer_size
+
+        next_window_size = init_window_size
+        next_window_start = start_buffer_size
+        while next_window_start < end_window_start:
+            cur_window_start = next_window_start
+            next_window_start = min(end_window_start, cur_window_start + next_window_size)
+            adaptation_schedule.append(adapt_window(cur_window_start, next_window_start - 1))
+            next_window_size = 2 * next_window_size
+
+        adaptation_schedule.append(adapt_window(end_window_start,
+                                                self._warmup_steps - 1))
+        return adaptation_schedule
+
+    def reset_step_size(self, step_size):
+        self._step_size_adapt_scheme.prox_center = math.log(10 * step_size)
+        self._step_size_adapt_scheme.reset()
+
+    def _update_step_size(self, accept_prob):
+        # calculate a statistic for Dual Averaging scheme
+        H = self.target_accept_prob - accept_prob
+        self._step_size_adapt_scheme.step(H)
+        log_step_size, _ = self._step_size_adapt_scheme.get_state()
+        self._step_size = math.exp(log_step_size)
+
+    def _update_r_dist(self):
+        loc = self._inverse_mass_matrix.new_zeros(self._inverse_mass_matrix.size(0))
+        if self.is_diag_mass:
+            self._r_dist = dist.Normal(loc, self._inverse_mass_matrix.rsqrt())
+        else:
+            self._r_dist = dist.MultivariateNormal(loc,
+                                                   precision_matrix=self._inverse_mass_matrix)
+
+    def configure(self, warmup_steps, inv_mass_matrix, initial_step_size=None):
+        r"""
+        Model specific properties that are specified when the HMC kernel is setup.
+        """
+        self._warmup_steps = warmup_steps
+        if initial_step_size is not None and self.adapt_step_size:
+            self._step_size = initial_step_size
+            self.reset_step_size(initial_step_size)
+        self._inverse_mass_matrix = inv_mass_matrix
+        self._update_r_dist()
+        if not self._adaptation_disabled:
+            self._adaptation_schedule = self._build_adaptation_schedule()
+
+    def _end_adaptation(self):
+        if self.adapt_step_size:
+            _, log_step_size_avg = self._step_size_adapt_scheme.get_state()
+            self._step_size = math.exp(log_step_size_avg)
+
+    def step(self, t, z, accept_prob):
+        if t > self._warmup_steps or self._adaptation_disabled:
+            return
+        window = self._adaptation_schedule[self._current_window]
+        num_windows = len(self._adaptation_schedule)
+        mass_matrix_adaptation_phase = self.adapt_mass_matrix and \
+            (0 < self._current_window < num_windows - 1)
+        if self.adapt_step_size:
+            self._update_step_size(accept_prob)
+        if mass_matrix_adaptation_phase:
+            z_flat = torch.cat([z[name].reshape(-1) for name in sorted(z)])
+            self._mass_matrix_adapt_scheme.update(z_flat.detach())
+        if t == window.end:
+            if self._current_window == num_windows - 1:
+                self._end_adaptation()
+                return
+
+            if self.adapt_step_size:
+                self._step_size_adapt_scheme.prox_center = math.log(10 * self.step_size)
+                self._step_size_adapt_scheme.reset()
+
+            if mass_matrix_adaptation_phase:
+                self._inverse_mass_matrix = self._mass_matrix_adapt_scheme.get_covariance()
+                self._update_r_dist()
+                self._mass_matrix_adapt_scheme.reset()
+            self._current_window += 1
+
+    @property
+    def adaptation_schedule(self):
+        return self._adaptation_schedule
+
+    @property
+    def step_size(self):
+        return self._step_size
+
+    @property
+    def inverse_mass_matrix(self):
+        return self._inverse_mass_matrix
+
+    @property
+    def r_dist(self):
+        return self._r_dist

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -85,7 +85,7 @@ class WarmupAdapter(object):
                                                 self._warmup_steps - 1))
         return adaptation_schedule
 
-    def reset_step_size(self, step_size):
+    def _reset_step_size(self, step_size):
         self._step_size_adapt_scheme.prox_center = math.log(10 * step_size)
         self._step_size_adapt_scheme.reset()
 
@@ -120,7 +120,7 @@ class WarmupAdapter(object):
         self._warmup_steps = warmup_steps
         if initial_step_size is not None and self.adapt_step_size:
             self._step_size = initial_step_size
-            self.reset_step_size(initial_step_size)
+            self._reset_step_size(initial_step_size)
         self._inverse_mass_matrix = inv_mass_matrix
         self._update_r_dist()
         if not self._adaptation_disabled:

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -147,7 +147,12 @@ class WarmupAdapter(object):
             z_flat = torch.cat([z[name].reshape(-1) for name in sorted(z)])
             self._mass_matrix_adapt_scheme.update(z_flat.detach())
         if t == window.end:
+            if self._current_window == 0:
+                self._current_window += 1
+                return
+
             if self._current_window == num_windows - 1:
+                self._current_window += 1
                 self._end_adaptation()
                 return
 

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -18,7 +18,7 @@ class WarmupAdapter(object):
     """
 
     def __init__(self,
-                 step_size,
+                 step_size=1,
                  adapt_step_size=False,
                  target_accept_prob=0.8,
                  adapt_mass_matrix=False,
@@ -27,7 +27,7 @@ class WarmupAdapter(object):
         self.adapt_mass_matrix = adapt_mass_matrix
         self.target_accept_prob = target_accept_prob
         self.is_diag_mass = is_diag_mass
-        self._step_size = step_size if step_size is not None else 1
+        self._step_size = step_size
         self._adaptation_disabled = not (adapt_step_size or adapt_mass_matrix)
         if adapt_step_size:
             self._step_size_adapt_scheme = DualAveraging()

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -73,11 +73,14 @@ class WarmupAdapter(object):
         next_window_size = init_window_size
         next_window_start = start_buffer_size
         while next_window_start < end_window_start:
-            cur_window_start = next_window_start
-            next_window_start = min(end_window_start, cur_window_start + next_window_size)
+            cur_window_start, cur_window_size = next_window_start, next_window_size
+            # Ensure that slow adaptation windows are monotonically increasing
+            if 3 * cur_window_size <= end_window_start - cur_window_start:
+                next_window_size = 2 * cur_window_size
+            else:
+                cur_window_size = end_window_start - cur_window_start
+            next_window_start = cur_window_start + cur_window_size
             adaptation_schedule.append(adapt_window(cur_window_start, next_window_start - 1))
-            next_window_size = 2 * next_window_size
-
         adaptation_schedule.append(adapt_window(end_window_start,
                                                 self._warmup_steps - 1))
         return adaptation_schedule

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -27,7 +27,7 @@ class WarmupAdapter(object):
         self.adapt_mass_matrix = adapt_mass_matrix
         self.target_accept_prob = target_accept_prob
         self.is_diag_mass = is_diag_mass
-        self._step_size = step_size
+        self._step_size = step_size if step_size is not None else 1
         self._adaptation_disabled = not (adapt_step_size or adapt_mass_matrix)
         if adapt_step_size:
             self._step_size_adapt_scheme = DualAveraging()

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -86,7 +86,7 @@ class HMC(TraceKernel):
 
     def __init__(self,
                  model,
-                 step_size=1,  # from Stan
+                 step_size=1,
                  trajectory_length=None,
                  num_steps=None,
                  adapt_step_size=True,

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -143,21 +143,21 @@ class NUTS(HMC):
         r_right_flat = torch.cat([r_right[site_name].reshape(-1) for site_name in sorted(r_right)])
         # TODO: change to torch.dot for pytorch 1.0
         if self.full_mass:
-            if (((r_sum - r_left_flat) * (self._inverse_mass_matrix.matmul(r_left_flat)))
+            if (((r_sum - r_left_flat) * (self.inverse_mass_matrix.matmul(r_left_flat)))
                     .sum() > 0 and
-                    ((r_sum - r_right_flat) * (self._inverse_mass_matrix.matmul(r_right_flat)))
+                    ((r_sum - r_right_flat) * (self.inverse_mass_matrix.matmul(r_right_flat)))
                     .sum() > 0):
                 return False
         else:
-            if ((self._inverse_mass_matrix * (r_sum - r_left_flat) * r_left_flat).sum() > 0 and
-                    (self._inverse_mass_matrix * (r_sum - r_right_flat) * r_right_flat).sum() > 0):
+            if ((self.inverse_mass_matrix * (r_sum - r_left_flat) * r_left_flat).sum() > 0 and
+                    (self.inverse_mass_matrix * (r_sum - r_right_flat) * r_right_flat).sum() > 0):
                 return False
         return True
 
     def _build_basetree(self, z, r, z_grads, log_slice, direction, energy_current):
         step_size = self.step_size if direction == 1 else -self.step_size
         z_new, r_new, z_grads, potential_energy = velocity_verlet(
-            z, r, self._potential_energy, self._inverse_mass_matrix, step_size, z_grads=z_grads)
+            z, r, self._potential_energy, self.inverse_mass_matrix, step_size, z_grads=z_grads)
         r_new_flat = torch.cat([r_new[site_name].reshape(-1) for site_name in sorted(r_new)])
         energy_new = potential_energy + self._kinetic_energy(r_new)
         # handle the NaN case
@@ -309,7 +309,7 @@ class NUTS(HMC):
 
         # Temporarily disable distributions args checking as
         # NaNs are expected during step size adaptation.
-        with optional(pyro.validation_enabled(False), self._adapt_phase):
+        with optional(pyro.validation_enabled(False), self._t < self._warmup_steps):
             # doubling process, stop when turning or diverging
             for tree_depth in range(self._max_tree_depth + 1):
                 direction = pyro.sample("direction_t={}_treedepth={}".format(self._t, tree_depth),
@@ -353,20 +353,14 @@ class NUTS(HMC):
                     else:
                         tree_weight = tree_weight + new_tree.weight
 
-        self._t += 1
-
-        if self._adapt_phase:
-            if self.adapt_step_size:
-                accept_prob = new_tree.sum_accept_probs / new_tree.num_proposals
-                self._adapt_step_size(accept_prob)
-            if self._adapt_mass_matrix_phase:
-                z_flat = torch.cat([z[name].reshape(-1) for name in sorted(z)])
-                self._mass_matrix_adapt_scheme.update(z_flat)
-            if self._t == self._adapt_window_ending:
-                self._end_adapt_window()
+        if self._t < self._warmup_steps:
+            accept_prob = new_tree.sum_accept_probs / new_tree.num_proposals
+            self._adapter.step(self._t, z, accept_prob)
 
         if accepted:
             self._accept_cnt += 1
+
+        self._t += 1
         # get trace with the constrained values for `z`.
         for name, transform in self.transforms.items():
             z[name] = transform.inv(z[name])

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -100,7 +100,7 @@ class NUTS(HMC):
 
     def __init__(self,
                  model,
-                 step_size=None,
+                 step_size=1,
                  adapt_step_size=True,
                  adapt_mass_matrix=True,
                  full_mass=False,

--- a/tests/infer/mcmc/test_adaptation.py
+++ b/tests/infer/mcmc/test_adaptation.py
@@ -17,6 +17,6 @@ def test_adaptation_schedule(adapt_step_size, adapt_mass, warmup_steps, expected
     adapter = WarmupAdapter(0.1,
                             adapt_step_size=adapt_step_size,
                             adapt_mass_matrix=adapt_mass)
-    adapter.configure(warmup_steps, torch.eye(5, 5))
+    adapter.configure(warmup_steps, inv_mass_matrix=torch.eye(5, 5))
     expected_schedule = [adapt_window(i, j) for i, j in expected]
     assert_equal(adapter.adaptation_schedule, expected_schedule, prec=0)

--- a/tests/infer/mcmc/test_adaptation.py
+++ b/tests/infer/mcmc/test_adaptation.py
@@ -10,7 +10,7 @@ from tests.common import assert_equal
     (False, True, 50, [(0, 6), (7, 44), (45, 49)]),
     (True, False, 150, [(0, 74), (75, 99), (100, 149)]),
     (True, True, 200, [(0, 74), (75, 99), (100, 149), (150, 199)]),
-    (True, True, 280, [(0, 74), (75, 99), (100, 149), (150, 229), (230, 279)]),
+    (True, True, 280, [(0, 74), (75, 99), (100, 229), (230, 279)]),
     (True, True, 18, [(0, 17)]),
 ])
 def test_adaptation_schedule(adapt_step_size, adapt_mass, warmup_steps, expected):

--- a/tests/infer/mcmc/test_adaptation.py
+++ b/tests/infer/mcmc/test_adaptation.py
@@ -1,0 +1,22 @@
+import pytest
+import torch
+
+from pyro.infer.mcmc.adaptation import WarmupAdapter, adapt_window
+from tests.common import assert_equal
+
+
+@pytest.mark.parametrize("adapt_step_size, adapt_mass, warmup_steps, expected", [
+    (False, False, 100, []),
+    (False, True, 50, [(0, 6), (7, 44), (45, 49)]),
+    (True, False, 150, [(0, 74), (75, 99), (100, 149)]),
+    (True, True, 200, [(0, 74), (75, 99), (100, 149), (150, 199)]),
+    (True, True, 280, [(0, 74), (75, 99), (100, 149), (150, 229), (230, 279)]),
+    (True, True, 18, [(0, 17)]),
+])
+def test_adaptation_schedule(adapt_step_size, adapt_mass, warmup_steps, expected):
+    adapter = WarmupAdapter(0.1,
+                            adapt_step_size=adapt_step_size,
+                            adapt_mass_matrix=adapt_mass)
+    adapter.configure(warmup_steps, torch.eye(5, 5))
+    expected_schedule = [adapt_window(i, j) for i, j in expected]
+    assert_equal(adapter.adaptation_schedule, expected_schedule, prec=0)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -268,34 +268,3 @@ def test_gaussian_hmm_enum_shape(num_steps, use_einsum):
     nuts_kernel = NUTS(model, max_plate_nesting=0, experimental_use_einsum=use_einsum)
     MCMC(nuts_kernel, num_samples=5, warmup_steps=5).run(data)
 
-
-@pytest.mark.parametrize("num_steps", [10, 20])
-def test_gaussian_hmm(num_steps):
-    dim = 4
-
-    def model(data):
-        initialize = pyro.sample("initialize", dist.Dirichlet(torch.ones(dim)))
-        transition = pyro.sample("transition", dist.Dirichlet(torch.ones(dim, dim)))
-        emission_loc = pyro.sample("emission_loc", dist.Normal(torch.zeros(dim), torch.ones(dim)))
-        emission_scale = pyro.sample("emission_scale", dist.LogNormal(torch.zeros(dim), torch.ones(dim)))
-        x = None
-        for t, y in enumerate(data):
-            x = pyro.sample("x_{}".format(t), dist.Categorical(initialize if x is None else transition[x]))
-            pyro.sample("y_{}".format(t), dist.Normal(emission_loc[x], emission_scale[x]), obs=y)
-            # check shape
-            effective_dim = sum(1 for size in x.shape if size > 1)
-            assert effective_dim == 1
-
-    transition_probs = torch.tensor([[0.3, 0.2, 0.1, 0.4],
-                                     [0.2, 0.3, 0.1, 0.1],
-                                     [0.3, 0.2, 0.2, 0.3],
-                                     [0.6, 0.2, 0.1, 0.1]])
-    fixed_emissions = torch.tensor([10., 20., 30., 40.])
-    state = torch.tensor(1)
-    data = [fixed_emissions[state]]
-    for _ in range(num_steps):
-        state = dist.Categorical(transition_probs[state]).sample()
-        data.append(fixed_emissions[state])
-    data = torch.stack(data)
-    nuts_kernel = NUTS(model, max_plate_nesting=0, experimental_use_einsum=True, adapt_mass_matrix=True)
-    MCMC(nuts_kernel, num_samples=200, warmup_steps=100).run(data)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -267,3 +267,35 @@ def test_gaussian_hmm_enum_shape(num_steps, use_einsum):
     data = torch.ones(num_steps)
     nuts_kernel = NUTS(model, max_plate_nesting=0, experimental_use_einsum=use_einsum)
     MCMC(nuts_kernel, num_samples=5, warmup_steps=5).run(data)
+
+
+@pytest.mark.parametrize("num_steps", [10, 20])
+def test_gaussian_hmm(num_steps):
+    dim = 4
+
+    def model(data):
+        initialize = pyro.sample("initialize", dist.Dirichlet(torch.ones(dim)))
+        transition = pyro.sample("transition", dist.Dirichlet(torch.ones(dim, dim)))
+        emission_loc = pyro.sample("emission_loc", dist.Normal(torch.zeros(dim), torch.ones(dim)))
+        emission_scale = pyro.sample("emission_scale", dist.LogNormal(torch.zeros(dim), torch.ones(dim)))
+        x = None
+        for t, y in enumerate(data):
+            x = pyro.sample("x_{}".format(t), dist.Categorical(initialize if x is None else transition[x]))
+            pyro.sample("y_{}".format(t), dist.Normal(emission_loc[x], emission_scale[x]), obs=y)
+            # check shape
+            effective_dim = sum(1 for size in x.shape if size > 1)
+            assert effective_dim == 1
+
+    transition_probs = torch.tensor([[0.3, 0.2, 0.1, 0.4],
+                                     [0.2, 0.3, 0.1, 0.1],
+                                     [0.3, 0.2, 0.2, 0.3],
+                                     [0.6, 0.2, 0.1, 0.1]])
+    fixed_emissions = torch.tensor([10., 20., 30., 40.])
+    state = torch.tensor(1)
+    data = [fixed_emissions[state]]
+    for _ in range(num_steps):
+        state = dist.Categorical(transition_probs[state]).sample()
+        data.append(fixed_emissions[state])
+    data = torch.stack(data)
+    nuts_kernel = NUTS(model, max_plate_nesting=0, experimental_use_einsum=True, adapt_mass_matrix=True)
+    MCMC(nuts_kernel, num_samples=200, warmup_steps=100).run(data)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -267,4 +267,3 @@ def test_gaussian_hmm_enum_shape(num_steps, use_einsum):
     data = torch.ones(num_steps)
     nuts_kernel = NUTS(model, max_plate_nesting=0, experimental_use_einsum=use_einsum)
     MCMC(nuts_kernel, num_samples=5, warmup_steps=5).run(data)
-


### PR DESCRIPTION
Addresses #1520. 

This refactors the step size and mass matrix adaptation into its own class. The motivation for this is to reduce the complexity in the HMC class that arises out of maintaining many stateful attributes during adaptation. The logic that previously resided here has been refactored to keep mutable attributes to a minimum, and moved to `WarmupAdapter`. 

We are doing this by constructing an adaptation schedule instead and then moving within this schedule to take appropriate actions as needed. One minor departure from earlier might be that the slow adaptation windows are always monotonically increasing, i.e. the last slow window (before the end buffer) cannot be smaller than the penultimate one. This is to ensure that we are collecting enough number of samples for estimating the covariance.

### Testing
Test is added to check if the adaptation schedule is built correctly. Remaining tests should pass as is (or with minor changes) since this is a straight up refactor.

### TODOs:
 - [x] Ensure that there is no perf regression.
 - [x] Understand test failures, if any; ensure that logic is largely the same as earlier. 