### PR TITLE
Remove duplicated functional of gp

### DIFF
--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -101,7 +101,8 @@ def main(args):
     # CNN will transform a high dimension image into a low dimension 2D tensors for RBF kernel.
     # This kernel accepts inputs are inputs of CNN and gives outputs are covariance matrix of RBF on
     # outputs of CNN.
-    kernel = gp.kernels.RBF(input_dim=10, lengthscale=torch.ones(10)).warp(iwarping_fn=cnn_fn)
+    kernel = gp.kernels.Warp(gp.kernels.RBF(input_dim=10, lengthscale=torch.ones(10)),
+                             iwarping_fn=cnn_fn)
 
     # init inducing points (taken randomly from dataset)
     Xu = next(iter(train_loader))[0][:args.num_inducing]

--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -73,89 +73,6 @@ class Kernel(Parameterized):
         else:
             raise ValueError("Input X must be either 1 or 2 dimensional.")
 
-    def add(self, other, name=None):
-        """
-        Creates a new kernel from a sum/direct sum of this kernel object and ``other``.
-
-        :param other: A kernel to be combined with this kernel object.
-        :type other: Kernel or numbers.Number
-        :param str name: An optional name for the derived kernel.
-        :returns: a Sum kernel
-        :rtype: Sum
-        """
-        return Sum(self, other, name)
-
-    def mul(self, other, name=None):
-        """
-        Creates a new kernel from a product/tensor product of this kernel object and
-        ``other``.
-
-        :param Kernel other: A kernel to be combined with this kernel object.
-        :type other: Kernel or numbers.Number
-        :param str name: An optional name for the derived kernel.
-        :returns: a Product kernel
-        :rtype: Product
-        """
-        return Product(self, other, name)
-
-    def exp(self, name=None):
-        r"""
-        Creates a new kernel according to
-
-            :math:`k_{new}(x, z) = \exp(k(x, z)).`
-
-        :param str name: An optional name for the derived kernel.
-        :returns: an Exponent kernel
-        :rtype: Exponent
-        """
-        return Exponent(self, name)
-
-    def vertical_scale(self, vscaling_fn, name=None):
-        """
-        Creates a new kernel according to
-
-            :math:`k_{new}(x, z) = f(x)k(x, z)f(z),`
-
-        where :math:`f` is a function.
-
-        :param callable vscaling_fn: A vertical scaling function :math:`f`.
-        :param str name: An optional name for the derived kernel.
-        :returns: a vertical scaled kernel
-        :rtype: VerticalScaling
-        """
-        return VerticalScaling(self, vscaling_fn, name)
-
-    def warp(self, iwarping_fn=None, owarping_coef=None, name=None):
-        """
-        Creates a new kernel according to
-
-            :math:`k_{new}(x, z) = q(k(f(x), f(z))),`
-
-        where :math:`f` is an function and :math:`q` is a polynomial with non-negative
-        coefficients ``owarping_coef``.
-
-        :param callable iwarping_fn: An input warping function :math:`f`.
-        :param list owarping_coef: A list of coefficients of the output warping
-            polynomial. These coefficients must be non-negative.
-        :param str name: An optional name for the derived kernel.
-        :returns: a warped kernel
-        :rtype: Warping
-        """
-        return Warping(self, iwarping_fn, owarping_coef, name)
-
-    def get_subkernel(self, name):
-        """
-        Returns the subkernel corresponding to ``name``.
-
-        :param str name: Name of the subkernel.
-        :returns: A subkernel.
-        :rtype: Kernel
-        """
-        if name in self._subkernels:
-            return self._subkernels[name]
-        else:
-            raise KeyError("There is no subkernel with the name '{}'.".format(name))
-
 
 class Combination(Kernel):
     """
@@ -182,26 +99,6 @@ class Combination(Kernel):
 
         self.kern0 = kern0
         self.kern1 = kern1
-
-        if kern0._subkernels:
-            self._subkernels.update(kern0._subkernels)
-        else:
-            self._subkernels[kern0.name] = kern0
-
-        if isinstance(kern1, Kernel):
-            if kern1._subkernels:
-                subkernels1 = kern1._subkernels
-            else:
-                subkernels1 = OrderedDict({kern1.name: kern1})
-            for name, kernel in subkernels1.items():
-                if name in self._subkernels:
-                    if self._subkernels[name] is not kernel:
-                        raise KeyError("Detect two different subkernels with the same "
-                                       "name '{}'. Consider to change the default "
-                                       "name of these subkernels to distinguish them."
-                                       .format(name))
-                else:
-                    self._subkernels[name] = kernel
 
 
 class Sum(Combination):
@@ -239,11 +136,6 @@ class Transforming(Kernel):
         super(Transforming, self).__init__(kern.input_dim, kern.active_dims, name)
 
         self.kern = kern
-
-        if kern._subkernels:
-            self._subkernels.update(kern._subkernels)
-        else:
-            self._subkernels[kern.name] = kern
 
 
 class Exponent(Transforming):

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -127,14 +127,15 @@ class SparseGPRegression(GPModel):
         # y_cov = W @ W.T + D
         # trace_term is added into log_prob
 
-        M = Xu.shape[0]
+        N = self.X.size(0)
+        M = Xu.size(0)
         Kuu = self.kernel(Xu).contiguous()
         Kuu.view(-1)[::M + 1] += self.jitter  # add jitter to the diagonal
         Luu = Kuu.cholesky()
         Kuf = self.kernel(Xu, self.X)
         W = Kuf.trtrs(Luu, upper=False)[0].t()
 
-        D = noise.expand(W.shape[0])
+        D = noise.expand(M)
         if self.approx == "FITC" or self.approx == "VFE":
             Kffdiag = self.kernel(self.X, diag=True)
             Qffdiag = W.pow(2).sum(dim=-1)
@@ -143,7 +144,7 @@ class SparseGPRegression(GPModel):
             else:  # approx = "VFE"
                 trace_term = (Kffdiag - Qffdiag).sum() / noise
 
-        zero_loc = self.X.new_zeros(self.X.shape[0])
+        zero_loc = self.X.new_zeros(N)
         f_loc = zero_loc + self.mean_function(self.X)
         if self.y is None:
             f_var = D + W.pow(2).sum(dim=-1)
@@ -205,17 +206,18 @@ class SparseGPRegression(GPModel):
         # cov = Kss - Ksu @ inv(Kuu) @ Kus + Ksu @ S @ Kus
         #     = kss - Ksu @ inv(Kuu) @ Kus + Ws.T @ inv(L).T @ inv(L) @ Ws
 
-        N = self.X.shape[0]
-        M = Xu.shape[0]
+        N = self.X.size(0)
+        M = Xu.size(0)
+
+        # TODO: cache these calculations to get faster inference
 
         Kuu = self.kernel(Xu).contiguous()
         Kuu.view(-1)[::M + 1] += self.jitter  # add jitter to the diagonal
         Luu = Kuu.cholesky()
-        Kus = self.kernel(Xu, Xnew)
+
         Kuf = self.kernel(Xu, self.X)
 
         W = Kuf.trtrs(Luu, upper=False)[0]
-        Ws = Kus.trtrs(Luu, upper=False)[0]
         D = noise.expand(N)
         if self.approx == "FITC":
             Kffdiag = self.kernel(self.X, diag=True)
@@ -231,13 +233,19 @@ class SparseGPRegression(GPModel):
         y_residual = self.y - self.mean_function(self.X)
         y_2D = y_residual.reshape(-1, N).t()
         W_Dinv_y = W_Dinv.matmul(y_2D)
+
+        # End caching ----------
+
+        Kus = self.kernel(Xu, Xnew)
+        Ws = Kus.trtrs(Luu, upper=False)[0]
         pack = torch.cat((W_Dinv_y, Ws), dim=1)
         Linv_pack = pack.trtrs(L, upper=False)[0]
         # unpack
         Linv_W_Dinv_y = Linv_pack[:, :W_Dinv_y.shape[1]]
         Linv_Ws = Linv_pack[:, W_Dinv_y.shape[1]:]
 
-        loc_shape = self.y.shape[:-1] + (Xnew.shape[0],)
+        C = Xnew.size(0)
+        loc_shape = self.y.shape[:-1] + (C,)
         loc = Linv_W_Dinv_y.t().matmul(Linv_Ws).reshape(loc_shape)
 
         if full_cov:
@@ -253,7 +261,7 @@ class SparseGPRegression(GPModel):
             Qssdiag = Ws.pow(2).sum(dim=0)
             cov = Kssdiag - Qssdiag + Linv_Ws.pow(2).sum(dim=0)
 
-        cov_shape = self.y.shape[:-1] + (Xnew.shape[0], Xnew.shape[0])
+        cov_shape = self.y.shape[:-1] + (C, C)
         cov = cov.expand(cov_shape)
 
         return loc + self.mean_function(Xnew), cov

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -135,7 +135,7 @@ class SparseGPRegression(GPModel):
         Kuf = self.kernel(Xu, self.X)
         W = Kuf.trtrs(Luu, upper=False)[0].t()
 
-        D = noise.expand(M)
+        D = noise.expand(N)
         if self.approx == "FITC" or self.approx == "VFE":
             Kffdiag = self.kernel(self.X, diag=True)
             Qffdiag = W.pow(2).sum(dim=-1)

--- a/tests/contrib/gp/test_kernels.py
+++ b/tests/contrib/gp/test_kernels.py
@@ -5,8 +5,9 @@ from collections import namedtuple
 import pytest
 import torch
 
-from pyro.contrib.gp.kernels import (RBF, Brownian, Constant, Coregionalize, Cosine, Exponent, Exponential, Linear,
-                                     Matern32, Matern52, Periodic, Polynomial, Product, RationalQuadratic, Sum,
+from pyro.contrib.gp.kernels import (RBF, Brownian, Constant, Coregionalize, Cosine, Exponent,
+                                     Exponential, Linear, Matern32, Matern52, Periodic,
+                                     Polynomial, Product, RationalQuadratic, Sum,
                                      VerticalScaling, Warping, WhiteNoise)
 from tests.common import assert_equal
 

--- a/tests/contrib/gp/test_kernels.py
+++ b/tests/contrib/gp/test_kernels.py
@@ -134,9 +134,6 @@ def test_combination():
 
     assert_equal(K.data, k(X, Z).data)
 
-    # test get_subkernel
-    assert k.get_subkernel(k5.name) is k5
-
 
 def test_active_dims_overlap_ok():
     k1 = Matern52(2, variance, lengthscale[0], active_dims=[0, 1])
@@ -170,7 +167,3 @@ def test_transforming():
     assert_equal(K_owarp.data, Warping(k, owarping_coef=owarping_coef)(X, Z).data)
     assert_equal(K_vscale.data, VerticalScaling(k, vscaling_fn=vscaling_fn)(X, Z).data)
     assert_equal(K.exp().data, Exponent(k)(X, Z).data)
-
-    # test get_subkernel
-    k1 = Sum(Warping(k, iwarping_fn=iwarping_fn), TEST_CASES[7][0])
-    assert k1.get_subkernel(k.name) is k

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -107,7 +107,7 @@ def svgp_multiclass(num_steps, whiten):
     f = K.cholesky().matmul(torch.randn(100, 3))
     y = f.argmax(dim=-1)
 
-    kernel = gp.kernels.Sum(gp.kernels.Matern32(1.),
+    kernel = gp.kernels.Sum(gp.kernels.Matern32(1),
                             gp.kernels.WhiteNoise(1, variance=torch.tensor(0.01)))
     likelihood = gp.likelihoods.MultiClass(num_classes=3)
     Xu = X[::5].clone()

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -107,8 +107,8 @@ def svgp_multiclass(num_steps, whiten):
     f = K.cholesky().matmul(torch.randn(100, 3))
     y = f.argmax(dim=-1)
 
-    kernel = gp.kernels.Matern32(1).add(
-        gp.kernels.WhiteNoise(1, variance=torch.tensor(0.01)))
+    kernel = gp.kernels.Sum(gp.kernels.Matern32(1.),
+                            gp.kernels.WhiteNoise(1, variance=torch.tensor(0.01)))
     likelihood = gp.likelihoods.MultiClass(num_classes=3)
     Xu = X[::5].clone()
 

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -97,8 +97,8 @@ def bernoulli_beta_hmc(**kwargs):
     return mcmc_run.marginal('p_latent').empirical
 
 
-@register_model(num_steps=2000, whiten=False, id='SVGP::MultiClass_whiten=False')
-@register_model(num_steps=2000, whiten=True, id='SVGP::MultiClass_whiten=True')
+@register_model(num_steps=2000, whiten=False, id='VSGP::MultiClass_whiten=False')
+@register_model(num_steps=2000, whiten=True, id='VSGP::MultiClass_whiten=True')
 def svgp_multiclass(num_steps, whiten):
     # adapted from http://gpflow.readthedocs.io/en/latest/notebooks/multiclass.html
     pyro.set_rng_seed(0)
@@ -117,7 +117,7 @@ def svgp_multiclass(num_steps, whiten):
                                             whiten=whiten)
 
     gpmodel.fix_param("Xu")
-    gpmodel.kernel.get_subkernel("WhiteNoise").fix_param("variance")
+    gpmodel.kernel.kern1.fix_param("variance")
 
     gpmodel.optimize(optim.Adam({"lr": 0.0001}), num_steps=num_steps)
 


### PR DESCRIPTION
This PR cleans GP by removing duplicated functions `add`, `sum`, `product`. In addition, I also remove `get_subkernel` method because it is unnecessary.