### PR TITLE
Modify slow running HMC unit tests to run faster

### DIFF
--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -191,43 +191,6 @@ def test_logistic_regression(step_size, trajectory_length, num_steps,
     assert_equal(rmse(true_coefs, beta_posterior.mean).item(), 0.0, prec=0.1)
 
 
-@pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
-def test_beta_bernoulli(jit):
-    def model(data):
-        # wrapped by `pyro.param` to test if it works
-        alpha = pyro.param('alpha', torch.tensor([1.1, 1.1]))
-        beta = pyro.param('beta', torch.tensor([1.1, 1.1]))
-        p_latent = pyro.sample('p_latent', dist.Beta(alpha, beta))
-        pyro.sample('obs', dist.Bernoulli(p_latent), obs=data)
-        return p_latent
-
-    true_probs = torch.tensor([0.9, 0.1])
-    data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
-    hmc_kernel = HMC(model, trajectory_length=1, jit_compile=jit, ignore_jit_warnings=True)
-    mcmc_run = MCMC(hmc_kernel, num_samples=800, warmup_steps=500).run(data)
-    posterior = mcmc_run.marginal('p_latent').empirical['p_latent']
-    assert_equal(posterior.mean, true_probs, prec=0.05)
-
-
-@pytest.mark.parametrize("jit", [False, mark_jit(True, marks=[
-    pytest.mark.skip(reason="https://github.com/uber/pyro/issues/1487")])],
-                         ids=jit_idfn)
-def test_gamma_normal(jit):
-    def model(data):
-        rate = torch.tensor([1.0, 1.0])
-        concentration = torch.tensor([1.0, 1.0])
-        p_latent = pyro.sample('p_latent', dist.Gamma(rate, concentration))
-        pyro.sample("obs", dist.Normal(3, p_latent), obs=data)
-        return p_latent
-
-    true_std = torch.tensor([0.5, 2])
-    data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
-    hmc_kernel = HMC(model, trajectory_length=1, step_size=0.3, jit_compile=jit, ignore_jit_warnings=True)
-    mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
-    posterior = mcmc_run.marginal('p_latent').empirical['p_latent']
-    assert_equal(posterior.mean, true_std, prec=0.05)
-
-
 @pytest.mark.parametrize("jit", [False, mark_jit(True, marks=[
     pytest.mark.skip(reason="https://github.com/uber/pyro/issues/1487")])],
                          ids=jit_idfn)
@@ -247,27 +210,7 @@ def test_dirichlet_categorical(jit):
 
 
 @pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
-def test_logistic_regression_with_dual_averaging(jit):
-    dim = 3
-    data = torch.randn(2000, dim)
-    true_coefs = torch.arange(1., dim + 1.)
-    labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
-
-    def model(data):
-        coefs_mean = torch.zeros(dim)
-        coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(dim)))
-        y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
-        return y
-
-    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True,
-                     jit_compile=jit, ignore_jit_warnings=True)
-    mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
-    posterior = mcmc_run.marginal(["beta"]).empirical["beta"]
-    assert_equal(rmse(posterior.mean, true_coefs).item(), 0.0, prec=0.1)
-
-
-@pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
-def test_beta_bernoulli_with_dual_averaging(jit):
+def test_beta_bernoulli(jit):
     def model(data):
         alpha = torch.tensor([1.1, 1.1])
         beta = torch.tensor([1.1, 1.1])
@@ -288,7 +231,8 @@ def test_beta_bernoulli_with_dual_averaging(jit):
 @pytest.mark.parametrize("jit", [False, mark_jit(True, marks=[
     pytest.mark.skip(reason="https://github.com/uber/pyro/issues/1487")])],
                          ids=jit_idfn)
-def test_gamma_normal_with_dual_averaging(jit):
+@pytest.mark.init(rng_seed=0)
+def test_gamma_normal(jit):
     def model(data):
         rate = torch.tensor([1.0, 1.0])
         concentration = torch.tensor([1.0, 1.0])
@@ -298,9 +242,9 @@ def test_gamma_normal_with_dual_averaging(jit):
 
     true_std = torch.tensor([0.5, 2])
     data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
-    hmc_kernel = HMC(model, trajectory_length=1, step_size=0.3,
+    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True,
                      jit_compile=jit, ignore_jit_warnings=True)
-    mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=100).run(data)
+    mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=200).run(data)
     posterior = mcmc_run.marginal(['p_latent']).empirical['p_latent']
     assert_equal(posterior.mean, true_std, prec=0.05)
 

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -221,7 +221,7 @@ def test_beta_bernoulli(jit):
 
     true_probs = torch.tensor([0.9, 0.1])
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
-    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True, max_plate_nesting=2,
+    hmc_kernel = HMC(model, trajectory_length=1, max_plate_nesting=2,
                      jit_compile=jit, ignore_jit_warnings=True)
     mcmc_run = MCMC(hmc_kernel, num_samples=800, warmup_steps=500).run(data)
     posterior = mcmc_run.marginal(["p_latent"]).empirical["p_latent"]
@@ -242,8 +242,7 @@ def test_gamma_normal(jit):
 
     true_std = torch.tensor([0.5, 2])
     data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
-    hmc_kernel = HMC(model, trajectory_length=1, adapt_step_size=True,
-                     jit_compile=jit, ignore_jit_warnings=True)
+    hmc_kernel = HMC(model, trajectory_length=1, jit_compile=jit, ignore_jit_warnings=True)
     mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=200).run(data)
     posterior = mcmc_run.marginal(['p_latent']).empirical['p_latent']
     assert_equal(posterior.mean, true_std, prec=0.05)

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -231,7 +231,6 @@ def test_beta_bernoulli(jit):
 @pytest.mark.parametrize("jit", [False, mark_jit(True, marks=[
     pytest.mark.skip(reason="https://github.com/uber/pyro/issues/1487")])],
                          ids=jit_idfn)
-@pytest.mark.init(rng_seed=0)
 def test_gamma_normal(jit):
     def model(data):
         rate = torch.tensor([1.0, 1.0])
@@ -242,7 +241,8 @@ def test_gamma_normal(jit):
 
     true_std = torch.tensor([0.5, 2])
     data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
-    hmc_kernel = HMC(model, trajectory_length=1, jit_compile=jit, ignore_jit_warnings=True)
+    hmc_kernel = HMC(model, trajectory_length=1, step_size=0.03, adapt_step_size=False,
+                     jit_compile=jit, ignore_jit_warnings=True)
     mcmc_run = MCMC(hmc_kernel, num_samples=200, warmup_steps=200).run(data)
     posterior = mcmc_run.marginal(['p_latent']).empirical['p_latent']
     assert_equal(posterior.mean, true_std, prec=0.05)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -257,8 +257,7 @@ def test_gaussian_mixture_model(jit):
     true_mix_proportions = torch.tensor([0.1, 0.3, 0.6])
     cluster_assignments = dist.Categorical(true_mix_proportions).sample(torch.Size((N,)))
     data = dist.Normal(true_cluster_means[cluster_assignments], 1.0).sample()
-    nuts_kernel = NUTS(gmm, adapt_step_size=True, max_plate_nesting=1,
-                       jit_compile=jit, ignore_jit_warnings=True)
+    nuts_kernel = NUTS(gmm, max_plate_nesting=1, jit_compile=jit, ignore_jit_warnings=True)
     mcmc_run = MCMC(nuts_kernel, num_samples=300, warmup_steps=100).run(data)
     posterior = mcmc_run.marginal(["phi", "cluster_means"]).empirical
     assert_equal(posterior["phi"].mean.sort()[0], true_mix_proportions, prec=0.05)
@@ -280,8 +279,7 @@ def test_bernoulli_latent_model(jit):
     y = dist.Bernoulli(y_prob).sample(torch.Size((N,)))
     z = dist.Bernoulli(0.65 * y + 0.1).sample()
     data = dist.Normal(2. * z, 1.0).sample()
-    nuts_kernel = NUTS(model, adapt_step_size=True, max_plate_nesting=1,
-                       jit_compile=jit, ignore_jit_warnings=True)
+    nuts_kernel = NUTS(model, max_plate_nesting=1, jit_compile=jit, ignore_jit_warnings=True)
     mcmc_run = MCMC(nuts_kernel, num_samples=600, warmup_steps=200).run(data)
     posterior = mcmc_run.marginal("y_prob").empirical["y_prob"]
     assert_equal(posterior.mean, y_prob, prec=0.05)
@@ -325,8 +323,7 @@ def test_gaussian_hmm(jit, num_steps):
         return torch.stack(obs)
 
     data = _generate_data()
-    nuts_kernel = NUTS(model, adapt_step_size=True, max_plate_nesting=1,
-                       jit_compile=jit, ignore_jit_warnings=True)
+    nuts_kernel = NUTS(model, max_plate_nesting=1, jit_compile=jit, ignore_jit_warnings=True)
     if num_steps == 30:
         nuts_kernel.initial_trace = _get_initial_trace()
     MCMC(nuts_kernel, num_samples=5, warmup_steps=5).run(data)


### PR DESCRIPTION
 - Removed gmm test, since we have the same one in `test_nuts.py` using pretty much the same code path (i.e. einsum evaluator and potential energy computation).
 - ~Specified an initial step size for `test_gamma_normal`~ (Edit - turned off step size adaptation) which was going really slow with a very small step size (the initialization seems to have changed upon merge of pytoch-1.0 branch).