### PR TITLE
Tiny cleanup nuts test

### DIFF
--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -83,8 +83,8 @@ TEST_CASES = [
     ),
     T(
         GaussianChain(dim=10, chain_len=4, num_obs=1),
-        num_samples=800,
-        warmup_steps=200,
+        num_samples=1600,
+        warmup_steps=300,
         hmc_params={'step_size': 0.46,
                     'num_steps': 5},
         expected_means=[0.20, 0.40, 0.60, 0.80],
@@ -94,9 +94,9 @@ TEST_CASES = [
     ),
     T(
         GaussianChain(dim=5, chain_len=2, num_obs=100),
-        num_samples=800,
-        warmup_steps=100,
-        hmc_params={'num_steps': 15, 'step_size': 0.4},
+        num_samples=2000,
+        warmup_steps=1000,
+        hmc_params={'num_steps': 15, 'step_size': 0.7},
         expected_means=[0.5, 1.0],
         expected_precs=[2.0, 100],
         mean_tol=0.08,
@@ -104,13 +104,13 @@ TEST_CASES = [
     ),
     T(
         GaussianChain(dim=5, chain_len=9, num_obs=1),
-        num_samples=800,
-        warmup_steps=200,
-        hmc_params={'step_size': 0.4,
+        num_samples=3000,
+        warmup_steps=500,
+        hmc_params={'step_size': 0.2,
                     'num_steps': 15},
         expected_means=[0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90],
         expected_precs=[1.11, 0.63, 0.48, 0.42, 0.4, 0.42, 0.48, 0.63, 1.11],
-        mean_tol=0.12,
+        mean_tol=0.11,
         std_tol=0.11,
     )
 ]
@@ -123,6 +123,7 @@ TEST_IDS = [t[0].id_fn() if type(t).__name__ == 'TestExample'
     'fixture, num_samples, warmup_steps, hmc_params, expected_means, expected_precs, mean_tol, std_tol',
     TEST_CASES,
     ids=TEST_IDS)
+@pytest.mark.skip(reason='Slow test (https://github.com/pytorch/pytorch/issues/12190)')
 @pytest.mark.disable_validation()
 def test_hmc_conjugate_gaussian(fixture,
                                 num_samples,
@@ -148,14 +149,14 @@ def test_hmc_conjugate_gaussian(fixture,
         logger.debug(latent_loc)
         logger.debug('Posterior mean (expected) - {}'.format(param_name))
         logger.debug(expected_mean)
-        assert_equal((latent_loc - expected_mean).abs().mean().item(), 0.0, prec=mean_tol)
+        assert_equal(rmse(latent_loc, expected_mean).item(), 0.0, prec=mean_tol)
 
         # Actual vs expected posterior precisions for the latents
         logger.debug('Posterior std (actual) - {}'.format(param_name))
         logger.debug(latent_std)
         logger.debug('Posterior std (expected) - {}'.format(param_name))
         logger.debug(expected_std)
-        assert_equal((latent_std - expected_std).abs().mean().item(), 0.0, prec=std_tol)
+        assert_equal(rmse(latent_std, expected_std).item(), 0.0, prec=std_tol)
 
 
 @pytest.mark.parametrize(
@@ -302,9 +303,8 @@ def test_gamma_normal_with_dual_averaging(jit):
     assert_equal(posterior.mean, true_std, prec=0.05)
 
 
-@pytest.mark.parametrize("jit", [False,
-                                 mark_jit(True, marks=[pytest.mark.skip(
-                                     "https://github.com/uber/pyro/issues/1487")])],
+@pytest.mark.parametrize("jit", [False, mark_jit(True,
+                                                 marks=[pytest.mark.skip("FIXME: Slow on JIT.")])],
                          ids=jit_idfn)
 def test_gaussian_mixture_model(jit):
     K, N = 3, 1000

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -44,7 +44,7 @@ TEST_CASES = [
     ),
     T(
         GaussianChain(dim=10, chain_len=4, num_obs=1),
-        num_samples=800,
+        num_samples=1600,
         warmup_steps=200,
         expected_means=[0.20, 0.40, 0.60, 0.80],
         expected_precs=[1.25, 0.83, 0.83, 1.25],
@@ -53,8 +53,8 @@ TEST_CASES = [
     ),
     T(
         GaussianChain(dim=5, chain_len=2, num_obs=10000),
-        num_samples=400,
-        warmup_steps=20,
+        num_samples=800,
+        warmup_steps=200,
         expected_means=[0.5, 1.0],
         expected_precs=[2.0, 10000],
         mean_tol=0.05,
@@ -62,11 +62,11 @@ TEST_CASES = [
     ),
     T(
         GaussianChain(dim=5, chain_len=9, num_obs=1),
-        num_samples=400,
-        warmup_steps=60,
+        num_samples=1400,
+        warmup_steps=200,
         expected_means=[0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90],
         expected_precs=[1.11, 0.63, 0.48, 0.42, 0.4, 0.42, 0.48, 0.63, 1.11],
-        mean_tol=0.12,
+        mean_tol=0.08,
         std_tol=0.08,
     )
 ]
@@ -96,6 +96,7 @@ def jit_idfn(param):
     'fixture, num_samples, warmup_steps, expected_means, expected_precs, mean_tol, std_tol',
     TEST_CASES,
     ids=TEST_IDS)
+@pytest.mark.skip(reason='Slow test (https://github.com/pytorch/pytorch/issues/12190)')
 @pytest.mark.disable_validation()
 def test_nuts_conjugate_gaussian(fixture,
                                  num_samples,
@@ -120,14 +121,14 @@ def test_nuts_conjugate_gaussian(fixture,
         logger.debug(latent_loc)
         logger.debug('Posterior mean (expected) - {}'.format(param_name))
         logger.debug(expected_mean)
-        assert_equal((latent_loc - expected_mean).abs().mean().item(), 0.0, prec=mean_tol)
+        assert_equal(rmse(latent_loc, expected_mean).item(), 0.0, prec=mean_tol)
 
         # Actual vs expected posterior precisions for the latents
         logger.debug('Posterior std (actual) - {}'.format(param_name))
         logger.debug(latent_std)
         logger.debug('Posterior std (expected) - {}'.format(param_name))
         logger.debug(expected_std)
-        assert_equal((latent_std - expected_std).abs().mean().item(), 0.0, prec=std_tol)
+        assert_equal(rmse(latent_std, expected_std).item(), 0.0, prec=std_tol)
 
 
 @pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
@@ -179,9 +180,7 @@ def test_beta_bernoulli(step_size, adapt_step_size, adapt_mass_matrix, full_mass
     assert_equal(posterior.mean, true_probs, prec=0.02)
 
 
-@pytest.mark.parametrize("jit", [False,
-                                 mark_jit(True, marks=[pytest.mark.skip(
-                                     reason="https://github.com/uber/pyro/issues/1487")])],
+@pytest.mark.parametrize("jit", [False, mark_jit(True, marks=[pytest.mark.skip("Doesn't finish")])],
                          ids=jit_idfn)
 @pytest.mark.parametrize("use_multinomial_sampling", [True, False])
 def test_gamma_normal(jit, use_multinomial_sampling):
@@ -250,7 +249,6 @@ def test_dirichlet_categorical(jit):
 
     true_probs = torch.tensor([0.1, 0.6, 0.3])
     data = dist.Categorical(true_probs).sample(sample_shape=(torch.Size((2000,))))
-    print(data.dtype)
     nuts_kernel = NUTS(model, jit_compile=jit, ignore_jit_warnings=True)
     mcmc_run = MCMC(nuts_kernel, num_samples=200, warmup_steps=100).run(data)
     posterior = mcmc_run.marginal('p_latent').empirical['p_latent']


### PR DESCRIPTION
~This PR fixes various bugs reported in #1532 and #1511.~

This PR adds a clearer message for the reason why JIT is slow.