### PR TITLE
Small test fixes for CI

### DIFF
--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -141,17 +141,17 @@ def test_hmc_conjugate_gaussian(fixture,
         expected_std = 1 / torch.sqrt(torch.ones(fixture.dim) * expected_precs[i - 1])
 
         # Actual vs expected posterior means for the latents
-        logger.info('Posterior mean (actual) - {}'.format(param_name))
-        logger.info(latent_loc)
-        logger.info('Posterior mean (expected) - {}'.format(param_name))
-        logger.info(expected_mean)
+        logger.debug('Posterior mean (actual) - {}'.format(param_name))
+        logger.debug(latent_loc)
+        logger.debug('Posterior mean (expected) - {}'.format(param_name))
+        logger.debug(expected_mean)
         assert_equal(rmse(latent_loc, expected_mean).item(), 0.0, prec=mean_tol)
 
         # Actual vs expected posterior precisions for the latents
-        logger.info('Posterior std (actual) - {}'.format(param_name))
-        logger.info(latent_std)
-        logger.info('Posterior std (expected) - {}'.format(param_name))
-        logger.info(expected_std)
+        logger.debug('Posterior std (actual) - {}'.format(param_name))
+        logger.debug(latent_std)
+        logger.debug('Posterior std (expected) - {}'.format(param_name))
+        logger.debug(expected_std)
         assert_equal(rmse(latent_std, expected_std).item(), 0.0, prec=std_tol)
 
 

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -92,17 +92,17 @@ def test_nuts_conjugate_gaussian(fixture,
         expected_std = 1 / torch.sqrt(torch.ones(fixture.dim) * expected_precs[i - 1])
 
         # Actual vs expected posterior means for the latents
-        logger.info('Posterior mean (actual) - {}'.format(param_name))
-        logger.info(latent_loc)
-        logger.info('Posterior mean (expected) - {}'.format(param_name))
-        logger.info(expected_mean)
+        logger.debug('Posterior mean (actual) - {}'.format(param_name))
+        logger.debug(latent_loc)
+        logger.debug('Posterior mean (expected) - {}'.format(param_name))
+        logger.debug(expected_mean)
         assert_equal(rmse(latent_loc, expected_mean).item(), 0.0, prec=mean_tol)
 
         # Actual vs expected posterior precisions for the latents
-        logger.info('Posterior std (actual) - {}'.format(param_name))
-        logger.info(latent_std)
-        logger.info('Posterior std (expected) - {}'.format(param_name))
-        logger.info(expected_std)
+        logger.debug('Posterior std (actual) - {}'.format(param_name))
+        logger.debug(latent_std)
+        logger.debug('Posterior std (expected) - {}'.format(param_name))
+        logger.debug(expected_std)
         assert_equal(rmse(latent_std, expected_std).item(), 0.0, prec=std_tol)
 
 

--- a/tests/nn/conftest.py
+++ b/tests/nn/conftest.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if item.nodeid.startswith("tests/nn"):
+            if "stage" not in item.keywords:
+                item.add_marker(pytest.mark.stage("unit"))
+            if "init" not in item.keywords:
+                item.add_marker(pytest.mark.init(rng_seed=123))

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -63,7 +63,7 @@ def test_networkx_copy():
     g = nx.DiGraph()
     expected = count_objects_of_type(nx.DiGraph)
     for _ in range(10):
-        h = g.fresh_copy()
+        h = g.__class__()
         h.__dict__.clear()
         del h
         counts.append(count_objects_of_type(nx.DiGraph))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 from pyro import util
 
-pytestmark = pytest.mark.stage('test_util')
+pytestmark = pytest.mark.stage('unit')
 
 
 def test_warn_if_nan():


### PR DESCRIPTION
 - I was finding instances where our travis log output was getting truncated due to large size; changing the NUTS/HMC tests to use `.debug` instead of `.info`. If I continue to see issues, I'll follow up with similar fixes for some of our other tests.
 - tests in `nn` were getting run at every stage, so just adding a stage marker to ensure that they only run in the unit test stage.