### PR TITLE
Add pretty printing of trace shapes on error

### DIFF
--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
+import sys
+
+import six
+
 from .messenger import Messenger
 from .trace_struct import Trace
 from .util import site_is_subsample
@@ -173,7 +177,14 @@ class TraceHandler(object):
             self.msngr.trace.add_node("_INPUT",
                                       name="_INPUT", type="args",
                                       args=args, kwargs=kwargs)
-            ret = self.fn(*args, **kwargs)
+            try:
+                ret = self.fn(*args, **kwargs)
+            except (ValueError, RuntimeError):
+                exc_type, exc_value, traceback = sys.exc_info()
+                shapes = self.msngr.trace.format_shapes()
+                six.reraise(exc_type,
+                            exc_type(u"{}\n{}".format(exc_value, shapes)),
+                            traceback)
             self.msngr.trace.add_node("_RETURN", name="_RETURN", type="return", value=ret)
         return ret
 

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -136,7 +136,7 @@ class Trace(networkx.DiGraph):
                         log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
                     except ValueError:
                         _, exc_value, traceback = sys.exc_info()
-                        shapes = self.print_shapes(last_site=site["name"])
+                        shapes = self.format_shapes(last_site=site["name"])
                         six.reraise(ValueError,
                                     ValueError("Error while computing log_prob_sum at site '{}':\n{}\n"
                                                .format(name, exc_value, shapes)),
@@ -163,7 +163,7 @@ class Trace(networkx.DiGraph):
                         log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
                     except ValueError:
                         _, exc_value, traceback = sys.exc_info()
-                        shapes = self.print_shapes(last_site=site["name"])
+                        shapes = self.format_shapes(last_site=site["name"])
                         six.reraise(ValueError,
                                     ValueError("Error while computing log_prob at site '{}':\n{}\n{}"
                                                .format(name, exc_value, shapes)),
@@ -192,7 +192,7 @@ class Trace(networkx.DiGraph):
                     value = site["fn"].score_parts(site["value"], *site["args"], **site["kwargs"])
                 except ValueError:
                     _, exc_value, traceback = sys.exc_info()
-                    shapes = self.print_shapes(last_site=site["name"])
+                    shapes = self.format_shapes(last_site=site["name"])
                     six.reraise(ValueError,
                                 ValueError("Error while computing score_parts at site '{}':\n{}\n{}"
                                            .format(name, exc_value, shapes)),
@@ -320,15 +320,15 @@ class Trace(networkx.DiGraph):
                     packed["unscaled_log_prob"] = pack(site["unscaled_log_prob"], dim_to_symbol)
             except ValueError:
                 _, exc_value, traceback = sys.exc_info()
-                shapes = self.print_shapes(last_site=site["name"])
+                shapes = self.format_shapes(last_site=site["name"])
                 six.reraise(ValueError,
                             ValueError("Error while packing tensors at site '{}':\n  {}\n{}"
                                        .format(site["name"], exc_value, shapes)),
                             traceback)
 
-    def print_shapes(self, title='Trace Shapes:', last_site=None):
+    def format_shapes(self, title='Trace Shapes:', last_site=None):
         """
-        Returns a string showing a table of the shapes of all values in the
+        Returns a string showing a table of the shapes of all sites in the
         trace.
         """
         if not self.nodes:
@@ -395,7 +395,10 @@ def _format_table(rows):
                 j += 1
             else:
                 cols[j].append(cell)
-        cols = [[""] * (width - len(col)) + col for width, col in zip(column_widths, cols)]
+        cols = [[""] * (width - len(col)) + col
+                if direction == 'r' else
+                col + [""] * (width - len(col))
+                for width, col, direction in zip(column_widths, cols, 'rrl')]
         rows[i] = sum(cols, [])
 
     # compute cell widths

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -830,8 +830,8 @@ def test_trace_log_prob_err_msg():
         pyro.sample("test_site", dist.Beta(1., 1.), obs=v)
 
     tr = poutine.trace(model).get_trace(torch.tensor(2.))
-    exp_msg = "Error while computing log_prob at site 'test_site': " \
-              "The value argument must be within the support"
+    exp_msg = r"Error while computing log_prob at site 'test_site':\s*" \
+              r"The value argument must be within the support"
     with pytest.raises(ValueError, match=exp_msg):
         tr.compute_log_prob()
 
@@ -841,8 +841,8 @@ def test_trace_log_prob_sum_err_msg():
         pyro.sample("test_site", dist.Beta(1., 1.), obs=v)
 
     tr = poutine.trace(model).get_trace(torch.tensor(2.))
-    exp_msg = "Error while computing log_prob_sum at site 'test_site': " \
-              "The value argument must be within the support"
+    exp_msg = r"Error while computing log_prob_sum at site 'test_site':\s*" \
+              r"The value argument must be within the support"
     with pytest.raises(ValueError, match=exp_msg):
         tr.log_prob_sum()
 
@@ -852,7 +852,7 @@ def test_trace_score_parts_err_msg():
         pyro.sample("test_site", dist.Beta(1., 1.), obs=v)
 
     tr = poutine.trace(guide).get_trace(torch.tensor(2.))
-    exp_msg = "Error while computing score_parts at site 'test_site': " \
-              "The value argument must be within the support"
+    exp_msg = r"Error while computing score_parts at site 'test_site':\s*" \
+              r"The value argument must be within the support"
     with pytest.raises(ValueError, match=exp_msg):
         tr.compute_score_parts()


### PR DESCRIPTION
Addresses #1453 

Adds tensor_shapes.ipynb-style pretty printing of trace shapes on error. For example in the hmm error fixed by the recent #1521 , this would have printed
```
$ python examples/hmm.py
      977 Loading data
     1054 ----------------------------------------
     1054 Training model_1 on 229 sequences
     1067 Step	Loss
Traceback (most recent call last):
...
ValueError: Error while packing tensors at site 'y_0':
  Invalid tensor shape.
  Allowed dims: -3, -2, -1
  Actual shape: (16, 1, 8, 88)
  Try adding shape assertions for your model's sample values and distribution parameters.
Trace Shapes:
 Param Sites:
Sample Sites:
 probs_x dist            | 16 16
        value            | 16 16
     log_prob            |
 probs_y dist            | 16 88
        value            | 16 88
     log_prob            |
     x_0 dist       8  1 |
        value    16 1  1 |
     log_prob    16 8  1 |
     y_0 dist 16  1 8 88 |
        value       8 88 |
     log_prob 16  1 8 88 |
```