### PR TITLE
Make noise is GPR/SGPR constraints.positive by default

### DIFF
--- a/pyro/contrib/gp/models/gpr.py
+++ b/pyro/contrib/gp/models/gpr.py
@@ -71,7 +71,7 @@ class GPRegression(GPModel):
 
         noise = self.X.new_ones(()) if noise is None else noise
         self.noise = Parameter(noise)
-        self.set_constraint("noise", torchdist.constraints.greater_than(self.jitter))
+        self.set_constraint("noise", torchdist.constraints.positive)
 
     def model(self):
         self.set_mode("model")
@@ -80,7 +80,7 @@ class GPRegression(GPModel):
 
         N = self.X.shape[0]
         Kff = self.kernel(self.X)
-        Kff.view(-1)[::N + 1] += noise  # add noise to diagonal
+        Kff.view(-1)[::N + 1] += self.jitter + noise  # add noise to diagonal
         Lff = Kff.cholesky()
 
         zero_loc = self.X.new_zeros(self.X.shape[0])
@@ -128,7 +128,7 @@ class GPRegression(GPModel):
 
         N = self.X.shape[0]
         Kff = self.kernel(self.X).contiguous()
-        Kff.view(-1)[::N + 1] += noise  # add noise to the diagonal
+        Kff.view(-1)[::N + 1] += self.jitter + noise  # add noise to the diagonal
         Lff = Kff.cholesky()
 
         y_residual = self.y - self.mean_function(self.X)

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -102,7 +102,7 @@ class SparseGPRegression(GPModel):
 
         noise = self.X.new_ones(()) if noise is None else noise
         self.noise = Parameter(noise)
-        self.set_constraint("noise", constraints.greater_than(self.jitter))
+        self.set_constraint("noise", constraints.positive)
 
         if approx is None:
             self.approx = "VFE"

--- a/tests/contrib/gp/test_models.py
+++ b/tests/contrib/gp/test_models.py
@@ -27,7 +27,7 @@ X = torch.tensor([[1., 5., 3.], [4., 3., 7.]])
 y1D = torch.tensor([2., 1.])
 y2D = torch.tensor([[1., 2.], [3., 3.], [1., 4.], [-1., 1.]])
 kernel = RBF(input_dim=3, variance=torch.tensor(3.), lengthscale=torch.tensor(2.))
-noise = torch.tensor(1e-6)
+noise = torch.tensor(1e-7)
 likelihood = Gaussian(noise)
 
 TEST_CASES = [


### PR DESCRIPTION
This PR makes a small change at GPR/SGPR models:
+ Previously: noise's constraint is `constraints.greater_than(jitter)`. We only add noise to the diagonal of k(X, X).
+ Now: noise's constraint is `constraints.positive`. We will add noise+jitter to the diagonal of k(X, X).

This change does not affect much the inference and the term is added to k(X, X) is always guaranteed to greater than `jitter`.