### PR TITLE
fix cpu/gpu oed's eig&ewma tests

### DIFF
--- a/tests/contrib/oed/test_eig.py
+++ b/tests/contrib/oed/test_eig.py
@@ -21,7 +21,6 @@ from pyro.contrib.oed.eig import (
 )
 from pyro.contrib.oed.util import linear_model_ground_truth
 from pyro.infer import Trace_ELBO
-from tests.common import xfail_param
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +147,7 @@ TEST_CASES = [
         False,
         0.3
     ),
-    xfail_param(*T(
+    T(
         basic_2p_linear_model_sds_10_2pt5,
         X_circle_5d_1n_2p,
         "y",
@@ -158,7 +157,7 @@ TEST_CASES = [
          optim.Adam({"lr": 0.025}), False, None, 500],
         True,
         0.3
-    ), reason="https://github.com/uber/pyro/issues/1418"),
+    ),
     T(
         basic_2p_linear_model_sds_10_2pt5,
         AB_test_2d_10n_2p,
@@ -204,7 +203,7 @@ TEST_CASES = [
         0.3,
         marks=pytest.mark.xfail
     ),
-    xfail_param(*T(
+    T(
         group_2p_linear_model_sds_10_2pt5,
         X_circle_5d_1n_2p,
         "y",
@@ -214,7 +213,7 @@ TEST_CASES = [
          optim.Adam({"lr": 0.025}), False, None, 500],
         True,
         0.3
-    ), reason="https://github.com/uber/pyro/issues/1418"),
+    ),
     T(
         group_2p_linear_model_sds_10_2pt5,
         X_circle_5d_1n_2p,

--- a/tests/contrib/oed/test_ewma.py
+++ b/tests/contrib/oed/test_ewma.py
@@ -8,7 +8,6 @@ from tests.common import assert_equal
 
 
 @pytest.mark.parametrize("alpha", [0.5, 0.9, 0.99])
-@pytest.mark.xfail(reason="https://github.com/uber/pyro/issues/1418")
 def test_ewma(alpha, NS=10000, D=1):
     ewma_log = EwmaLog(alpha=alpha)
     sigma = torch.tensor(1.0, requires_grad=True)


### PR DESCRIPTION
This PR addresses bugs announced in #1373 and #1418.

We get those bugs because:
+ EmwaLog uses old style of `torch.autograd.Function`, which might not be supported anymore (it still works in some cases but there will be many edge cases around the old style).
+ EmwaLog is initialized with `torch.tensor`, so GPU tests will fail.