### PR TITLE
Print time taken by slowest examples in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,6 @@ jobs:
           script:
               - pip install -e .[profile]
               - pytest -vs --benchmark-disable tests/perf/test_benchmark.py
-        - python: 3.6
-          if: type = cron
-          env: STAGE=perf
-          script:
-              - pip install -e .[profile]
-              - make perf-test
         - stage: profiler
           python: 2.7
           env: STAGE=profiler
@@ -64,15 +58,18 @@ jobs:
         - python: 2.7
           env: STAGE=examples
           script:
-              - CI=1 pytest -vs --cov=pyro --cov-config .coveragerc --stage test_examples
+              - CI=1 pytest -vs --cov=pyro --cov-config .coveragerc --stage test_examples --durations 10
               - grep -l smoke_test tutorial/source/*.ipynb | xargs grep -L 'smoke_test = False' \
-                  | CI=1 xargs pytest -vx --nbval-lax --current-env
+                  | CI=1 xargs pytest -vx --nbval-lax --current-env --durations 10
         - python: 3.6
           env: STAGE=unit
           script: pytest -vs --cov=pyro --cov-config .coveragerc --stage unit --durations 20
         - python: 3.6
           env: STAGE=examples
-          script: pytest -vs --cov=pyro --cov-config .coveragerc --stage test_examples
+          script:
+              - CI=1 pytest -vs --cov=pyro --cov-config .coveragerc --stage test_examples --durations 10
+              - grep -l smoke_test tutorial/source/*.ipynb | xargs grep -L 'smoke_test = False' \
+                  | CI=1 xargs pytest -vx --nbval-lax --current-env --durations 10
         - stage: integration test
           python: 2.7
           env: STAGE=integration_batch_1

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
           script:
               - CI=1 pytest -vs --cov=pyro --cov-config .coveragerc --stage test_examples --durations 10
               - grep -l smoke_test tutorial/source/*.ipynb | xargs grep -L 'smoke_test = False' \
-                  | CI=1 xargs pytest -vx --nbval-lax --current-env --durations 10
+                  | CI=1 xargs pytest -vx --nbval-lax --current-env
         - python: 3.6
           env: STAGE=unit
           script: pytest -vs --cov=pyro --cov-config .coveragerc --stage unit --durations 20
@@ -69,7 +69,7 @@ jobs:
           script:
               - CI=1 pytest -vs --cov=pyro --cov-config .coveragerc --stage test_examples --durations 10
               - grep -l smoke_test tutorial/source/*.ipynb | xargs grep -L 'smoke_test = False' \
-                  | CI=1 xargs pytest -vx --nbval-lax --current-env --durations 10
+                  | CI=1 xargs pytest -vx --nbval-lax --current-env
         - stage: integration test
           python: 2.7
           env: STAGE=integration_batch_1


### PR DESCRIPTION
This adds the time taken by the slowest examples in `test_examples`. I wanted to look at this while debugging #1540. 

Some other minor modifications to `.travis.yml`:
 - Removed the `perf-test` cron job (already disabled) which has instead been running on my workstation for a long time.
 - Added the tutorial notebook cells to also run in python 3.6.