### PR TITLE
Revise baseball example with diagnostics info

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -5,7 +5,6 @@ import logging
 import math
 import os
 
-import numpy as np
 import pandas as pd
 import torch
 
@@ -16,6 +15,7 @@ from pyro.distributions.util import logsumexp
 from pyro.infer import EmpiricalMarginal
 from pyro.infer.abstract_infer import TracePredictive
 from pyro.infer.mcmc import MCMC, NUTS
+from pyro.ops.stats import effective_sample_size, split_gelman_rubin
 
 """
 Example has been adapted from [1]. It demonstrates how to do Bayesian inference using
@@ -64,34 +64,37 @@ DATA_URL = "https://d2fefpcigoriu7.cloudfront.net/datasets/EfronMorrisBB.txt"
 # ===================================
 
 
-def fully_pooled(at_bats):
+def fully_pooled(at_bats, hits):
     r"""
     Number of hits in $K$ at bats for each player has a Binomial
     distribution with a common probability of success, $\phi$.
 
     :param (torch.Tensor) at_bats: Number of at bats for each player.
+    :param (torch.Tensor) hits: Number of hits for the given at bats.
     :return: Number of hits predicted by the model.
     """
     phi_prior = Uniform(at_bats.new_tensor(0), at_bats.new_tensor(1))
     phi = pyro.sample("phi", phi_prior)
-    return pyro.sample("obs", Binomial(at_bats, phi))
+    return pyro.sample("obs", Binomial(at_bats, phi), obs=hits)
 
 
-def not_pooled(at_bats):
+def not_pooled(at_bats, hits):
     r"""
     Number of hits in $K$ at bats for each player has a Binomial
     distribution with independent probability of success, $\phi_i$.
 
     :param (torch.Tensor) at_bats: Number of at bats for each player.
+    :param (torch.Tensor) hits: Number of hits for the given at bats.
     :return: Number of hits predicted by the model.
     """
     num_players = at_bats.shape[0]
+    # TODO: use pyro.plate when pytorch 1.0 is released
     phi_prior = Uniform(at_bats.new_tensor(0), at_bats.new_tensor(1)).expand_by([num_players]).independent(1)
     phi = pyro.sample("phi", phi_prior)
-    return pyro.sample("obs", Binomial(at_bats, phi))
+    return pyro.sample("obs", Binomial(at_bats, phi), obs=hits)
 
 
-def partially_pooled(at_bats):
+def partially_pooled(at_bats, hits):
     r"""
     Number of hits has a Binomial distribution with independent
     probability of success, $\phi_i$. Each $\phi_i$ follows a Beta
@@ -100,6 +103,7 @@ def partially_pooled(at_bats):
     and $kappa ~ Pareto(1, 1.5)$.
 
     :param (torch.Tensor) at_bats: Number of at bats for each player.
+    :param (torch.Tensor) hits: Number of hits for the given at bats.
     :return: Number of hits predicted by the model.
     """
     num_players = at_bats.shape[0]
@@ -107,34 +111,24 @@ def partially_pooled(at_bats):
     kappa = pyro.sample("kappa", Pareto(at_bats.new_tensor(1), at_bats.new_tensor(1.5)))
     phi_prior = Beta(m * kappa, (1 - m) * kappa).expand_by([num_players]).independent(1)
     phi = pyro.sample("phi", phi_prior)
-    return pyro.sample("obs", Binomial(at_bats, phi))
+    return pyro.sample("obs", Binomial(at_bats, phi), obs=hits)
 
 
-def partially_pooled_with_logit(at_bats):
+def partially_pooled_with_logit(at_bats, hits):
     r"""
     Number of hits has a Binomial distribution with a logit link function.
     The logits $\alpha$ for each player is normally distributed with the
     mean and scale parameters sharing a common prior.
 
     :param (torch.Tensor) at_bats: Number of at bats for each player.
+    :param (torch.Tensor) hits: Number of hits for the given at bats.
     :return: Number of hits predicted by the model.
     """
     num_players = at_bats.shape[0]
     loc = pyro.sample("loc", Normal(at_bats.new_tensor(-1), at_bats.new_tensor(1)))
     scale = pyro.sample("scale", HalfCauchy(scale=at_bats.new_tensor(1)))
     alpha = pyro.sample("alpha", Normal(loc, scale).expand_by([num_players]).independent(1))
-    return pyro.sample("obs", Binomial(at_bats, logits=alpha))
-
-
-def conditioned_model(model, at_bats, hits):
-    """
-    Condition the model on observed data, for inference.
-
-    :param model: python callable with Pyro primitives.
-    :param (torch.Tensor) at_bats: Number of at bats for each player.
-    :param (torch.Tensor) hits: Number of hits for the given at bats.
-    """
-    return poutine.condition(model, data={"obs": hits})(at_bats)
+    return pyro.sample("obs", Binomial(at_bats, logits=alpha), obs=hits)
 
 
 # ===================================
@@ -147,6 +141,7 @@ def get_site_stats(array, player_names):
     Return the summarized statistics for a given array corresponding
     to the values sampled for a latent or response site.
     """
+    # TODO: only use pandas (or any lightweight tabular package) to display final result
     if len(array.shape) == 1:
         df = pd.DataFrame(array).transpose()
     else:
@@ -154,20 +149,37 @@ def get_site_stats(array, player_names):
     return df.apply(pd.Series.describe, axis=1)[["mean", "std", "25%", "50%", "75%"]]
 
 
-def summary(traces, sites, player_names, transforms={}):
+def summary(trace_posterior, sites, player_names, transforms={}, diagnostics=True):
     """
     Return summarized statistics for each of the ``sites`` in the
     traces corresponding to the approximate posterior.
     """
-    marginal = EmpiricalMarginal(traces, sites).get_samples_and_weights()[0].numpy()
+    marginal = EmpiricalMarginal(trace_posterior, sites).get_samples_and_weights()[0]
+
+    if diagnostics and trace_posterior.sampler.num_chains > 1:
+        chain_indices = trace_posterior.sampler.chain_indices
+        n_eff, r_hat = chain_diagnostics(marginal, chain_indices)
+
     site_stats = {}
     for i in range(marginal.shape[1]):
         site_name = sites[i]
         marginal_site = marginal[:, i]
         if site_name in transforms:
             marginal_site = transforms[site_name](marginal_site)
-        site_stats[site_name] = get_site_stats(marginal_site, player_names)
+        site_stats[site_name] = get_site_stats(marginal_site.numpy(), player_names)
+        if chain_indices is not None:
+            site_stats[site_name].assign(n_eff=n_eff[i].numpy())
+            site_satts[site_name].assign(r_hat=r_hat[i].numpy())
     return site_stats
+
+
+def chain_diagnostics(samples, chain_indices):
+    assert samples.size(0) == chain_indices.numel()
+    chain_samples = samples[chain_indices.reshape(-1)].reshape(
+        chain_indices.shape + samples.shape[1:])
+    n_eff = effective_sample_size(chain_samples, sample_dim=1, chain_dim=0)
+    r_hat = split_gelman_rubin(chain_samples, sample_dim=1, chain_dim=0)
+    return n_eff, r_hat
 
 
 def train_test_split(pd_dataframe):
@@ -199,29 +211,29 @@ def sample_posterior_predictive(posterior_predictive, baseball_dataset):
     logging.info("\nPosterior Predictive:")
     logging.info("Hit Rate - Initial 45 At Bats")
     logging.info("-----------------------------")
-    train_predict = posterior_predictive.run(at_bats)
-    train_summary = summary(train_predict, sites=["obs"], player_names=player_names)["obs"]
+    # set hits=None to convert it from observation node to sample node
+    train_predict = posterior_predictive.run(at_bats, None)
+    train_summary = summary(train_predict, sites=["obs"],
+                            player_names=player_names, diagnostics=False)["obs"]
     train_summary = train_summary.assign(ActualHits=baseball_dataset[["Hits"]].values)
     logging.info(train_summary)
     logging.info("\nHit Rate - Season Predictions")
     logging.info("-----------------------------")
-    test_predict = posterior_predictive.run(at_bats_season)
-    test_summary = summary(test_predict, sites=["obs"], player_names=player_names)["obs"]
+    test_predict = posterior_predictive.run(at_bats_season, None)
+    test_summary = summary(test_predict, sites=["obs"],
+                           player_names=player_names, diagnostics=False)["obs"]
     test_summary = test_summary.assign(ActualHits=baseball_dataset[["SeasonHits"]].values)
     logging.info(test_summary)
 
 
-def evaluate_log_predictive_density(model, model_trace_posterior, baseball_dataset):
+def evaluate_log_predictive_density(posterior_predictive, baseball_dataset):
     """
     Evaluate the log probability density of observing the unseen data (season hits)
     given a model and empirical distribution over the parameters.
     """
     _, test, player_names = train_test_split(baseball_dataset)
     at_bats_season, hits_season = test[:, 0], test[:, 1]
-    test_eval = TracePredictive(conditioned_model,
-                                model_trace_posterior,
-                                num_samples=args.num_samples)
-    test_eval.run(model, at_bats_season, hits_season)
+    test_eval = posterior_predictive.run(at_bats_season, hits_season)
     trace_log_pdf = []
     for tr in test_eval.exec_traces:
         trace_log_pdf.append(tr.log_prob_sum())
@@ -229,7 +241,7 @@ def evaluate_log_predictive_density(model, model_trace_posterior, baseball_datas
     # where $\theta^{i}$ are parameter samples from the model's posterior.
     posterior_pred_density = logsumexp(torch.stack(trace_log_pdf), dim=-1) - math.log(len(trace_log_pdf))
     logging.info("\nLog posterior predictive density")
-    logging.info("---------------------------------")
+    logging.info("--------------------------------")
     logging.info("{:.4f}\n".format(posterior_pred_density))
 
 
@@ -238,16 +250,16 @@ def main(args):
     baseball_dataset = pd.read_csv(DATA_URL, "\t")
     train, _, player_names = train_test_split(baseball_dataset)
     at_bats, hits = train[:, 0], train[:, 1]
-    nuts_kernel = NUTS(conditioned_model)
     logging.info("Original Dataset:")
     logging.info(baseball_dataset)
 
     # (1) Full Pooling Model
+    nuts_kernel = NUTS(fully_pooled)
     posterior_fully_pooled = MCMC(nuts_kernel,
                                   num_samples=args.num_samples,
                                   warmup_steps=args.warmup_steps,
                                   num_chains=args.num_chains) \
-        .run(fully_pooled, at_bats, hits)
+        .run(at_bats, hits)
     logging.info("\nModel: Fully Pooled")
     logging.info("===================")
     logging.info("\nphi:")
@@ -256,9 +268,10 @@ def main(args):
                                            posterior_fully_pooled,
                                            num_samples=args.num_samples)
     sample_posterior_predictive(posterior_predictive, baseball_dataset)
-    evaluate_log_predictive_density(fully_pooled, posterior_fully_pooled, baseball_dataset)
+    evaluate_log_predictive_density(posterior_predictive, baseball_dataset)
 
     # (2) No Pooling Model
+    nuts_kernel = NUTS(not_pooled)
     posterior_not_pooled = MCMC(nuts_kernel,
                                 num_samples=args.num_samples,
                                 warmup_steps=args.warmup_steps,
@@ -272,11 +285,12 @@ def main(args):
                                            posterior_not_pooled,
                                            num_samples=args.num_samples)
     sample_posterior_predictive(posterior_predictive, baseball_dataset)
-    evaluate_log_predictive_density(not_pooled, posterior_not_pooled, baseball_dataset)
+    evaluate_log_predictive_density(posterior_predictive, baseball_dataset)
 
     # (3) Partially Pooled Model
     # TODO: remove once htps://github.com/uber/pyro/issues/1458 is resolved
     if "CI" not in os.environ:
+        nuts_kernel = NUTS(partially_pooled)
         posterior_partially_pooled = MCMC(nuts_kernel,
                                           num_samples=args.num_samples,
                                           warmup_steps=args.warmup_steps,
@@ -291,9 +305,10 @@ def main(args):
                                                posterior_partially_pooled,
                                                num_samples=args.num_samples)
         sample_posterior_predictive(posterior_predictive, baseball_dataset)
-        evaluate_log_predictive_density(partially_pooled, posterior_partially_pooled, baseball_dataset)
+        evaluate_log_predictive_density(posterior_predictive, baseball_dataset)
 
     # (4) Partially Pooled with Logit Model
+    nuts_kernel = NUTS(partially_pooled_with_logit)
     posterior_partially_pooled_with_logit = MCMC(nuts_kernel,
                                                  num_samples=args.num_samples,
                                                  warmup_steps=args.warmup_steps,
@@ -305,13 +320,12 @@ def main(args):
     logging.info(summary(posterior_partially_pooled_with_logit,
                          sites=["alpha"],
                          player_names=player_names,
-                         transforms={"alpha": lambda x: 1. / (1 + np.exp(-x))})["alpha"])
+                         transforms={"alpha": lambda x: 1. / (1 + (-x).exp())})["alpha"])
     posterior_predictive = TracePredictive(partially_pooled_with_logit,
                                            posterior_partially_pooled_with_logit,
                                            num_samples=args.num_samples)
     sample_posterior_predictive(posterior_predictive, baseball_dataset)
-    evaluate_log_predictive_density(partially_pooled_with_logit,
-                                    posterior_partially_pooled_with_logit, baseball_dataset)
+    evaluate_log_predictive_density(posterior_predictive, baseball_dataset)
 
 
 if __name__ == "__main__":

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -9,6 +9,7 @@ from torch.distributions import constraints
 from pyro.distributions.torch import Categorical
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.util import copy_docs_from, logsumexp
+from pyro.ops.stats import effective_sample_size, split_gelman_rubin
 
 
 @copy_docs_from(TorchDistribution)

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -9,7 +9,6 @@ from torch.distributions import constraints
 from pyro.distributions.torch import Categorical
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.util import copy_docs_from, logsumexp
-from pyro.ops.stats import effective_sample_size, split_gelman_rubin
 
 
 @copy_docs_from(TorchDistribution)

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -48,9 +48,9 @@ class TracePosterior(object):
     that need access to the collected execution traces.
     """
     def __init__(self):
-        self._init()
+        self._reset()
 
-    def _init(self):
+    def _reset(self):
         self.log_weights = []
         self.exec_traces = []
         self._categorical = None
@@ -79,7 +79,7 @@ class TracePosterior(object):
         :param args: optional args taken by `self._traces`.
         :param kwargs: optional keywords args taken by `self._traces`.
         """
-        self._init()
+        self._reset()
         with poutine.block():
             for tr, logit in self._traces(*args, **kwargs):
                 self.exec_traces.append(tr)

--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -4,7 +4,7 @@ import os
 import sys
 from collections import OrderedDict
 
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 
 # Identifiers to distinguish between diagnostic messages for progress bars
 # vs. logging output. Useful when using QueueHandler in multiprocessing.

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -268,6 +268,7 @@ class MCMC(TracePosterior):
                  num_chains=1, mp_context=None):
         self.warmup_steps = warmup_steps if warmup_steps is not None else num_samples // 2  # Stan
         self.num_samples = num_samples
+        self.num_chains = num_chains
         if num_chains > 1:
             cpu_count = mp.cpu_count()
             if num_chains > cpu_count:

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         'opt_einsum>=2.2.0',
         'six>=1.10.0',
         'torch==0.4.0',
-        'tqdm>=4.25',
+        'tqdm>=4.27',
     ],
     extras_require={
         'extras': EXTRAS_REQUIRE,


### PR DESCRIPTION
This full request does the following:
- Make baseball example easier to follow (by removing conditioned model and renaming several variables). For predictions based on posterior, now the user only needs  to use one `TracePredictive` instance (not two instances: one for `model`, another for `conditioned_model` as before).
- Add chain diagnostics to the summary. To be able to achieve this, I modify Parallel sampler in mcmc a bit to trace the indices of samples for each chain. (addressing #1520)
- Fix the warning when using `tqdm.autonotebook` and fix the error `RuntimeError: received 0 items of ancdata` (when running multiprocessing in slow computer).
- `num_samples` in MCMC is now the number of samples in each chain.

If you obverse effective sample size > (num_samples * num_chains), then it is totally fine. Discussion about that can be found [here](https://andrewgelman.com/2018/01/18/measuring-speed-stan-incorrectly-faster-thought-cases-due-antithetical-sampling/).