### PR TITLE
Fixed bug where Empirical.mean() and Empirical.variance() could return nan

### DIFF
--- a/examples/rsa/search_inference.py
+++ b/examples/rsa/search_inference.py
@@ -125,12 +125,10 @@ class HashingMarginal(dist.Distribution):
             return d
 
     def _weighted_mean(self, value, dim=0):
-        weights = self._dist_and_values()[0].logits
-        for _ in range(value.dim() - 1):
-            weights = weights.unsqueeze(-1)
-        max_val = weights.max(dim)[0]
-        normalization = (value.new_tensor([1.]) * (weights - max_val.unsqueeze(-1)).exp()).sum(dim=dim)
-        return (value * (weights - max_val.unsqueeze(-1)).exp()).sum(dim=dim) / normalization
+        weights = self._log_weights.reshape([-1] + (value.dim() - 1) * [1])
+        max_weight = weights.max(dim=dim)[0]
+        relative_probs = (weights - max_weight).exp()
+        return (value * relative_probs).sum(dim=dim) / relative_probs.sum(dim=dim)
 
     @property
     def mean(self):

--- a/examples/rsa/search_inference.py
+++ b/examples/rsa/search_inference.py
@@ -6,18 +6,18 @@ Adapted from: http://dippl.org/chapters/03-enumeration.html
 
 from __future__ import absolute_import, division, print_function
 
+import collections
+
+import six
 import torch
+from six.moves import queue
 
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-
 from pyro.infer.abstract_infer import TracePosterior
 from pyro.poutine.runtime import NonlocalExit
 
-import six
-from six.moves import queue
-import collections
 if six.PY3:
     import functools
 else:
@@ -129,18 +129,19 @@ class HashingMarginal(dist.Distribution):
         for _ in range(value.dim() - 1):
             weights = weights.unsqueeze(-1)
         max_val = weights.max(dim)[0]
-        return max_val.exp() * (value * (weights - max_val.unsqueeze(-1)).exp()).sum(dim=dim)
+        normalization = (value.new_tensor([1.]) * (weights - max_val.unsqueeze(-1)).exp()).sum(dim=dim)
+        return (value * (weights - max_val.unsqueeze(-1)).exp()).sum(dim=dim) / normalization
 
     @property
     def mean(self):
         samples = torch.stack(list(self._dist_and_values()[1].values()))
-        return self._weighted_mean(samples) / self._weighted_mean(samples.new_tensor([1.]))
+        return self._weighted_mean(samples)
 
     @property
     def variance(self):
         samples = torch.stack(list(self._dist_and_values()[1].values()))
         deviation_squared = torch.pow(samples - self.mean, 2)
-        return self._weighted_mean(deviation_squared) / self._weighted_mean(samples.new_tensor([1.]))
+        return self._weighted_mean(deviation_squared)
 
 
 ########################

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -134,7 +134,8 @@ class Empirical(TorchDistribution):
         for _ in range(value.dim() - 1):
             weights = weights.unsqueeze(-1)
         max_val = weights.max(dim)[0]
-        return max_val.exp() * (value * (weights - max_val.unsqueeze(-1)).exp()).sum(dim=dim)
+        normalization = (value.new_tensor([1.]) * (weights - max_val.unsqueeze(-1)).exp()).sum(dim=dim)
+        return (value * (weights - max_val.unsqueeze(-1)).exp()).sum(dim=dim) / normalization
 
     @property
     def event_shape(self):
@@ -152,7 +153,7 @@ class Empirical(TorchDistribution):
                              "or ``torch.float64``. If these are samples from a " +
                              "`Categorical` distribution, consider converting to a " +
                              "`OneHotCategorical` distribution.")
-        return self._weighted_mean(self._samples) / self._weighted_mean(self._samples.new_tensor([1.]))
+        return self._weighted_mean(self._samples)
 
     @property
     def variance(self):
@@ -164,7 +165,7 @@ class Empirical(TorchDistribution):
                              "`Categorical` distribution, consider converting to a " +
                              "`OneHotCategorical` distribution.")
         deviation_squared = torch.pow(self._samples - self.mean, 2)
-        return self._weighted_mean(deviation_squared) / self._weighted_mean(self._samples.new_tensor([1.]))
+        return self._weighted_mean(deviation_squared)
 
     def get_samples_and_weights(self):
         self._finalize()

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -130,10 +130,7 @@ class Empirical(TorchDistribution):
         return logsumexp(log_probs, dim=-1)
 
     def _weighted_mean(self, value, dim=0):
-        dims_to_prepend = dim
-        dims_to_append = value.dim() - dim - 1
-        new_shape = dims_to_prepend * [1] + [-1] + dims_to_append * [1]
-        weights = self._log_weights.reshape(new_shape)
+        weights = self._log_weights.reshape([-1] + (value.dim() - 1) * [1])
         max_weight = weights.max(dim=dim)[0]
         relative_probs = (weights - max_weight).exp()
         return (value * relative_probs).sum(dim=dim) / relative_probs.sum(dim=dim)

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -89,8 +89,9 @@ def test_weighted_mean_var(event_shape, dtype):
 
 
 def test_mean_var_non_nan():
+    true_mean = torch.randn([1, 2, 3])
     empirical_dist = Empirical()
     for i in range(10):
-        empirical_dist.add(torch.ones([5, 2, 3]), log_weight=-1000.)
-    assert (~torch.isnan(empirical_dist.mean)).all()
-    assert (~torch.isnan(empirical_dist.variance)).all()
+        empirical_dist.add(true_mean, log_weight=-1000.)
+    assert_equal(empirical_dist.mean, true_mean)
+    assert_equal(empirical_dist.variance, torch.zeros_like(true_mean))

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -91,6 +91,6 @@ def test_weighted_mean_var(event_shape, dtype):
 def test_mean_var_non_nan():
     empirical_dist = Empirical()
     for i in range(10):
-        empirical_dist.add(torch.ones(1), log_weight=-1000.)
-    assert not torch.isnan(empirical_dist.mean)
-    assert not torch.isnan(empirical_dist.variance)
+        empirical_dist.add(torch.ones([5, 2, 3]), log_weight=-1000.)
+    assert (~torch.isnan(empirical_dist.mean)).all()
+    assert (~torch.isnan(empirical_dist.variance)).all()

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -86,3 +86,10 @@ def test_weighted_mean_var(event_shape, dtype):
         with pytest.raises(ValueError):
             empirical_dist.mean
             empirical_dist.variance
+
+def test_mean_var_non_nan():
+    empirical_dist = Empirical()
+    for i in range(10):
+        empirical_dist.add(torch.ones(1), log_weight=-1000.)
+    assert not torch.isnan(empirical_dist.mean)
+    assert not torch.isnan(empirical_dist.variance)

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -87,6 +87,7 @@ def test_weighted_mean_var(event_shape, dtype):
             empirical_dist.mean
             empirical_dist.variance
 
+
 def test_mean_var_non_nan():
     empirical_dist = Empirical()
     for i in range(10):

--- a/tutorial/source/search_inference.py
+++ b/tutorial/source/search_inference.py
@@ -130,18 +130,19 @@ class HashingMarginal(dist.Distribution):
         for _ in range(value.dim() - 1):
             weights = weights.unsqueeze(-1)
         max_val = weights.max(dim)[0]
-        return max_val.exp() * (value * (weights - max_val.unsqueeze(-1)).exp()).sum(dim=dim)
+        normalization = (value.new_tensor([1.]) * (weights - max_val.unsqueeze(-1)).exp()).sum(dim=dim)
+        return (value * (weights - max_val.unsqueeze(-1)).exp()).sum(dim=dim) / normalization
 
     @property
     def mean(self):
         samples = torch.stack(list(self._dist_and_values()[1].values()))
-        return self._weighted_mean(samples) / self._weighted_mean(samples.new_tensor([1.]))
+        return self._weighted_mean(samples)
 
     @property
     def variance(self):
         samples = torch.stack(list(self._dist_and_values()[1].values()))
         deviation_squared = torch.pow(samples - self.mean, 2)
-        return self._weighted_mean(deviation_squared) / self._weighted_mean(samples.new_tensor([1.]))
+        return self._weighted_mean(deviation_squared)
 
 
 ########################


### PR DESCRIPTION
Fixed bug in https://github.com/uber/pyro/issues/1548.

Previously, `Empirical.mean()` and `Empirical.variance()` returned `nan` if the largest sample probability was rounded to zero. The `Empirical._weighted_mean()` helper now normalizes by dividing by the sum of the sample probabilities, with an algebraic simplification to avoid multiplying by `max_val.exp()`. A simple test was added to verify the bug has been fixed.

The same `_weighted_mean()` and usage pattern appeared in two other files, which have been similarly corrected.