### PR TITLE
Refactoring HMC class to set initial trace

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -116,8 +116,8 @@ class HMC(TraceKernel):
         # In NUTS paper, this threshold is set to a fixed log(0.5).
         # After https://github.com/stan-dev/stan/pull/356, it is set to a fixed log(0.8).
         self._direction_threshold = math.log(0.8)  # from Stan
-        # number of tries to get a valid prototype trace
-        self._max_tries_prototype_trace = 100
+        # number of tries to get a valid initial trace
+        self._max_tries_initial_trace = 100
         self.transforms = {} if transforms is None else transforms
         self._automatic_transform_enabled = True if transforms is None else False
         self._reset()
@@ -128,7 +128,7 @@ class HMC(TraceKernel):
         super(HMC, self).__init__()
 
     def _get_trace(self, z):
-        z_trace = self._prototype_trace
+        z_trace = self.initial_trace
         for name, value in z.items():
             z_trace.nodes[name]["value"] = value
         trace_poutine = poutine.trace(poutine.replay(self.model, trace=z_trace))
@@ -176,11 +176,12 @@ class HMC(TraceKernel):
         self._r_numels = {}
         self._args = None
         self._kwargs = None
-        self._prototype_trace = None
+        self._initial_trace = None
         self._has_enumerable_sites = False
         self._trace_prob_evaluator = None
         self._potential_energy_last = None
         self._z_grads_last = None
+        self._warmup_steps = None
 
     def _find_reasonable_step_size(self, z):
         step_size = self.step_size
@@ -214,15 +215,14 @@ class HMC(TraceKernel):
             direction_new = 1 if self._direction_threshold < -delta_energy else -1
         return step_size
 
-    def _guess_max_plate_nesting(self, model, *args, **kwargs):
+    def _guess_max_plate_nesting(self):
         """
         Guesses max_plate_nesting by running the model once
         without enumeration. This optimistically assumes static model
         structure.
         """
-        # Ignore validation to allow model-enumerated sites absent from the guide.
         with poutine.block():
-            model_trace = poutine.trace(model).get_trace(*args, **kwargs)
+            model_trace = poutine.trace(self.model).get_trace(*self._args, **self._kwargs)
         sites = [site
                  for site in model_trace.nodes.values()
                  if site["type"] == "sample"]
@@ -233,10 +233,10 @@ class HMC(TraceKernel):
                 if frame.vectorized]
         self.max_plate_nesting = -min(dims) if dims else 0
 
-    def _configure_adaptation(self, trace):
+    def _configure_adaptation(self):
         initial_step_size = None
         if self.adapt_step_size:
-            z = {name: node["value"].detach() for name, node in self._iter_latent_nodes(trace)}
+            z = {name: node["value"].detach() for name, node in self._iter_latent_nodes(self.initial_trace)}
             for name, transform in self.transforms.items():
                 z[name] = transform(z[name])
             with pyro.validation_enabled(False):
@@ -257,19 +257,6 @@ class HMC(TraceKernel):
         assert pos == r_flat.size(0)
         return r, r_flat
 
-    def _set_valid_prototype_trace(self, trace):
-        trace_eval = TraceEinsumEvaluator if self.use_einsum else TraceTreeEvaluator
-        self._trace_prob_evaluator = trace_eval(trace,
-                                                self._has_enumerable_sites,
-                                                self.max_plate_nesting)
-        for i in range(self._max_tries_prototype_trace):
-            trace_log_prob_sum = self._compute_trace_log_prob(trace)
-            if not torch_isnan(trace_log_prob_sum) and not torch_isinf(trace_log_prob_sum):
-                self._prototype_trace = trace
-                return
-            trace = poutine.trace(self.model).get_trace(self._args, self._kwargs)
-        raise ValueError("Model specification seems incorrect - can not find a valid trace.")
-
     @property
     def inverse_mass_matrix(self):
         return self._adapter.inverse_mass_matrix
@@ -282,24 +269,38 @@ class HMC(TraceKernel):
     def num_steps(self):
         return max(1, int(self.trajectory_length / self.step_size))
 
+    @property
     def initial_trace(self):
-        return self._prototype_trace
+        """
+        Find a valid trace to initiate the MCMC sampler. This is also used as a
+        prototype trace to inter-convert between Pyro's trace object and dict
+        object used by the integrator.
+        """
+        if self._initial_trace:
+            return self._initial_trace
+        trace = poutine.trace(self.model).get_trace(*self._args, **self._kwargs)
+        for i in range(self._max_tries_initial_trace):
+            trace_log_prob_sum = self._compute_trace_log_prob(trace)
+            if not torch_isnan(trace_log_prob_sum) and not torch_isinf(trace_log_prob_sum):
+                self._initial_trace = trace
+                return self._initial_trace
+            trace = poutine.trace(self.model).get_trace(self._args, self._kwargs)
+        raise ValueError("Model specification seems incorrect - cannot find a valid trace.")
 
-    def setup(self, warmup_steps, *args, **kwargs):
-        self._warmup_steps = warmup_steps
-        self._args = args
-        self._kwargs = kwargs
+    @initial_trace.setter
+    def initial_trace(self, trace):
+        self._initial_trace = trace
+
+    def _initialize_model_properties(self):
         if self.max_plate_nesting is None:
-            self._guess_max_plate_nesting(self.model, *args, **kwargs)
+            self._guess_max_plate_nesting()
         # Wrap model in `poutine.enum` to enumerate over discrete latent sites.
         # No-op if model does not have any discrete latents.
         self.model = poutine.enum(config_enumerate(self.model, default="parallel"),
                                   first_available_dim=-1 - self.max_plate_nesting)
-        # set the trace prototype to inter-convert between trace object
-        # and dict object used by the integrator
-        trace = poutine.trace(self.model).get_trace(*args, **kwargs)
         if self._automatic_transform_enabled:
             self.transforms = {}
+        trace = poutine.trace(self.model).get_trace(*self._args, **self._kwargs)
         for name, node in trace.iter_stochastic_nodes():
             if isinstance(node["fn"], _Subsample):
                 continue
@@ -312,15 +313,23 @@ class HMC(TraceKernel):
                 site_value = self.transforms[name](node["value"])
             self._r_shapes[name] = site_value.shape
             self._r_numels[name] = site_value.numel()
-
+        trace_eval = TraceEinsumEvaluator if self.use_einsum else TraceTreeEvaluator
+        self._trace_prob_evaluator = trace_eval(trace,
+                                                self._has_enumerable_sites,
+                                                self.max_plate_nesting)
         mass_matrix_size = sum(self._r_numels.values())
         if self.full_mass:
             initial_mass_matrix = eye_like(site_value, mass_matrix_size)
         else:
             initial_mass_matrix = site_value.new_ones(mass_matrix_size)
         self._adapter.inverse_mass_matrix = initial_mass_matrix
-        self._set_valid_prototype_trace(trace)
-        self._configure_adaptation(trace)
+
+    def setup(self, warmup_steps, *args, **kwargs):
+        self._warmup_steps = warmup_steps
+        self._args = args
+        self._kwargs = kwargs
+        self._initialize_model_properties()
+        self._configure_adaptation()
 
     def cleanup(self):
         self._reset()

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -283,7 +283,7 @@ class HMC(TraceKernel):
             trace_log_prob_sum = self._compute_trace_log_prob(trace)
             if not torch_isnan(trace_log_prob_sum) and not torch_isinf(trace_log_prob_sum):
                 self._initial_trace = trace
-                return self._initial_trace
+                return trace
             trace = poutine.trace(self.model).get_trace(self._args, self._kwargs)
         raise ValueError("Model specification seems incorrect - cannot find a valid trace.")
 

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -215,7 +215,7 @@ class _SingleSampler(TracePosterior):
             if not is_multiprocessing else None
         self.logger = initialize_logger(self.logger, logger_id, progress_bar, log_queue)
         self.kernel.setup(self.warmup_steps, *args, **kwargs)
-        trace = self.kernel.initial_trace()
+        trace = self.kernel.initial_trace
         with optional(progress_bar, not is_multiprocessing):
             for trace in self._gen_samples(self.warmup_steps, trace):
                 continue

--- a/pyro/infer/mcmc/trace_kernel.py
+++ b/pyro/infer/mcmc/trace_kernel.py
@@ -41,14 +41,21 @@ class TraceKernel(object):
         """
         pass
 
-    @abstractmethod
+    @property
     def initial_trace(self):
         """
-        Returns an initial trace from the prior to initiate the MCMC run.
+        Returns an initial trace (by default, from the prior) to initiate the MCMC run.
 
         :return: Trace instance.
         """
-        return NotImplementedError
+        raise NotImplementedError
+
+    @initial_trace.setter
+    def initial_trace(self, trace):
+        """
+        Sets the trace to initiate the MCMC run.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def sample(self, trace):

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -79,34 +79,27 @@ TEST_CASES = [
         mean_tol=0.06,
         std_tol=0.06,
     ),
-    # XXX: Very sensitive to HMC parameters. Biased estimate is obtained
-    # without enough samples and/or larger step size.
-    pytest.param(*T(
-        GaussianChain(dim=5, chain_len=2, num_obs=10000),
+    T(
+        GaussianChain(dim=5, chain_len=2, num_obs=100),
         num_samples=2000,
         warmup_steps=500,
-        hmc_params={'step_size': 0.013,
-                    'num_steps': 25},
+        hmc_params={'num_steps': 25},
         expected_means=[0.5, 1.0],
-        expected_precs=[2.0, 10000],
-        mean_tol=0.05,
-        std_tol=0.05,
-    ), marks=[pytest.mark.xfail(reason="flaky"),
-              pytest.mark.skipif('CI' in os.environ or 'CUDA_TEST' in os.environ,
-                                 reason='Slow test - skip on CI/CUDA')]),
-    pytest.param(*T(
+        expected_precs=[2.0, 100],
+        mean_tol=0.06,
+        std_tol=0.06,
+    ),
+    T(
         GaussianChain(dim=5, chain_len=9, num_obs=1),
         num_samples=3000,
         warmup_steps=500,
-        hmc_params={'step_size': 0.3,
-                    'num_steps': 8},
+        hmc_params={'step_size': 0.1,
+                    'num_steps': 15},
         expected_means=[0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90],
         expected_precs=[1.11, 0.63, 0.48, 0.42, 0.4, 0.42, 0.48, 0.63, 1.11],
-        mean_tol=0.08,
-        std_tol=0.08,
-    ), marks=[pytest.mark.xfail(reason="flaky"),
-              pytest.mark.skipif('CI' in os.environ or 'CUDA_TEST' in os.environ,
-                                 reason='Slow test - skip on CI/CUDA')])
+        mean_tol=0.1,
+        std_tol=0.1,
+    )
 ]
 
 TEST_IDS = [t[0].id_fn() if type(t).__name__ == 'TestExample'
@@ -117,7 +110,8 @@ TEST_IDS = [t[0].id_fn() if type(t).__name__ == 'TestExample'
     'fixture, num_samples, warmup_steps, hmc_params, expected_means, expected_precs, mean_tol, std_tol',
     TEST_CASES,
     ids=TEST_IDS)
-@pytest.mark.init(rng_seed=34)
+@pytest.mark.skipif('CI' in os.environ or 'CUDA_TEST' in os.environ,
+                    reason='Slow test - skip on CI/CUDA')
 @pytest.mark.disable_validation()
 def test_hmc_conjugate_gaussian(fixture,
                                 num_samples,
@@ -128,8 +122,6 @@ def test_hmc_conjugate_gaussian(fixture,
                                 mean_tol,
                                 std_tol):
     pyro.get_param_store().clear()
-    hmc_params["adapt_step_size"] = False
-    hmc_params["adapt_mass_matrix"] = False
     hmc_kernel = HMC(fixture.model, **hmc_params)
     mcmc_run = MCMC(hmc_kernel, num_samples, warmup_steps).run(fixture.data)
     for i in range(1, fixture.chain_len + 1):

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -272,7 +272,7 @@ def test_gaussian_hmm(num_steps, use_einsum):
 
     def _get_initial_trace():
         guide = AutoDelta(poutine.block(model, expose_fn=lambda msg: not msg["name"].startswith("x") and
-                                                                     not msg["name"].startswith("y")))
+                                        not msg["name"].startswith("y")))
         elbo = TraceEnum_ELBO(max_plate_nesting=1)
         svi = SVI(model, guide, optim.Adam({"lr": .01}), elbo, num_steps=100).run(data)
         return svi.exec_traces[-1]


### PR DESCRIPTION
Addresses #1520.

Refactors the class internals to:
 - Have the ability to set the initial trace to something other than sampling from the prior. Changed the internal `_prototype_trace` to `_initial_trace`. 
 - All model specific attributes that are required to be setup are done in `_initialize_model_properties`.

This is tested on the HMM example by passing in the trace from SVI inference with an AutoDelta guide. I would like to play around with the HMM example once this PR is merged. Additionally, I have removed all conjugate gaussian tests from running on CI and set wide enough precisions that they will run successfully locally since we use it for profiling, and measuring improvements to the algorithm, as mentioned in #1532.