### PR TITLE
Make einsum trace evaluator default for HMC

### DIFF
--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -76,10 +76,6 @@ class NUTS(HMC):
     :param bool jit_compile: Optional parameter denoting whether to use
         the PyTorch JIT to trace the log density computation, and use this
         optimized executable trace in the integrator.
-    :param bool experimental_use_einsum: Whether to use an einsum operation
-        to evaluat log pdf for the model trace. No-op unless the trace has
-        discrete sample sites. This flag is experimental and will most likely
-        be removed in a future release.
 
     Example:
 
@@ -112,8 +108,7 @@ class NUTS(HMC):
                  max_plate_nesting=None,
                  max_iarange_nesting=None,  # DEPRECATED
                  jit_compile=False,
-                 ignore_jit_warnings=False,
-                 experimental_use_einsum=False):
+                 ignore_jit_warnings=False):
         if max_iarange_nesting is not None:
             warnings.warn("max_iarange_nesting is deprecated; use max_plate_nesting instead",
                           DeprecationWarning)
@@ -128,8 +123,7 @@ class NUTS(HMC):
                                    max_plate_nesting=max_plate_nesting,
                                    max_iarange_nesting=max_iarange_nesting,
                                    jit_compile=jit_compile,
-                                   ignore_jit_warnings=ignore_jit_warnings,
-                                   experimental_use_einsum=experimental_use_einsum)
+                                   ignore_jit_warnings=ignore_jit_warnings)
         self.use_multinomial_sampling = use_multinomial_sampling
         self._max_tree_depth = 10  # from Stan
         # There are three conditions to stop doubling process:

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -178,7 +178,8 @@ class TraceEinsumEvaluator(object):
                 self.ordering[name] = frozenset(model_trace.plate_to_symbol[f.name]
                                                 for f in site["cond_indep_stack"]
                                                 if f.vectorized)
-        self._enum_dims = set(model_trace.symbol_to_dim) - set(model_trace.plate_to_symbol.values())
+        self._enum_dims = set(model_trace.symbol_to_dim) - \
+                          set(model_trace.plate_to_symbol.values())
 
     def _get_log_factors(self, model_trace):
         """

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -330,8 +330,7 @@ def test_gaussian_mixture_model(jit):
 
 
 @pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
-@pytest.mark.parametrize("use_einsum", [False, True])
-def test_bernoulli_latent_model(jit, use_einsum):
+def test_bernoulli_latent_model(jit):
     def model(data):
         y_prob = pyro.sample("y_prob", dist.Beta(1.0, 1.0))
         y = pyro.sample("y", dist.Bernoulli(y_prob))
@@ -346,8 +345,7 @@ def test_bernoulli_latent_model(jit, use_einsum):
     z = dist.Bernoulli(0.65 * y + 0.1).sample()
     data = dist.Normal(2. * z, 1.0).sample()
     hmc_kernel = HMC(model, trajectory_length=1, max_plate_nesting=1,
-                     jit_compile=jit, ignore_jit_warnings=True,
-                     experimental_use_einsum=use_einsum)
+                     jit_compile=jit, ignore_jit_warnings=True)
     mcmc_run = MCMC(hmc_kernel, num_samples=600, warmup_steps=200).run(data)
     posterior = mcmc_run.marginal("y_prob").empirical["y_prob"].mean
     assert_equal(posterior, y_prob, prec=0.05)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -325,13 +325,8 @@ def test_bernoulli_latent_model(jit):
 
 
 @pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
-@pytest.mark.parametrize("num_steps,use_einsum", [
-    (2, False),
-    (3, False),
-    (3, True),
-    (30, True),  # This will crash without the einsum backend
-])
-def test_gaussian_hmm(jit, num_steps, use_einsum):
+@pytest.mark.parametrize("num_steps", [2, 3, 30])
+def test_gaussian_hmm(jit, num_steps):
     dim = 4
 
     def model(data):
@@ -368,8 +363,7 @@ def test_gaussian_hmm(jit, num_steps, use_einsum):
 
     data = _generate_data()
     nuts_kernel = NUTS(model, adapt_step_size=True, max_plate_nesting=1,
-                       jit_compile=jit, ignore_jit_warnings=True,
-                       experimental_use_einsum=use_einsum)
-    if use_einsum:
+                       jit_compile=jit, ignore_jit_warnings=True)
+    if num_steps == 30:
         nuts_kernel.initial_trace = _get_initial_trace()
     MCMC(nuts_kernel, num_samples=5, warmup_steps=5).run(data)

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -41,8 +41,7 @@ def print_debug_info(model_trace):
     (HMC, {"adapt_step_size": True, "num_steps": 3}),
     (NUTS, {"adapt_step_size": True}),
 ])
-@pytest.mark.parametrize("use_einsum", [False, True])
-def test_model_error_stray_batch_dims(kernel, kwargs, use_einsum):
+def test_model_error_stray_batch_dims(kernel, kwargs):
 
     def gmm():
         data = torch.tensor([0., 0., 3., 3., 3., 5., 5.])
@@ -53,11 +52,11 @@ def test_model_error_stray_batch_dims(kernel, kwargs, use_einsum):
             pyro.sample("obs", dist.Normal(cluster_means[assignments], 1.), obs=data)
         return cluster_means
 
-    mcmc_kernel = kernel(gmm, experimental_use_einsum=use_einsum, **kwargs)
+    mcmc_kernel = kernel(gmm, **kwargs)
     # Error due to non finite value for `max_plate_nesting`.
     assert_error(mcmc_kernel)
     # Error due to batch dims not inside plate.
-    mcmc_kernel = kernel(gmm, max_plate_nesting=1, experimental_use_einsum=use_einsum, **kwargs)
+    mcmc_kernel = kernel(gmm, max_plate_nesting=1, **kwargs)
     assert_error(mcmc_kernel)
 
 
@@ -65,8 +64,7 @@ def test_model_error_stray_batch_dims(kernel, kwargs, use_einsum):
     (HMC, {"adapt_step_size": True, "num_steps": 3}),
     (NUTS, {"adapt_step_size": True}),
 ])
-@pytest.mark.parametrize("use_einsum", [False, True])
-def test_model_error_enum_dim_clash(kernel, kwargs, use_einsum):
+def test_model_error_enum_dim_clash(kernel, kwargs):
 
     def gmm():
         data = torch.tensor([0., 0., 3., 3., 3., 5., 5.])
@@ -78,8 +76,7 @@ def test_model_error_enum_dim_clash(kernel, kwargs, use_einsum):
             pyro.sample("obs", dist.Normal(cluster_means[assignments], 1.), obs=data)
         return cluster_means
 
-    mcmc_kernel = kernel(gmm, max_plate_nesting=0,
-                         experimental_use_einsum=use_einsum, **kwargs)
+    mcmc_kernel = kernel(gmm, max_plate_nesting=0, **kwargs)
     assert_error(mcmc_kernel)
 
 


### PR DESCRIPTION
This removes the `experimental_use_einsum` flag from HMC / NUTS. All our tests that using `TraceEinsumEvaluator` are nearly as fast as the `TraceTreeEvaluator`, and we should make this the default without cluttering the interface. 

Note that I have preserved `TraceTreeEvaluator` for internal profiling purpose, at least for the time being, but it is only used in `mcmc/test_valid_models` and isn't part of anything that is exposed to the users.