### PR TITLE
More jit fixes, e.g. baseball and eight_schools/svi

### DIFF
--- a/examples/lda.py
+++ b/examples/lda.py
@@ -96,7 +96,7 @@ def parametrized_guide(predictor, data, args, batch_size=None):
         if torch._C._get_tracing_state():
             counts = torch.eye(1024)[data[:, ind]].sum(0).t()
         else:
-            counts = torch.zeros(args.num_words, batch_size)
+            counts = torch.zeros(args.num_words, ind.size(0))
             counts.scatter_add_(0, data[:, ind], torch.tensor(1.).expand(counts.shape))
         doc_topics = predictor(counts.transpose(0, 1))
         pyro.sample("doc_topics", dist.Delta(doc_topics, event_dim=1))

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -185,12 +185,8 @@ def scale_and_mask(tensor, scale=1.0, mask=None):
     if mask is None:
         return tensor * scale
     tensor, mask = broadcast_all(tensor, mask)
-    # TODO: Remove .contiguous once https://github.com/pytorch/pytorch/issues/12230 is fixed.
-    tensor = (tensor * scale).contiguous()
-    if torch._C._get_tracing_state():
-        tensor[~mask] = 0.
-    else:
-        tensor.masked_fill_(~mask, 0.)
+    tensor = tensor * scale
+    tensor.masked_fill_(~mask, 0.)
     return tensor
 
 

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -305,8 +305,11 @@ class _Marginal(object):
         if self._diagnostics:
             return self._diagnostics
         for site in self.sites:
-            self._diagnostics[site] = OrderedDict([
-                ("n_eff", stats.effective_sample_size(self.support()[site])),
-                ("r_hat", stats.split_gelman_rubin(self.support()[site]))
-            ])
+            site_stats = OrderedDict()
+            try:
+                site_stats["n_eff"] = stats.effective_sample_size(self.support()[site])
+            except NotImplementedError:
+                site_stats["n_eff"] = torch.tensor(float('nan'))
+            site_stats["r_hat"] = stats.split_gelman_rubin(self.support()[site])
+            self._diagnostics[site] = site_stats
         return self._diagnostics

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -449,7 +449,7 @@ class JitTraceEnum_ELBO(TraceEnum_ELBO):
                 self = weakself()
                 elbo = 0.0
                 for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
-                    elbo += _compute_dice_elbo(model_trace, guide_trace)
+                    elbo = elbo + _compute_dice_elbo(model_trace, guide_trace)
                 return elbo * (-1.0 / self.num_particles)
 
             self._differentiable_loss = differentiable_loss

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -126,7 +126,6 @@ def test_grad_expand():
     f(torch.zeros(2, requires_grad=True), torch.zeros(1, requires_grad=True))
 
 
-@pytest.mark.xfail(reason="https://github.com/pytorch/pytorch/issues/11555")
 def test_masked_fill():
 
     def f(y, mask):
@@ -135,25 +134,12 @@ def test_masked_fill():
     x = torch.tensor([-float('inf'), -1., 0., 1., float('inf')])
     y = x / x.unsqueeze(-1)
     mask = ~(y == y)
-    f = torch.jit.trace(f, (y, mask))
+    jit_f = torch.jit.trace(f, (y, mask))
+    assert_equal(jit_f(y, mask), f(y, mask))
 
-
-def test_masked_fill_workaround():
-
-    def f(y, mask):
-        return y.clone().masked_fill_(mask, 0.)
-
-    def g(y, mask):
-        y = y.clone()
-        y[mask] = 0.  # this is much slower than .masked_fill_()
-        return y
-
-    x = torch.tensor([-float('inf'), -1., 0., 1., float('inf')])
-    y = x / x.unsqueeze(-1)
-    mask = ~(y == y)
-    assert_equal(f(y, mask), g(y, mask))
-    g = torch.jit.trace(g, (y, mask))
-    assert_equal(f(y, mask), g(y, mask))
+    mask = torch.tensor([True, False, False, True, False, False])
+    y = torch.tensor([1.5, 2.5, 3.5, 4.5, 5.5, 6.5])
+    assert_equal(jit_f(y, mask), f(y, mask))
 
 
 @pytest.mark.xfail(reason="https://github.com/pytorch/pytorch/issues/11614")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -84,7 +84,7 @@ def xfail_jit(*args):
 
 JIT_EXAMPLES = [
     'air/main.py --num-steps=1 --jit',
-    'baseball.py --num-samples=200 --warmup-steps=100 --jit',
+    xfail_jit('baseball.py --num-samples=200 --warmup-steps=100 --jit'),
     'bayesian_regression.py --num-epochs=1 --jit',
     'contrib/autoname/mixture.py --num-epochs=1 --jit',
     xfail_jit('contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --jit'),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -84,14 +84,15 @@ def xfail_jit(*args):
 
 JIT_EXAMPLES = [
     'air/main.py --num-steps=1 --jit',
-    xfail_jit('baseball.py --num-samples=200 --warmup-steps=100 --jit'),
+    'baseball.py --num-samples=200 --warmup-steps=100 --jit',
     'bayesian_regression.py --num-epochs=1 --jit',
     'contrib/autoname/mixture.py --num-epochs=1 --jit',
     xfail_jit('contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --jit'),
     xfail_jit('dmm/dmm.py --num-epochs=1 --jit'),
     xfail_jit('dmm/dmm.py --num-epochs=1 --num-iafs=1 --jit'),
-    xfail_jit('eight_schools/mcmc.py --num-samples=500 --warmup-steps=100 --jit'),
-    xfail_jit('eight_schools/svi.py --num-epochs=1 --jit'),
+    skipif_param('eight_schools/mcmc.py --num-samples=500 --warmup-steps=100 --jit',
+                 condition=True, reason='very slow test'),
+    'eight_schools/svi.py --num-epochs=1 --jit',
     'hmm.py --num-steps=1 --truncate=65 --model=1 --jit',
     'hmm.py --num-steps=1 --truncate=65 --model=2 --jit',
     'hmm.py --num-steps=1 --truncate=65 --model=3 --jit',


### PR DESCRIPTION
- Removes our old `.masked_fill_()` workaround now that `.masked_fill_()` seems to be supported by the jit
- Misc other workarounds, though I haven't been able to get lda.py working

## Tested
- tested examples locally (with opt_einsum 2.3)