### PR TITLE
Refactor pyro.ops.contract to prepare for MAP algorithm

### DIFF
--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -38,7 +38,7 @@ def _check_tree_structure(parent, leaf):
 
 
 @add_metaclass(ABCMeta)
-class TensorRing(object):
+class Ring(object):
     """
     Abstract tensor ring class.
 
@@ -64,14 +64,6 @@ class TensorRing(object):
         return result
 
     @abstractmethod
-    def dims(self, term):
-        """
-        Returns an iterable of nontrivial dims associted with this term.
-        Derived classes may use any hashable type for dims.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     def sumproduct(self, terms, dims):
         """
         Multiply all ``terms`` together, then sum-contract out all ``dims``
@@ -93,8 +85,7 @@ class TensorRing(object):
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def broadcast(self, tensor, ordinal):
+    def broadcast(self, term, ordinal):
         """
         Broadcast the given ``term`` by expanding along any batch dimensions
         present in ``ordinal`` but not ``term``.
@@ -102,78 +93,77 @@ class TensorRing(object):
         :param torch.Tensor term: the term to expand
         :param frozenset ordinal: an ordinal specifying batch context
         """
-        raise NotImplementedError
+        dims = term._pyro_dims
+        missing_dims = ''.join(sorted(set(ordinal) - set(dims)))
+        if missing_dims:
+            key = 'broadcast', self._hash_by_id(term), missing_dims
+            if key in self._cache:
+                term = self._cache[key]
+            else:
+                missing_shape = tuple(self._dim_to_size[dim] for dim in missing_dims)
+                term = term.expand(missing_shape + term.shape)
+                dims = missing_dims + dims
+                self._cache[key] = term
+                term._pyro_dims = dims
+        return term
 
+    @abstractmethod
     def inv(self, term):
         """
         Computes the reciprocal of a term, for use in inclusion-exclusion.
 
-        The default implementation assumes log-space representation.
-
         :param torch.Tensor term: the term to invert
         """
-        key = 'inv', self._hash_by_id(term)
-        if key in self._cache:
-            return self._cache[key]
+        raise NotImplementedError
 
-        result = -term
-        result.clamp_(max=_finfo(result).max)  # avoid nan due to inf - inf
-        result._pyro_dims = term._pyro_dims
-        self._cache[key] = result
-        return result
-
-    def forward_backward(self, term, dims, ordinal):
+    def global_local(self, term, dims, ordinal):
         r"""
-        Computes forward and backward messages for tensor message passing
+        Computes global and local terms for tensor message passing
         using inclusion-exclusion::
 
             term / sum(term, dims) * product(sum(term, dims), ordinal)
             \____________________/   \_______________________________/
-                backward part                  forward part
+                  local part                    global part
 
         :param torch.Tensor term: the term to contract
         :param dims: an iterable of sum dims to contract
         :param frozenset ordinal: an ordinal specifying batch dims to contract
-        :return: a tuple
-            ``(product(sum(term, dims), ordinal), term / sum(term, dims))``
+        :return: a tuple ``(global_part, local_part)`` as defined above
         :rtype: tuple
         """
         assert dims, 'dims was empty, use .product() instead'
-        key = 'forward_backward', self._hash_by_id(term), frozenset(dims), ordinal
+        key = 'global_local', self._hash_by_id(term), frozenset(dims), ordinal
         if key in self._cache:
             return self._cache[key]
 
         term_sum = self.sumproduct([term], dims)
-        forward_part = self.product(term_sum, ordinal)
-        backward_part = self.sumproduct([term, self.inv(term_sum)], set())
-        assert self.dims(backward_part) == self.dims(term)
-        result = forward_part, backward_part
+        global_part = self.product(term_sum, ordinal)
+        local_part = self.sumproduct([term, self.inv(term_sum)], set())
+        assert local_part._pyro_dims == term._pyro_dims
+        result = global_part, local_part
         self._cache[key] = result
         return result
 
 
-class PackedLogRing(TensorRing):
+class LogRing(Ring):
     """
-    Tensor Ring of packed tensors with named dimensions in log space.
+    Ring of sum-product operations in log space.
 
     Tensor values are in log units, so ``sum`` is implemented as ``logsumexp``,
     and ``product`` is implemented as ``sum``.
-    Tensor dimensions are packed; to read the name of a tensor, call
-    :meth:`dims`, which returns a string of dimension names aligned with the
-    tensor's shape.
+    Tensor dimensions are packed; to read the name of a tensor, read the
+    ``._pyro_dims`` attribute, which is a string of dimension names aligned
+    with the tensor's shape.
 
     Dims are characters (string or unicode).
     Ordinals are frozensets of characters.
     """
     def __init__(self, cache=None, dim_to_size=None):
-        super(PackedLogRing, self).__init__(cache=cache)
+        super(LogRing, self).__init__(cache=cache)
         self._dim_to_size = {} if dim_to_size is None else dim_to_size
 
-    def dims(self, term):
-        return term._pyro_dims
-
     def sumproduct(self, terms, dims):
-        inputs = [self.dims(term) for term in terms]
+        inputs = [term._pyro_dims for term in terms]
         output = ''.join(sorted(set(''.join(inputs)) - set(dims)))
         equation = ','.join(inputs) + '->' + output
         term = contract(equation, *terms, backend='pyro.ops.einsum.torch_log')
@@ -181,7 +171,7 @@ class PackedLogRing(TensorRing):
         return term
 
     def product(self, term, ordinal):
-        dims = self.dims(term)
+        dims = term._pyro_dims
         for dim in sorted(ordinal, reverse=True):
             pos = dims.find(dim)
             if pos != -1:
@@ -195,20 +185,16 @@ class PackedLogRing(TensorRing):
                     term._pyro_dims = dims
         return term
 
-    def broadcast(self, term, ordinal):
-        dims = self.dims(term)
-        missing_dims = ''.join(sorted(set(ordinal) - set(dims)))
-        if missing_dims:
-            key = 'broadcast', self._hash_by_id(term), missing_dims
-            if key in self._cache:
-                term = self._cache[key]
-            else:
-                missing_shape = tuple(self._dim_to_size[dim] for dim in missing_dims)
-                term = term.expand(missing_shape + term.shape)
-                dims = missing_dims + dims
-                self._cache[key] = term
-                term._pyro_dims = dims
-        return term
+    def inv(self, term):
+        key = 'inv', self._hash_by_id(term)
+        if key in self._cache:
+            return self._cache[key]
+
+        result = -term
+        result.clamp_(max=_finfo(result).max)  # avoid nan due to inf - inf
+        result._pyro_dims = term._pyro_dims
+        self._cache[key] = result
+        return result
 
 
 def _partition_terms(ring, terms, dims):
@@ -223,7 +209,7 @@ def _partition_terms(ring, terms, dims):
     # are enumerated. This conflates terms and dims (tensors and ints).
     neighbors = OrderedDict([(t, []) for t in terms] + [(d, []) for d in sorted(dims)])
     for term in terms:
-        for dim in ring.dims(term):
+        for dim in term._pyro_dims:
             if dim in dims:
                 neighbors[term].append(dim)
                 neighbors[dim].append(term)
@@ -259,7 +245,7 @@ def _contract_component(ring, tensor_tree, sum_dims, target_dims):
     This function should be deterministic.
     This function has side-effects: it modifies ``tensor_tree``.
 
-    :param TensorRing ring: an algebraic ring defining tensor operations.
+    :param Ring ring: an algebraic ring defining tensor operations.
     :param OrderedDict tensor_tree: a dictionary mapping ordinals to lists of
         tensors. An ordinal is a frozenset of ``CondIndepStack`` frames.
     :param set sum_dims: the complete set of sum-contractions dimensions
@@ -274,16 +260,16 @@ def _contract_component(ring, tensor_tree, sum_dims, target_dims):
     dim_to_ordinal = {}
     for t, terms in tensor_tree.items():
         for term in terms:
-            for dim in sum_dims.intersection(ring.dims(term)):
+            for dim in sum_dims.intersection(term._pyro_dims):
                 dim_to_ordinal[dim] = dim_to_ordinal.get(dim, t) & t
     dims_tree = defaultdict(set)
     for dim, t in dim_to_ordinal.items():
         dims_tree[t].add(dim)
 
     # Recursively combine terms in different plate contexts.
-    backward_terms = []
-    backward_dims = target_dims.copy()
-    backward_ordinal = frozenset()
+    local_terms = []
+    local_dims = target_dims.copy()
+    local_ordinal = frozenset()
     min_ordinal = frozenset.intersection(*tensor_tree)
     while any(dims_tree.values()):
         # Arbitrarily deterministically choose a leaf.
@@ -295,22 +281,22 @@ def _contract_component(ring, tensor_tree, sum_dims, target_dims):
         for terms, dims in _partition_terms(ring, leaf_terms, leaf_dims):
 
             # Eliminate sum dims via a sumproduct contraction.
-            term = ring.sumproduct(terms, dims - backward_dims)
+            term = ring.sumproduct(terms, dims - local_dims)
 
             # Eliminate extra plate dims via product contractions.
             if leaf == min_ordinal:
                 parent = leaf
             else:
-                pending_dims = sum_dims.intersection(ring.dims(term))
+                pending_dims = sum_dims.intersection(term._pyro_dims)
                 parent = frozenset.union(*(t for t, d in dims_tree.items() if d & pending_dims))
                 _check_tree_structure(parent, leaf)
                 contract_frames = leaf - parent
-                contract_dims = dims & backward_dims
+                contract_dims = dims & local_dims
                 if contract_dims:
-                    term, backward_term = ring.forward_backward(term, contract_dims, contract_frames)
-                    backward_terms.append(backward_term)
-                    backward_dims |= sum_dims.intersection(ring.dims(backward_term))
-                    backward_ordinal |= leaf
+                    term, local_term = ring.global_local(term, contract_dims, contract_frames)
+                    local_terms.append(local_term)
+                    local_dims |= sum_dims.intersection(local_term._pyro_dims)
+                    local_ordinal |= leaf
                 else:
                     term = ring.product(term, contract_frames)
             tensor_tree.setdefault(parent, []).append(term)
@@ -320,12 +306,12 @@ def _contract_component(ring, tensor_tree, sum_dims, target_dims):
     ordinal, (term,) = tensor_tree.popitem()
     assert ordinal == min_ordinal
 
-    # Perform optional backward pass.
-    if backward_terms:
+    # Perform optional localizing pass.
+    if local_terms:
         assert target_dims
-        backward_terms.append(term)
-        term = ring.sumproduct(backward_terms, backward_dims - target_dims)
-        ordinal |= backward_ordinal
+        local_terms.append(term)
+        term = ring.sumproduct(local_terms, local_dims - target_dims)
+        ordinal |= local_ordinal
 
     return ordinal, term
 
@@ -350,7 +336,7 @@ def contract_tensor_tree(tensor_tree, sum_dims, cache=None):
     assert isinstance(tensor_tree, OrderedDict)
     assert isinstance(sum_dims, set)
 
-    ring = PackedLogRing(cache)
+    ring = LogRing(cache)
     ordinals = {term: t for t, terms in tensor_tree.items() for term in terms}
     all_terms = [term for terms in tensor_tree.values() for term in terms]
     contracted_tree = OrderedDict()
@@ -401,7 +387,7 @@ def contract_to_tensor(tensor_tree, sum_dims, target_ordinal=None, target_dims=N
     assert isinstance(target_ordinal, frozenset)
     assert isinstance(target_dims, set) and target_dims <= sum_dims
 
-    ring = PackedLogRing(cache, dim_to_size)
+    ring = LogRing(cache, dim_to_size)
     ordinals = {term: t for t, terms in tensor_tree.items() for term in terms}
     all_terms = [term for terms in tensor_tree.values() for term in terms]
     contracted_terms = []
@@ -417,20 +403,20 @@ def contract_to_tensor(tensor_tree, sum_dims, target_ordinal=None, target_dims=N
 
         # Contract this connected component down to a single tensor.
         ordinal, term = _contract_component(ring, component, dims, target_dims & dims)
-        _check_batch_dims_are_sensible(target_dims.intersection(ring.dims(term)),
+        _check_batch_dims_are_sensible(target_dims.intersection(term._pyro_dims),
                                        ordinal - target_ordinal)
 
         # Eliminate extra plate dims via product contractions.
         contract_frames = ordinal - target_ordinal
         if contract_frames:
-            assert not sum_dims.intersection(ring.dims(term))
+            assert not sum_dims.intersection(term._pyro_dims)
             term = ring.product(term, contract_frames)
 
         contracted_terms.append(term)
 
     # Combine contracted tensors via product, then broadcast.
     term = ring.sumproduct(contracted_terms, set())
-    assert sum_dims.intersection(ring.dims(term)) <= target_dims
+    assert sum_dims.intersection(term._pyro_dims) <= target_dims
     return ring.broadcast(term, target_ordinal)
 
 

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -10,7 +10,7 @@ import six
 import torch
 
 from pyro.distributions.util import logsumexp
-from pyro.ops.contract import (PackedLogRing, _partition_terms, contract_tensor_tree, contract_to_tensor, naive_ubersum,
+from pyro.ops.contract import (LogRing, _partition_terms, contract_tensor_tree, contract_to_tensor, naive_ubersum,
                                ubersum)
 from pyro.poutine.indep_messenger import CondIndepStackFrame
 from pyro.util import optional
@@ -102,7 +102,7 @@ def _normalize(tensor, dims, batch_dims):
     (['a', 'ab', 'bc', 'c'], set('abc'), 1),
 ])
 def test_partition_terms(inputs, dims, expected_num_components):
-    ring = PackedLogRing()
+    ring = LogRing()
     symbol_to_size = dict(zip('abc', [2, 3, 4]))
     shapes = [tuple(symbol_to_size[s] for s in input_) for input_ in inputs]
     tensors = [torch.randn(shape) for shape in shapes]


### PR DESCRIPTION
This cleans up pyro.ops.contract after #1521 in preparation for implementing MAP for enumerated variables:
- rename `TensorRing` -> `Ring`, `PackedLogRing` -> `LogRing` now that all tensors are packed
- replace `ring.dims(x)` -> `x._pyro_dims` now that all tensors are packed
- rename `.forward_backward()` -> `.global_local()` to avoid confusion with a different forward-backward algorithm planned for MAP estimation
- make `.inv()` abstract and `.broadcast()` concrete