### PR TITLE
Getting parameters from TransformModule & TransformedDistribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -178,3 +178,10 @@ PermuteTransform
     :members:
     :undoc-members:
     :show-inheritance:
+
+TransformModule
+----------------
+.. autoclass:: pyro.distributions.TransformModule
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -150,7 +150,7 @@ class DMM(nn.Module):
 
         # if we're using normalizing flows, instantiate those too
         self.iafs = [InverseAutoregressiveFlow(AutoRegressiveNN(z_dim, [iaf_dim])) for _ in range(num_iafs)]
-        self.iafs_modules = nn.ModuleList([self.iafs])
+        self.iafs_modules = nn.ModuleList(self.iafs)
 
         # define a (trainable) parameters z_0 and z_q_0 that help define the probability
         # distributions p(z_1) and q(z_1)

--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -150,7 +150,7 @@ class DMM(nn.Module):
 
         # if we're using normalizing flows, instantiate those too
         self.iafs = [InverseAutoregressiveFlow(AutoRegressiveNN(z_dim, [iaf_dim])) for _ in range(num_iafs)]
-        self.iafs_modules = nn.ModuleList([iaf.module for iaf in self.iafs])
+        self.iafs_modules = nn.ModuleList([self.iafs])
 
         # define a (trainable) parameters z_0 and z_q_0 that help define the probability
         # distributions p(z_1) and q(z_1)

--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -618,7 +618,7 @@ class AutoIAFNormal(AutoContinuous):
         if self.hidden_dim is None:
             self.hidden_dim = self.latent_dim
         iaf = dist.InverseAutoregressiveFlow(AutoRegressiveNN(self.latent_dim, [self.hidden_dim]))
-        pyro.module("{}_iaf".format(self.prefix), iaf.module)
+        pyro.module("{}_iaf".format(self.prefix), iaf)
         iaf_dist = dist.TransformedDistribution(dist.Normal(0., 1.).expand([self.latent_dim]), [iaf])
         return iaf_dist.independent(1)
 

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -49,6 +49,7 @@ __all__ = [
     "RelaxedBernoulliStraightThrough",
     "RelaxedOneHotCategoricalStraightThrough",
     "TorchDistribution",
+    "TransformModule",
     "VonMises",
     "VonMises3D",
     "ZeroInflatedPoisson"

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -21,6 +21,7 @@ from pyro.distributions.relaxed_straight_through import (RelaxedBernoulliStraigh
 from pyro.distributions.torch import *  # noqa F403
 from pyro.distributions.torch import __all__ as torch_dists
 from pyro.distributions.torch_distribution import TorchDistribution
+from pyro.distributions.torch_transform import TransformModule
 from pyro.distributions.util import enable_validation, is_validation_enabled, validation_enabled
 from pyro.distributions.von_mises import VonMises
 from pyro.distributions.von_mises_3d import VonMises3D

--- a/pyro/distributions/iaf.py
+++ b/pyro/distributions/iaf.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 from torch.distributions import constraints
 
-from pyro.distributions.torch import TransformModule
+from pyro.distributions.torch_transform import TransformModule
 from pyro.distributions.util import copy_docs_from
 
 # This helper function clamps gradients but still passes through the gradient in clamped regions

--- a/pyro/distributions/iaf.py
+++ b/pyro/distributions/iaf.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import torch
 import torch.nn as nn
-from torch.distributions.transforms import Transform
 from torch.distributions import constraints
 
+from pyro.distributions.torch import TransformModule
 from pyro.distributions.util import copy_docs_from
 
 # This helper function clamps gradients but still passes through the gradient in clamped regions
@@ -15,8 +15,8 @@ def clamp_preserve_gradients(x, min, max):
     return x + (x.clamp(min, max) - x).detach()
 
 
-@copy_docs_from(Transform)
-class InverseAutoregressiveFlow(Transform):
+@copy_docs_from(TransformModule)
+class InverseAutoregressiveFlow(TransformModule):
     """
     An implementation of Inverse Autoregressive Flow, using Eq (10) from Kingma Et Al., 2016,
 
@@ -32,7 +32,7 @@ class InverseAutoregressiveFlow(Transform):
     >>> from pyro.nn import AutoRegressiveNN
     >>> base_dist = dist.Normal(torch.zeros(10), torch.ones(10))
     >>> iaf = InverseAutoregressiveFlow(AutoRegressiveNN(10, [40]))
-    >>> iaf_module = pyro.module("my_iaf", iaf.module)
+    >>> iaf_module = pyro.module("my_iaf", iaf)
     >>> iaf_dist = dist.TransformedDistribution(base_dist, [iaf])
     >>> iaf_dist.sample()  # doctest: +SKIP
         tensor([-0.4071, -0.5030,  0.7924, -0.2366, -0.2387, -0.1417,  0.0868,
@@ -70,21 +70,11 @@ class InverseAutoregressiveFlow(Transform):
 
     def __init__(self, autoregressive_nn, log_scale_min_clip=-5., log_scale_max_clip=3.):
         super(InverseAutoregressiveFlow, self).__init__()
-        self.module = nn.Module()
-        self.module.arn = autoregressive_nn
+        self.arn = autoregressive_nn
         self._intermediates_cache = {}
         self.add_inverse_to_cache = True
         self.log_scale_min_clip = log_scale_min_clip
         self.log_scale_max_clip = log_scale_max_clip
-
-    @property
-    def arn(self):
-        """
-        :rtype: pyro.nn.AutoRegressiveNN
-
-        Return the AutoRegressiveNN associated with the InverseAutoregressiveFlow
-        """
-        return self.module.arn
 
     def _call(self, x):
         """
@@ -94,7 +84,7 @@ class InverseAutoregressiveFlow(Transform):
         Invokes the bijection x=>y; in the prototypical context of a TransformedDistribution `x` is a
         sample from the base distribution (or the output of a previous flow)
         """
-        mean, log_scale = self.module.arn(x)
+        mean, log_scale = self.arn(x)
         log_scale = clamp_preserve_gradients(log_scale, self.log_scale_min_clip, self.log_scale_max_clip)
         scale = torch.exp(log_scale)
 
@@ -115,13 +105,13 @@ class InverseAutoregressiveFlow(Transform):
             return x
         else:
             x_size = y.size()[:-1]
-            perm = self.module.arn.permutation
+            perm = self.arn.permutation
             input_dim = y.size(-1)
             x = [torch.zeros(x_size, device=y.device)] * input_dim
 
             # NOTE: Inversion is an expensive operation that scales in the dimension of the input
             for idx in perm:
-                mean, log_scale = self.module.arn(torch.stack(x, dim=-1))
+                mean, log_scale = self.arn(torch.stack(x, dim=-1))
                 inverse_scale = torch.exp(-clamp_preserve_gradients(
                     log_scale[..., idx], min=self.log_scale_min_clip, max=self.log_scale_max_clip))
                 mean = mean[..., idx]
@@ -145,13 +135,13 @@ class InverseAutoregressiveFlow(Transform):
         if (y, 'log_scale') in self._intermediates_cache:
             log_scale = self._intermediates_cache.pop((y, 'log_scale'))
         else:
-            _, log_scale = self.module.arn(x)
+            _, log_scale = self.arn(x)
             log_scale = clamp_preserve_gradients(log_scale, min=self.log_scale_min_clip, max=self.log_scale_max_clip)
         return log_scale
 
 
-@copy_docs_from(Transform)
-class InverseAutoregressiveFlowStable(Transform):
+@copy_docs_from(TransformModule)
+class InverseAutoregressiveFlowStable(TransformModule):
     """
     An implementation of an Inverse Autoregressive Flow, using Eqs (13)/(14) from Kingma Et Al., 2016,
 
@@ -170,7 +160,7 @@ class InverseAutoregressiveFlowStable(Transform):
     >>> from pyro.nn import AutoRegressiveNN
     >>> base_dist = dist.Normal(torch.zeros(10), torch.ones(10))
     >>> iaf = InverseAutoregressiveFlowStable(AutoRegressiveNN(10, [40]))
-    >>> iaf_module = pyro.module("my_iaf", iaf.module)
+    >>> iaf_module = pyro.module("my_iaf", iaf)
     >>> iaf_dist = dist.TransformedDistribution(base_dist, [iaf])
     >>> iaf_dist.sample()  # doctest: +SKIP
         tensor([-0.4071, -0.5030,  0.7924, -0.2366, -0.2387, -0.1417,  0.0868,
@@ -200,22 +190,12 @@ class InverseAutoregressiveFlowStable(Transform):
 
     def __init__(self, autoregressive_nn, sigmoid_bias=2.0):
         super(InverseAutoregressiveFlowStable, self).__init__()
-        self.module = nn.Module()
-        self.module.arn = autoregressive_nn
+        self.arn = autoregressive_nn
         self.sigmoid = nn.Sigmoid()
         self.logsigmoid = nn.LogSigmoid()
         self.sigmoid_bias = sigmoid_bias
         self._intermediates_cache = {}
         self.add_inverse_to_cache = True
-
-    @property
-    def arn(self):
-        """
-        :rtype: pyro.nn.AutoRegressiveNN
-
-        Return the AutoRegressiveNN associated with the InverseAutoregressiveFlow
-        """
-        return self.module.arn
 
     def _call(self, x):
         """
@@ -225,7 +205,7 @@ class InverseAutoregressiveFlowStable(Transform):
         Invokes the bijection x=>y; in the prototypical context of a TransformedDistribution `x` is a
         sample from the base distribution (or the output of a previous flow)
         """
-        mean, logit_scale = self.module.arn(x)
+        mean, logit_scale = self.arn(x)
         logit_scale = logit_scale + self.sigmoid_bias
         scale = self.sigmoid(logit_scale)
         log_scale = self.logsigmoid(logit_scale)
@@ -247,13 +227,13 @@ class InverseAutoregressiveFlowStable(Transform):
             return x
         else:
             x_size = y.size()[:-1]
-            perm = self.module.arn.permutation
+            perm = self.arn.permutation
             input_dim = y.size(-1)
             x = [torch.zeros(x_size, device=y.device)] * input_dim
 
             # NOTE: Inversion is an expensive operation that scales in the dimension of the input
             for idx in perm:
-                mean, logit_scale = self.module.arn(torch.stack(x, dim=-1))
+                mean, logit_scale = self.arn(torch.stack(x, dim=-1))
                 inverse_scale = 1 + torch.exp(-logit_scale[..., idx] - self.sigmoid_bias)
                 x[idx] = inverse_scale * y[..., idx] + (1 - inverse_scale) * mean[..., idx]
 
@@ -275,6 +255,6 @@ class InverseAutoregressiveFlowStable(Transform):
         if (y, 'log_scale') in self._intermediates_cache:
             log_scale = self._intermediates_cache.pop((y, 'log_scale'))
         else:
-            _, logit_scale = self.module.arn(x)
+            _, logit_scale = self.arn(x)
             log_scale = self.logsigmoid(logit_scale + self.sigmoid_bias)
         return log_scale

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -282,9 +282,24 @@ class StudentT(torch.distributions.StudentT, TorchDistributionMixin):
             return type(self)(df, loc, scale, validate_args=validate_args)
 
 
-class TransformedDistribution(torch.distributions.TransformedDistribution, TorchDistributionMixin):
+class TransformedDistribution(torch.distributions.TransformedDistribution, TorchDistributionMixin, torch.nn.Module):
+    def __init__(self, *args, **kwargs):
+        torch.distributions.TransformedDistribution.__init__(self, *args, **kwargs)
+        TorchDistributionMixin.__init__(self)
+        torch.nn.Module.__init__(self)
+        self.transforms = torch.nn.ModuleList(self.transforms)
+
     def expand(self, batch_shape):
         return super(TransformedDistribution, self).expand(batch_shape)
+
+
+class TransformModule(torch.distributions.Transform, torch.nn.Module):
+    def __init__(self):
+        torch.distributions.Transform.__init__(self)
+        torch.nn.Module.__init__(self)
+
+    def __hash__(self):
+        return super(torch.nn.Module, self).__hash__()
 
 
 class Uniform(torch.distributions.Uniform, TorchDistributionMixin):
@@ -324,6 +339,7 @@ for _name, _Dist in torch.distributions.__dict__.items():
 
     __all__.append(_name)
 
+__all__.append('TransformModule')
 
 # Create sphinx documentation.
 __doc__ = '\n\n'.join([

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -287,15 +287,6 @@ class TransformedDistribution(torch.distributions.TransformedDistribution, Torch
         return super(TransformedDistribution, self).expand(batch_shape)
 
 
-class TransformModule(torch.distributions.Transform, torch.nn.Module):
-    def __init__(self):
-        torch.distributions.Transform.__init__(self)
-        torch.nn.Module.__init__(self)
-
-    def __hash__(self):
-        return super(torch.nn.Module, self).__hash__()
-
-
 class Uniform(torch.distributions.Uniform, TorchDistributionMixin):
     def expand(self, batch_shape):
         try:
@@ -333,7 +324,6 @@ for _name, _Dist in torch.distributions.__dict__.items():
 
     __all__.append(_name)
 
-__all__.append('TransformModule')
 
 # Create sphinx documentation.
 __doc__ = '\n\n'.join([

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -282,16 +282,7 @@ class StudentT(torch.distributions.StudentT, TorchDistributionMixin):
             return type(self)(df, loc, scale, validate_args=validate_args)
 
 
-class TransformedDistribution(torch.distributions.TransformedDistribution, TorchDistributionMixin, torch.nn.Module):
-    def __init__(self, *args, **kwargs):
-        torch.distributions.TransformedDistribution.__init__(self, *args, **kwargs)
-        TorchDistributionMixin.__init__(self)
-        torch.nn.Module.__init__(self)
-
-        # Not all transforms have parameters, so only want to extract nn.Module ones
-        self.transform_modules = torch.nn.ModuleList([t for t in self.transforms +
-                                                      [self.base_dist] if isinstance(t, torch.nn.Module)])
-
+class TransformedDistribution(torch.distributions.TransformedDistribution, TorchDistributionMixin):
     def expand(self, batch_shape):
         return super(TransformedDistribution, self).expand(batch_shape)
 

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -289,7 +289,8 @@ class TransformedDistribution(torch.distributions.TransformedDistribution, Torch
         torch.nn.Module.__init__(self)
 
         # Not all transforms have parameters, so only want to extract nn.Module ones
-        self.transform_modules = torch.nn.ModuleList([t for t in self.transforms if isinstance(t, torch.nn.Module)])
+        self.transform_modules = torch.nn.ModuleList([t for t in self.transforms +
+                                                      [self.base_dist] if isinstance(t, torch.nn.Module)])
 
     def expand(self, batch_shape):
         return super(TransformedDistribution, self).expand(batch_shape)

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -287,7 +287,9 @@ class TransformedDistribution(torch.distributions.TransformedDistribution, Torch
         torch.distributions.TransformedDistribution.__init__(self, *args, **kwargs)
         TorchDistributionMixin.__init__(self)
         torch.nn.Module.__init__(self)
-        self.transforms = torch.nn.ModuleList(self.transforms)
+
+        # Not all transforms have parameters, so only want to extract nn.Module ones
+        self.transform_modules = torch.nn.ModuleList([t for t in self.transforms if isinstance(t, torch.nn.Module)])
 
     def expand(self, batch_shape):
         return super(TransformedDistribution, self).expand(batch_shape)

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -45,6 +45,19 @@ def _torch_dirichlet_grad(x, concentration, total):
     return unpatched_fn(x, concentration, total)
 
 
+@_patch('torch.distributions.transforms.Transform.__init__')
+def _Transform__init__(self, cache_size=0):
+    self._cache_size = cache_size
+    self._inv = None
+    if cache_size == 0:
+        pass  # default behavior
+    elif cache_size == 1:
+        self._cached_x_y = None, None
+    else:
+        raise ValueError('cache_size must be 0 or 1')
+    super(torch.distributions.transforms.Transform, self).__init__()
+
+
 @_patch('torch.linspace')
 def _torch_linspace(*args, **kwargs):
     unpatched_fn = _torch_linspace._pyro_unpatched

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -45,6 +45,7 @@ def _torch_dirichlet_grad(x, concentration, total):
     return unpatched_fn(x, concentration, total)
 
 
+# This can be removed when super(...).__init__() is added upstream
 @_patch('torch.distributions.transforms.Transform.__init__')
 def _Transform__init__(self, cache_size=0):
     self._cache_size = cache_size

--- a/pyro/distributions/torch_transform.py
+++ b/pyro/distributions/torch_transform.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+
+
+class TransformModule(torch.distributions.Transform, torch.nn.Module):
+    def __init__(self):
+        super(TransformModule, self).__init__()
+        # torch.distributions.Transform.__init__(self)
+        # torch.nn.Module.__init__(self)
+
+    def __hash__(self):
+        return super(torch.nn.Module, self).__hash__()

--- a/pyro/distributions/torch_transform.py
+++ b/pyro/distributions/torch_transform.py
@@ -4,10 +4,14 @@ import torch
 
 
 class TransformModule(torch.distributions.Transform, torch.nn.Module):
+    """
+    Transforms with learnable parameters such as normalizing flows should inherit from this class rather 
+    than `Transform` so they are also a subclass of `nn.Module` and inherit all the useful methods of that class.
+
+    """
+
     def __init__(self):
         super(TransformModule, self).__init__()
-        # torch.distributions.Transform.__init__(self)
-        # torch.nn.Module.__init__(self)
 
     def __hash__(self):
         return super(torch.nn.Module, self).__hash__()

--- a/pyro/distributions/torch_transform.py
+++ b/pyro/distributions/torch_transform.py
@@ -5,7 +5,7 @@ import torch
 
 class TransformModule(torch.distributions.Transform, torch.nn.Module):
     """
-    Transforms with learnable parameters such as normalizing flows should inherit from this class rather 
+    Transforms with learnable parameters such as normalizing flows should inherit from this class rather
     than `Transform` so they are also a subclass of `nn.Module` and inherit all the useful methods of that class.
 
     """


### PR DESCRIPTION
This PR is about discussing a better method for getting parameters out of a transformed distribution.

Previously, you had to do e.g., `x = PlanarFlow(2); x.module.parameters()` to extract the parameters from a single transform. To get the parameters out of a sequence of `Transform`s was tricky because you had to extract the `.module`s from each transform and it was decoupled from `TransformedDistribution`.

I'm suggesting a two-part fix. Firstly, a new class `TransformModule` that turns transforms into true `nn.Module`s, so you can do e.g. `x = PlanarFlow(2); x.parameters()` if `PlanarFlow` inherits from `TransformModule`. Secondly, also making `TransformedDistribution` a true `nn.Module`. Then you can simply pass the parameters from the transformed distribution to e.g. an optimizer by doing `flow_dist = TransformedDistributions(base_dist, flows); optimizer = torch.optim.Adam(flow_dist.parameters())`