### PR TITLE
Fix test_memory to ignore UserWarning with gc.getobjects()

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import gc
+import warnings
 
 import networkx as nx
 import pytest
@@ -17,7 +18,9 @@ pytestmark = pytest.mark.stage('unit')
 
 
 def count_objects_of_type(type_):
-    return sum(1 for obj in gc.get_objects() if isinstance(obj, type_))
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        return sum(1 for obj in gc.get_objects() if isinstance(obj, type_))
 
 
 def test_trace():


### PR DESCRIPTION
This is as a fix for errors in `test_memory.py` in `pytorch-1.0` branch due to an unrelated `UserWarning`:

```
>>> import torch
>>> import gc
>>> sum([1 if isinstance(obj, torch.Tensor) else 0 for obj in gc.get_objects()])
/home/npradhan/miniconda3/envs/pytorch-nightly/lib/python3.6/site-packages/torch/distributed/distributed_c10d.py:86: UserWarning: torch.distributed.reduce_op is deprecated, please use torch.distributed.ReduceOp instead
  warnings.warn("torch.distributed.reduce_op is deprecated, please use "
```

I have mentioned this on pytorch slack. Will merge into `pytorch-1.0` once it is landed on `dev`.