### PR TITLE
Fix handling of enumerated scales when jitting

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -83,16 +83,15 @@ def xfail_jit(*args):
 
 
 JIT_EXAMPLES = [
-    xfail_jit('air/main.py --num-steps=1 --jit'),
+    'air/main.py --num-steps=1 --jit',
     xfail_jit('baseball.py --num-samples=200 --warmup-steps=100 --jit'),
-    xfail_jit('bayesian_regression.py --num-epochs=1 --jit'),
-    xfail_jit('contrib/autoname/mixture.py --num-epochs=1 --jit'),
+    'bayesian_regression.py --num-epochs=1 --jit',
+    'contrib/autoname/mixture.py --num-epochs=1 --jit',
     xfail_jit('contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --jit'),
     xfail_jit('dmm/dmm.py --num-epochs=1 --jit'),
     xfail_jit('dmm/dmm.py --num-epochs=1 --num-iafs=1 --jit'),
     xfail_jit('eight_schools/mcmc.py --num-samples=500 --warmup-steps=100 --jit'),
     xfail_jit('eight_schools/svi.py --num-epochs=1 --jit'),
-    xfail_jit('examples/contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --jit'),
     xfail_jit('hmm.py --num-steps=1 --truncate=65 --model=1 --jit'),
     xfail_jit('hmm.py --num-steps=1 --truncate=65 --model=2 --jit'),
     xfail_jit('hmm.py --num-steps=1 --truncate=65 --model=3 --jit'),
@@ -100,12 +99,11 @@ JIT_EXAMPLES = [
     xfail_jit('hmm.py --num-steps=1 --truncate=65 --model=5 --jit'),
     xfail_jit('lda.py --num-steps=2 --num-words=100 --num-docs=100 --num-words-per-doc=8 --jit'),
     xfail_jit('vae/ss_vae_M2.py --num-epochs=1 --aux-loss --jit'),
-    xfail_jit('vae/ss_vae_M2.py --num-epochs=1 --enum-discrete=parallel --jit'),
-    xfail_jit('vae/ss_vae_M2.py --num-epochs=1 --enum-discrete=sequential --jit'),
-    xfail_jit('vae/ss_vae_M2.py --num-epochs=1 --jit'),
-    xfail_jit('vae/vae.py --num-epochs=1 --jit'),
-    xfail_jit('vae/vae_comparison.py --num-epochs=1 --jit'),
-    xfail_jit('contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --jit'),
+    'vae/ss_vae_M2.py --num-epochs=1 --enum-discrete=parallel --jit',
+    'vae/ss_vae_M2.py --num-epochs=1 --enum-discrete=sequential --jit',
+    'vae/ss_vae_M2.py --num-epochs=1 --jit',
+    'vae/vae.py --num-epochs=1 --jit',
+    'vae/vae_comparison.py --num-epochs=1 --jit',
 ]
 
 


### PR DESCRIPTION
This fixes our check for absence of multiple scales when run under the jit.

This also cleans up the test list in `tests/test_examples.py::test_jit` which had accumulated duplicates and xpasses.

## Tested

- ran jit tests locally (they are not run on CI)