### PR TITLE
miscellaneous formatting gpmodule

### DIFF
--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -47,33 +47,32 @@ class CNN(nn.Module):
         return x
 
 
-def train(args, train_loader, gpmodel, svi, epoch):
+def train(args, train_loader, gpmodule, svi, epoch):
     for batch_idx, (data, target) in enumerate(train_loader):
         if args.cuda:
             data, target = data.cuda(), target.cuda()
-        gpmodel.set_data(data, target)
+        gpmodule.set_data(data, target)
         loss = svi.step()
         if batch_idx % args.log_interval == 0:
-            print('Train Epoch: {:2d} [{:5d}/{} ({:2.0f}%)]\tLoss: {:.6f}'.format(
-                epoch, batch_idx * len(data), len(train_loader.dataset),
-                100. * batch_idx / len(train_loader), loss))
+            print("Train Epoch: {:2d} [{:5d}/{} ({:2.0f}%)]\tLoss: {:.6f}"
+                  .format(epoch, batch_idx * len(data), len(train_loader.dataset),
+                          100. * batch_idx / len(train_loader), loss))
 
 
-def test(args, test_loader, gpmodel):
+def test(args, test_loader, gpmodule):
     correct = 0
     for data, target in test_loader:
         if args.cuda:
             data, target = data.cuda(), target.cuda()
         # get prediction of GP model on new data
-        f_loc, f_var = gpmodel(data)
+        f_loc, f_var = gpmodule(data)
         # use its likelihood to give prediction class
-        pred = gpmodel.likelihood(f_loc, f_var)
+        pred = gpmodule.likelihood(f_loc, f_var)
         # compare prediction and target to count accuaracy
         correct += pred.eq(target).long().cpu().sum()
 
-    print('\nTest set: Accuracy: {}/{} ({:.0f}%)\n'.format(
-        correct, len(test_loader.dataset),
-        100. * correct / len(test_loader.dataset)))
+    print("\nTest set: Accuracy: {}/{} ({:.0f}%)\n"
+          .format(correct, len(test_loader.dataset), 100. * correct / len(test_loader.dataset)))
 
 
 def main(args):
@@ -97,10 +96,11 @@ def main(args):
     # so we need this helper to mark cnn's parameters active for each `svi.step()` call.
     def cnn_fn(x):
         return pyro.module("CNN", cnn)(x)
+
     # Create deep kernel by warping RBF with CNN.
     # CNN will transform a high dimension image into a low dimension 2D tensors for RBF kernel.
-    # This kernel accepts inputs are inputs of CNN and gives outputs are covariance matrix of RBF on
-    # outputs of CNN.
+    # This kernel accepts inputs are inputs of CNN and gives outputs are covariance matrix of RBF
+    # on outputs of CNN.
     kernel = gp.kernels.Warp(gp.kernels.RBF(input_dim=10, lengthscale=torch.ones(10)),
                              iwarping_fn=cnn_fn)
 
@@ -108,26 +108,27 @@ def main(args):
     Xu = next(iter(train_loader))[0][:args.num_inducing]
     # use MultiClass likelihood for 10-class classification problem
     likelihood = gp.likelihoods.MultiClass(num_classes=10)
-    # Because we use Categorical distribution in MultiClass likelihood, we need GP model returns a list
-    # of probabilities of each class. Hence it is required to use latent_shape = 10.
+    # Because we use Categorical distribution in MultiClass likelihood, we need GP model returns
+    # a list of probabilities of each class. Hence it is required to use latent_shape = 10.
     # Turns on "whiten" flag will help optimization for variational models.
-    gpmodel = gp.models.VariationalSparseGP(X=Xu, y=None, kernel=kernel, Xu=Xu,
-                                            likelihood=likelihood, latent_shape=torch.Size([10]),
-                                            num_data=60000, whiten=True)
+    gpmodule = gp.models.VariationalSparseGP(X=Xu, y=None, kernel=kernel, Xu=Xu,
+                                             likelihood=likelihood, latent_shape=torch.Size([10]),
+                                             num_data=60000, whiten=True)
     if args.cuda:
-        gpmodel.cuda()
+        gpmodule.cuda()
 
     optimizer = optim.Adam({"lr": args.lr})
 
     elbo = infer.JitTrace_ELBO() if args.jit else infer.Trace_ELBO()
-    svi = infer.SVI(gpmodel.model, gpmodel.guide, optimizer, elbo)
+    svi = infer.SVI(gpmodule.model, gpmodule.guide, optimizer, elbo)
 
     for epoch in range(1, args.epochs + 1):
         start_time = time.time()
-        train(args, train_loader, gpmodel, svi, epoch)
+        train(args, train_loader, gpmodule, svi, epoch)
         with torch.no_grad():
-            test(args, test_loader, gpmodel)
-        print("Amount of time spent for epoch {}: {}s\n".format(epoch, int(time.time() - start_time)))
+            test(args, test_loader, gpmodule)
+        print("Amount of time spent for epoch {}: {}s\n"
+              .format(epoch, int(time.time() - start_time)))
 
 
 if __name__ == '__main__':

--- a/pyro/contrib/gp/kernels/__init__.py
+++ b/pyro/contrib/gp/kernels/__init__.py
@@ -3,13 +3,15 @@ from __future__ import absolute_import, division, print_function
 from pyro.contrib.gp.kernels.brownian import Brownian
 from pyro.contrib.gp.kernels.coregionalize import Coregionalize
 from pyro.contrib.gp.kernels.dot_product import DotProduct, Linear, Polynomial
-from pyro.contrib.gp.kernels.isotropic import RBF, Exponential, Isotropy, Matern32, Matern52, RationalQuadratic
-from pyro.contrib.gp.kernels.kernel import (Combination, Exponent, Kernel, Product, Sum, Transforming, VerticalScaling,
-                                            Warping)
+from pyro.contrib.gp.kernels.isotropic import (RBF, Exponential, Isotropy, Matern32, Matern52,
+                                               RationalQuadratic)
+from pyro.contrib.gp.kernels.kernel import (Combination, Exponent, Kernel, Product, Sum,
+                                            Transforming, VerticalScaling, Warping)
 from pyro.contrib.gp.kernels.periodic import Cosine, Periodic
 from pyro.contrib.gp.kernels.static import Constant, WhiteNoise
 
 __all__ = [
+    "Kernel",
     "Brownian",
     "Combination",
     "Constant",
@@ -19,7 +21,6 @@ __all__ = [
     "Exponent",
     "Exponential",
     "Isotropy",
-    "Kernel",
     "Linear",
     "Matern32",
     "Matern52",
@@ -48,5 +49,5 @@ __doc__ = '\n\n'.join([
         :show-inheritance:
         :member-order: bysource
     '''.format(_name)
-    for _name in sorted(__all__)
+    for _name in __all__
 ])

--- a/pyro/contrib/gp/kernels/brownian.py
+++ b/pyro/contrib/gp/kernels/brownian.py
@@ -27,8 +27,7 @@ class Brownian(Kernel):
             raise ValueError("Input dimensional for Brownian kernel must be 1.")
         super(Brownian, self).__init__(input_dim, active_dims, name)
 
-        if variance is None:
-            variance = torch.tensor(1.)
+        variance = torch.tensor(1.) if variance is None else variance
         self.variance = Parameter(variance)
         self.set_constraint("variance", constraints.positive)
 

--- a/pyro/contrib/gp/kernels/coregionalize.py
+++ b/pyro/contrib/gp/kernels/coregionalize.py
@@ -59,8 +59,7 @@ class Coregionalize(Kernel):
 
         # Add a diagonal component initialized to torch.eye(input_dim, input_dim) / 2,
         # such that the total kernel has expected value the identity matrix.
-        if diagonal is None:
-            diagonal = components.new_ones(input_dim) * 0.5
+        diagonal = components.new_ones(input_dim) * 0.5 if diagonal is None else diagonal
         if diagonal.shape != (input_dim,):
             raise ValueError("Expected diagonal.shape == ({},), actual {}"
                              .format(input_dim, diagonal.shape))

--- a/pyro/contrib/gp/kernels/dot_product.py
+++ b/pyro/contrib/gp/kernels/dot_product.py
@@ -15,8 +15,7 @@ class DotProduct(Kernel):
     def __init__(self, input_dim, variance=None, active_dims=None, name=None):
         super(DotProduct, self).__init__(input_dim, active_dims, name)
 
-        if variance is None:
-            variance = torch.tensor(1.) if variance is None else variance
+        variance = torch.tensor(1.) if variance is None else variance
         self.variance = Parameter(variance)
         self.set_constraint("variance", constraints.positive)
 
@@ -73,14 +72,12 @@ class Polynomial(DotProduct):
                  name="Polynomial"):
         super(Polynomial, self).__init__(input_dim, variance, active_dims, name)
 
-        if bias is None:
-            bias = torch.tensor(1.)
+        bias = torch.tensor(1.) if bias is None else bias
         self.bias = Parameter(bias)
         self.set_constraint("bias", constraints.positive)
 
         if not isinstance(degree, int) or degree < 1:
-            raise ValueError("Degree for Polynomial kernel should be a positive "
-                             "integer.")
+            raise ValueError("Degree for Polynomial kernel should be a positive integer.")
         self.degree = degree
 
     def forward(self, X, Z=None, diag=False):

--- a/pyro/contrib/gp/kernels/isotropic.py
+++ b/pyro/contrib/gp/kernels/isotropic.py
@@ -31,13 +31,11 @@ class Isotropy(Kernel):
                  name=None):
         super(Isotropy, self).__init__(input_dim, active_dims, name)
 
-        if variance is None:
-            variance = torch.tensor(1.)
+        variance = torch.tensor(1.) if variance is None else variance
         self.variance = Parameter(variance)
         self.set_constraint("variance", constraints.positive)
 
-        if lengthscale is None:
-            lengthscale = torch.tensor(1.)
+        lengthscale = torch.tensor(1.) if lengthscale is None else lengthscale
         self.lengthscale = Parameter(lengthscale)
         self.set_constraint("lengthscale", constraints.positive)
 

--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -34,8 +34,7 @@ class Kernel(Parameterized):
         if active_dims is None:
             active_dims = list(range(input_dim))
         elif input_dim != len(active_dims):
-            raise ValueError("Input size and the length of active dimensionals should "
-                             "be equal.")
+            raise ValueError("Input size and the length of active dimensionals should be equal.")
         self.input_dim = input_dim
         self.active_dims = active_dims
 

--- a/pyro/contrib/gp/kernels/periodic.py
+++ b/pyro/contrib/gp/kernels/periodic.py
@@ -52,18 +52,15 @@ class Periodic(Kernel):
                  active_dims=None, name="Periodic"):
         super(Periodic, self).__init__(input_dim, active_dims, name)
 
-        if variance is None:
-            variance = torch.tensor(1.)
+        variance = torch.tensor(1.) if variance is None else variance
         self.variance = Parameter(variance)
         self.set_constraint("variance", constraints.positive)
 
-        if lengthscale is None:
-            lengthscale = torch.tensor(1.)
+        lengthscale = torch.tensor(1.) if lengthscale is None else lengthscale
         self.lengthscale = Parameter(lengthscale)
         self.set_constraint("lengthscale", constraints.positive)
 
-        if period is None:
-            period = torch.tensor(1.)
+        period = torch.tensor(1.) if period is None else period
         self.period = Parameter(period)
         self.set_constraint("period", constraints.positive)
 

--- a/pyro/contrib/gp/kernels/static.py
+++ b/pyro/contrib/gp/kernels/static.py
@@ -16,8 +16,7 @@ class Constant(Kernel):
     def __init__(self, input_dim, variance=None, active_dims=None, name="Constant"):
         super(Constant, self).__init__(input_dim, active_dims, name)
 
-        if variance is None:
-            variance = torch.tensor(1.)
+        variance = torch.tensor(1.) if variance is None else variance
         self.variance = Parameter(variance)
         self.set_constraint("variance", constraints.positive)
 
@@ -42,8 +41,7 @@ class WhiteNoise(Kernel):
     def __init__(self, input_dim, variance=None, active_dims=None, name="WhiteNoise"):
         super(WhiteNoise, self).__init__(input_dim, active_dims, name)
 
-        if variance is None:
-            variance = torch.tensor(1.)
+        variance = torch.tensor(1.) if variance is None else variance
         self.variance = Parameter(variance)
         self.set_constraint("variance", constraints.positive)
 

--- a/pyro/contrib/gp/likelihoods/__init__.py
+++ b/pyro/contrib/gp/likelihoods/__init__.py
@@ -7,9 +7,9 @@ from pyro.contrib.gp.likelihoods.multi_class import MultiClass
 from pyro.contrib.gp.likelihoods.poisson import Poisson
 
 __all__ = [
+    "Likelihood",
     "Binary",
     "Gaussian",
-    "Likelihood",
     "MultiClass",
     "Poisson",
 ]
@@ -28,5 +28,5 @@ __doc__ = '\n\n'.join([
         :show-inheritance:
         :member-order: bysource
     '''.format(_name)
-    for _name in sorted(__all__)
+    for _name in __all__
 ])

--- a/pyro/contrib/gp/likelihoods/gaussian.py
+++ b/pyro/contrib/gp/likelihoods/gaussian.py
@@ -21,8 +21,8 @@ class Gaussian(Likelihood):
     """
     def __init__(self, variance=None, name="Gaussian"):
         super(Gaussian, self).__init__(name)
-        if variance is None:
-            variance = torch.tensor(1.)
+
+        variance = torch.tensor(1.) if variance is None else variance
         self.variance = Parameter(variance)
         self.set_constraint("variance", constraints.positive)
 

--- a/pyro/contrib/gp/models/gplvm.py
+++ b/pyro/contrib/gp/models/gplvm.py
@@ -42,13 +42,13 @@ class GPLVM(Parameterized):
             ...                  dist.Exponential(0.5).sample((150,))])
 
         >>> # First, define the initial values for X_loc parameter:
-        >>> X_loc = torch.zeros(150, 2)
-        >>> # Then, define a Gaussian Process model with input X_loc and output y:
+        >>> X_init = torch.zeros(150, 2)
+        >>> # Then, define a Gaussian Process model with input X_init and output y:
         >>> kernel = gp.kernels.RBF(input_dim=2, lengthscale=torch.ones(2))
         >>> Xu = torch.zeros(20, 2)  # initial inducing inputs of sparse model
-        >>> gpmodel = gp.models.SparseGPRegression(X_loc, y, kernel, Xu)
-        >>> # Finally, wrap gpmodel by GPLVM, optimize, and get the "learned" mean of X:
-        >>> gplvm = gp.models.GPLVM(gpmodel)
+        >>> gpmodule = gp.models.SparseGPRegression(X_init, y, kernel, Xu)
+        >>> # Finally, wrap gpmodule by GPLVM, optimize, and get the "learned" mean of X:
+        >>> gplvm = gp.models.GPLVM(gpmodule)
         >>> gplvm.optimize()  # doctest: +SKIP
         >>> X = gplvm.get_param("X_loc")
 

--- a/pyro/contrib/gp/models/gpr.py
+++ b/pyro/contrib/gp/models/gpr.py
@@ -69,7 +69,7 @@ class GPRegression(GPModel):
                  name="GPR"):
         super(GPRegression, self).__init__(X, y, kernel, mean_function, jitter, name)
 
-        noise = self.X.new_ones(()) if noise is None else noise
+        noise = self.X.new_tensor(1.) if noise is None else noise
         self.noise = Parameter(noise)
         self.set_constraint("noise", torchdist.constraints.greater_than(self.jitter))
 

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -100,7 +100,7 @@ class SparseGPRegression(GPModel):
 
         self.Xu = Parameter(Xu)
 
-        noise = self.X.new_ones(()) if noise is None else noise
+        noise = self.X.new_tensor(1.) if noise is None else noise
         self.noise = Parameter(noise)
         self.set_constraint("noise", constraints.greater_than(self.jitter))
 

--- a/pyro/contrib/gp/models/vsgp.py
+++ b/pyro/contrib/gp/models/vsgp.py
@@ -83,27 +83,24 @@ class VariationalSparseGP(GPModel):
                  name="SVGP"):
         super(VariationalSparseGP, self).__init__(X, y, kernel, mean_function, jitter,
                                                   name)
+
         self.likelihood = likelihood
-
-        self.num_data = num_data if num_data is not None else self.X.size(0)
-        self.whiten = whiten
-
         self.Xu = Parameter(Xu)
 
         y_batch_shape = self.y.shape[:-1] if self.y is not None else torch.Size([])
         self.latent_shape = latent_shape if latent_shape is not None else y_batch_shape
 
         M = self.Xu.size(0)
-        u_loc_shape = self.latent_shape + (M,)
-        u_loc = self.Xu.new_zeros(u_loc_shape)
+        u_loc = self.Xu.new_zeros(self.latent_shape + (M,))
         self.u_loc = Parameter(u_loc)
 
-        u_scale_tril_shape = self.latent_shape + (M, M)
-        Id = eye_like(self.Xu, M)
-        u_scale_tril = Id.expand(u_scale_tril_shape)
+        identity = eye_like(self.Xu, M)
+        u_scale_tril = identity.repeat(self.latent_shape + (1, 1))
         self.u_scale_tril = Parameter(u_scale_tril)
         self.set_constraint("u_scale_tril", constraints.lower_cholesky)
 
+        self.num_data = num_data if num_data is not None else self.X.size(0)
+        self.whiten = whiten
         self._sample_latent = True
 
     def model(self):
@@ -121,9 +118,9 @@ class VariationalSparseGP(GPModel):
         zero_loc = Xu.new_zeros(u_loc.shape)
         u_name = param_with_module_name(self.name, "u")
         if self.whiten:
-            Id = eye_like(Xu, M)
+            identity = eye_like(Xu, M)
             pyro.sample(u_name,
-                        dist.MultivariateNormal(zero_loc, scale_tril=Id)
+                        dist.MultivariateNormal(zero_loc, scale_tril=identity)
                             .to_event(zero_loc.dim() - 1))
         else:
             pyro.sample(u_name,
@@ -131,14 +128,13 @@ class VariationalSparseGP(GPModel):
                             .to_event(zero_loc.dim() - 1))
 
         f_loc, f_var = conditional(self.X, Xu, self.kernel, u_loc, u_scale_tril,
-                                   Luu, full_cov=False, whiten=self.whiten,
-                                   jitter=self.jitter)
+                                   Luu, full_cov=False, whiten=self.whiten, jitter=self.jitter)
 
         f_loc = f_loc + self.mean_function(self.X)
         if self.y is None:
             return f_loc, f_var
         else:
-            with poutine.scale(None, self.num_data / self.X.shape[0]):
+            with poutine.scale(None, self.num_data / self.X.size(0)):
                 return self.likelihood(f_loc, f_var, self.y)
 
     def guide(self):
@@ -181,6 +177,5 @@ class VariationalSparseGP(GPModel):
         self._sample_latent = True
 
         loc, cov = conditional(Xnew, Xu, self.kernel, u_loc, u_scale_tril,
-                               full_cov=full_cov, whiten=self.whiten,
-                               jitter=self.jitter)
+                               full_cov=full_cov, whiten=self.whiten, jitter=self.jitter)
         return loc + self.mean_function(Xnew), cov


### PR DESCRIPTION
This PR changes coding style of GP to match the styles of other pyro's implementation. For example
+ Change `if x is None: x = torch.tensor(1.)` to `x = torch.tensor(1.) if x is None else x`.
+ `Id` -> `identity`.
+ `gpmodel` -> `gpmodule` to reflect that it is a nn.Module. This is also to avoid the confusion `gpmodel.model`.