### PR TITLE
Cache dataset directory on CI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ run_outputs*
 .DS_Store
 .benchmarks
 data
+.data
 results
 examples/*/processed
 examples/*/results

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ env:
     global:
         - PYTHONPATH=$PWD:$PYTHONPATH
 
+cache:
+    directories:
+        - $HOME/.data
+
 install:
     - pip install -U pip
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then

--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -22,6 +22,8 @@ import pyro
 import pyro.optim as optim
 import pyro.poutine as poutine
 from air import AIR, latents_to_tensor
+
+from pyro.contrib.examples.util import get_data_directory
 from pyro.infer import SVI, JitTraceGraph_ELBO, TraceGraph_ELBO
 from viz import draw_many, tensor_to_objs
 
@@ -110,7 +112,7 @@ def exp_decay(initial, final, begin, duration, t):
 
 
 def load_data():
-    inpath = './data'
+    inpath = get_data_directory(__file__)
     (X_np, Y), _ = multi_mnist(inpath, max_digits=2, canvas_size=50, seed=42)
     X_np = X_np.astype(np.float32)
     X_np /= 255.0

--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -131,7 +131,7 @@ def main(args):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Pyro GP MNIST Example')
-    parser.add_argument('--data-dir', type=str, default="", metavar='PATH',
+    parser.add_argument('--data-dir', type=str, default=None, metavar='PATH',
                         help='default directory to cache MNIST data')
     parser.add_argument('--num-inducing', type=int, default=70, metavar='N',
                         help='number of inducing input (default: 70)')

--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -27,7 +27,7 @@ import pyro
 import pyro.contrib.gp as gp
 import pyro.infer as infer
 import pyro.optim as optim
-from pyro.contrib.examples.util import get_data_loader
+from pyro.contrib.examples.util import get_data_loader, get_data_directory
 
 
 class CNN(nn.Module):
@@ -77,14 +77,15 @@ def test(args, test_loader, gpmodel):
 
 
 def main(args):
+    data_dir = args.data_dir if args.data_dir is not None else get_data_directory(__file__)
     train_loader = get_data_loader(dataset_name='MNIST',
-                                   data_dir=args.data_dir,
+                                   data_dir=data_dir,
                                    batch_size=args.batch_size,
                                    dataset_transforms=[transforms.Normalize((0.1307,), (0.3081,))],
                                    is_training_set=True,
                                    shuffle=True)
     test_loader = get_data_loader(dataset_name='MNIST',
-                                  data_dir=args.data_dir,
+                                  data_dir=data_dir,
                                   batch_size=args.batch_size,
                                   dataset_transforms=[transforms.Normalize((0.1307,), (0.3081,))],
                                   is_training_set=False,
@@ -130,7 +131,7 @@ def main(args):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Pyro GP MNIST Example')
-    parser.add_argument('--data-dir', type=str, default='../data', metavar='PATH',
+    parser.add_argument('--data-dir', type=str, default="", metavar='PATH',
                         help='default directory to cache MNIST data')
     parser.add_argument('--num-inducing', type=int, default=70, metavar='N',
                         help='number of inducing input (default: 70)')

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -21,11 +21,10 @@ import torch
 import torch.nn as nn
 from observations import jsb_chorales
 
-
-# this function processes the raw data; in particular it unsparsifies it
 from pyro.contrib.examples.util import get_data_directory
 
 
+# this function processes the raw data; in particular it unsparsifies it
 def process_data(base_path, filename, T_max=160, min_note=21, note_range=88):
     output = os.path.join(base_path, filename)
     if os.path.exists(output):

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -23,6 +23,9 @@ from observations import jsb_chorales
 
 
 # this function processes the raw data; in particular it unsparsifies it
+from pyro.contrib.examples.util import get_data_directory
+
+
 def process_data(base_path, filename, T_max=160, min_note=21, note_range=88):
     output = os.path.join(base_path, filename)
     if os.path.exists(output):
@@ -55,7 +58,7 @@ def process_data(base_path, filename, T_max=160, min_note=21, note_range=88):
 
 
 # this logic will be initiated upon import
-base_path = './data'
+base_path = get_data_directory(__file__)
 process_data(base_path, "jsb_processed.pkl")
 jsb_file_loc = "./data/jsb_processed.pkl"
 

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -60,7 +60,7 @@ def process_data(base_path, filename, T_max=160, min_note=21, note_range=88):
 # this logic will be initiated upon import
 base_path = get_data_directory(__file__)
 process_data(base_path, "jsb_processed.pkl")
-jsb_file_loc = "./data/jsb_processed.pkl"
+jsb_file_loc = os.path.join(base_path, "jsb_processed.pkl")
 
 
 # ingest training/validation/test data from disk

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -124,8 +124,10 @@ class SparseGammaDEF(object):
 def main(args):
     # load data
     print('loading training data...')
-    dataset_path = os.path.join(get_data_directory(__file__), 'faces_training.csv')
+    dataset_directory = get_data_directory(__file__)
+    dataset_path = os.path.join(dataset_directory, 'faces_training.csv')
     if not os.path.exists(dataset_path):
+        os.makedirs(dataset_directory, exist_ok=True)
         wget.download('https://d2fefpcigoriu7.cloudfront.net/datasets/faces_training.csv', dataset_path)
     data = torch.tensor(np.loadtxt(dataset_path, delimiter=',')).float()
 

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -131,7 +131,7 @@ def main(args):
         try:
             os.makedirs(dataset_directory)
         except OSError as e:
-            if e.errno != errno.EXIST:
+            if e.errno != errno.EEXIST:
                 raise
             pass
         wget.download('https://d2fefpcigoriu7.cloudfront.net/datasets/faces_training.csv', dataset_path)

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import, division, print_function
 
 import argparse
+import errno
 import os
 
 import numpy as np
@@ -127,7 +128,12 @@ def main(args):
     dataset_directory = get_data_directory(__file__)
     dataset_path = os.path.join(dataset_directory, 'faces_training.csv')
     if not os.path.exists(dataset_path):
-        os.makedirs(dataset_directory, exist_ok=True)
+        try:
+            os.makedirs(dataset_directory)
+        except OSError as e:
+            if e.errno != errno.EXIST:
+                raise
+            pass
         wget.download('https://d2fefpcigoriu7.cloudfront.net/datasets/faces_training.csv', dataset_path)
     data = torch.tensor(np.loadtxt(dataset_path, delimiter=',')).float()
 

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -18,6 +18,8 @@ import torch
 import pyro
 import pyro.optim as optim
 import wget
+
+from pyro.contrib.examples.util import get_data_directory
 from pyro.distributions import Gamma, Poisson
 from pyro.infer import SVI, Trace_ELBO
 
@@ -122,9 +124,10 @@ class SparseGammaDEF(object):
 def main(args):
     # load data
     print('loading training data...')
-    if not os.path.exists('faces_training.csv'):
-        wget.download('https://d2fefpcigoriu7.cloudfront.net/datasets/faces_training.csv', 'faces_training.csv')
-    data = torch.tensor(np.loadtxt('faces_training.csv', delimiter=',')).float()
+    dataset_path = os.path.join(get_data_directory(__file__), 'faces_training.csv')
+    if not os.path.exists(dataset_path):
+        wget.download('https://d2fefpcigoriu7.cloudfront.net/datasets/faces_training.csv', dataset_path)
+    data = torch.tensor(np.loadtxt(dataset_path, delimiter=',')).float()
 
     sparse_gamma_def = SparseGammaDEF()
     opt = optim.AdagradRMSProp({"eta": 4.5, "t": 0.1})

--- a/examples/vae/utils/mnist_cached.py
+++ b/examples/vae/utils/mnist_cached.py
@@ -7,6 +7,9 @@ import torch
 from torch.utils.data import DataLoader
 from torchvision.datasets import MNIST
 
+from pyro.contrib.examples.util import get_data_directory
+
+
 # This file contains utilities for caching, transforming and splitting MNIST data
 # efficiently. By default, a PyTorch DataLoader will apply the transform every epoch
 # we avoid this by caching the data early on in MNISTCached class
@@ -191,20 +194,21 @@ class MNISTCached(MNIST):
         return img, target
 
 
-def setup_data_loaders(dataset, use_cuda, batch_size, sup_num=None, root='./data', download=True, **kwargs):
+def setup_data_loaders(dataset, use_cuda, batch_size, sup_num=None, root=None, download=True, **kwargs):
     """
         helper function for setting up pytorch data loaders for a semi-supervised dataset
     :param dataset: the data to use
     :param use_cuda: use GPU(s) for training
     :param batch_size: size of a batch of data to output when iterating over the data loaders
     :param sup_num: number of supervised data examples
-    :param root: where on the filesystem should the dataset be
     :param download: download the dataset (if it doesn't exist already)
     :param kwargs: other params for the pytorch data loader
     :return: three data loaders: (supervised data for training, un-supervised data for training,
                                   supervised data for testing)
     """
     # instantiate the dataset as training/testing sets
+    if root is None:
+        root = get_data_directory(__file__)
     if 'num_workers' not in kwargs:
         kwargs = {'num_workers': 0, 'pin_memory': False}
 

--- a/pyro/contrib/examples/util.py
+++ b/pyro/contrib/examples/util.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import os
 import sys
 
 import torchvision.datasets as datasets
@@ -34,3 +35,10 @@ def print_and_log(logger, msg):
     if logger is not None:
         logger.write("{}\n".format(msg))
         logger.flush()
+
+
+def get_data_directory(filepath=None):
+    if 'CI' in os.environ:
+        return os.path.expanduser('~/.data')
+    return os.path.abspath(os.path.join(os.path.dirname(filepath),
+                                        '.data'))


### PR DESCRIPTION
This was as a result of debugging #1540 in the `pytorch-1.0` branch. While the problem there seems unrelated (due to pytorch dataloader in combination with other factors), I think this will be more generally useful. 

 - In travis, we download all datasets in the same location. This PR ensures that we don't have to download the same datasets again since the path remains the same. This is further cached by travis.
 - A second issue is that each example specifies its data path as `./data`, but this is created not relative to the file but from where the example is running. It might lead to a proliferation of data folders. This modifies the behavior to keep the dataset location always relative to the example file.