### PR TITLE
Fix bugs in adjoint algorithms

### DIFF
--- a/pyro/ops/einsum/adjoint.py
+++ b/pyro/ops/einsum/adjoint.py
@@ -38,6 +38,7 @@ class _LeafBackward(Backward):
 
     def process(self, message):
         target = self.target()
+        assert message is not target, 'memory leak'
         target._pyro_backward_result = message
         return ()
 
@@ -55,10 +56,13 @@ class _TransposeBackward(Backward):
         self.axes = axes
 
     def process(self, message):
-        inv_axes = [None] * len(self.axes)
-        for i, j in enumerate(self.axes):
-            inv_axes[j] = i
-        yield self.a._pyro_backward, message.permute(inv_axes)
+        if message is None:
+            yield self.a._pyro_backward, None
+        else:
+            inv_axes = [None] * len(self.axes)
+            for i, j in enumerate(self.axes):
+                inv_axes[j] = i
+            yield self.a._pyro_backward, message.permute(inv_axes)
 
 
 # this requires https://github.com/dgasmith/opt_einsum/pull/74

--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -20,6 +20,8 @@ def einsum(equation, *operands):
     equation = ''.join(rename.get(s, s) for s in equation)
 
     inputs, output = equation.split('->')
+    if inputs == output:
+        return operands[0][...]  # create a new object
     inputs = inputs.split(',')
 
     shifts = []

--- a/pyro/ops/einsum/torch_map.py
+++ b/pyro/ops/einsum/torch_map.py
@@ -39,6 +39,8 @@ def einsum(equation, *operands):
         result, argmax = result.reshape(output_shape + (-1,)).max(-1)
         if any_requires_backward:
             argmax = unflatten(argmax, output, contract_dims, contract_shape)
+    elif result is operands[0]:
+        result = result[...]  # create a new object
     result._pyro_dims = output
     assert result.dim() == len(result._pyro_dims)
 

--- a/pyro/ops/einsum/torch_marginal.py
+++ b/pyro/ops/einsum/torch_marginal.py
@@ -30,8 +30,11 @@ class _EinsumBackward(Backward):
             if not operand._pyro_backward.is_leaf:
                 del inputs_i[i]
                 del operands_i[i]
-            equation = ','.join(inputs_i) + '->' + output_i
-            message_i = pyro.ops.einsum.torch_log.einsum(equation, *operands_i)
+            if operands_i:
+                equation = ','.join(inputs_i) + '->' + output_i
+                message_i = pyro.ops.einsum.torch_log.einsum(equation, *operands_i)
+            else:
+                message_i = None
             yield operand._pyro_backward, message_i
 
 

--- a/pyro/ops/rings.py
+++ b/pyro/ops/rings.py
@@ -145,8 +145,6 @@ class LogRing(Ring):
         self._dim_to_size = {} if dim_to_size is None else dim_to_size
 
     def sumproduct(self, terms, dims):
-        if len(terms) == 1 and not dims:
-            return terms[0]
         inputs = [term._pyro_dims for term in terms]
         output = ''.join(sorted(set(''.join(inputs)) - set(dims)))
         equation = ','.join(inputs) + '->' + output


### PR DESCRIPTION
This fixes various edge case bugs in our adjoint algorihms.

- ensure marginal `._pyro_backward_result` exists even for trivial equations
- fixes handling of `map` result
- weakens map and sample tests to allow samples dims to be out of order from output dims; this is ok since sample results will only ever be consumed by `packed.gather()`

@eb8680 hopefully this will fix some of your collapes issues. Also remember to use `opt_einsum` master until the next release.

## Tested

- added regression test examples