### PR TITLE
Use pyro.plate in baseball example

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -88,10 +88,10 @@ def not_pooled(at_bats, hits):
     :return: Number of hits predicted by the model.
     """
     num_players = at_bats.shape[0]
-    # TODO: use pyro.plate when pytorch 1.0 is released
-    phi_prior = Uniform(at_bats.new_tensor(0), at_bats.new_tensor(1)).expand_by([num_players]).to_event(1)
-    phi = pyro.sample("phi", phi_prior)
-    return pyro.sample("obs", Binomial(at_bats, phi), obs=hits)
+    with pyro.plate("num_players", num_players):
+        phi_prior = Uniform(at_bats.new_tensor(0), at_bats.new_tensor(1))
+        phi = pyro.sample("phi", phi_prior)
+        return pyro.sample("obs", Binomial(at_bats, phi), obs=hits)
 
 
 def partially_pooled(at_bats, hits):
@@ -109,9 +109,10 @@ def partially_pooled(at_bats, hits):
     num_players = at_bats.shape[0]
     m = pyro.sample("m", Uniform(at_bats.new_tensor(0), at_bats.new_tensor(1)))
     kappa = pyro.sample("kappa", Pareto(at_bats.new_tensor(1), at_bats.new_tensor(1.5)))
-    phi_prior = Beta(m * kappa, (1 - m) * kappa).expand_by([num_players]).to_event(1)
-    phi = pyro.sample("phi", phi_prior)
-    return pyro.sample("obs", Binomial(at_bats, phi), obs=hits)
+    with pyro.plate("num_players", num_players):
+        phi_prior = Beta(m * kappa, (1 - m) * kappa)
+        phi = pyro.sample("phi", phi_prior)
+        return pyro.sample("obs", Binomial(at_bats, phi), obs=hits)
 
 
 def partially_pooled_with_logit(at_bats, hits):
@@ -127,8 +128,9 @@ def partially_pooled_with_logit(at_bats, hits):
     num_players = at_bats.shape[0]
     loc = pyro.sample("loc", Normal(at_bats.new_tensor(-1), at_bats.new_tensor(1)))
     scale = pyro.sample("scale", HalfCauchy(scale=at_bats.new_tensor(1)))
-    alpha = pyro.sample("alpha", Normal(loc, scale).expand_by([num_players]).to_event(1))
-    return pyro.sample("obs", Binomial(at_bats, logits=alpha), obs=hits)
+    with pyro.plate("num_players", num_players):
+        alpha = pyro.sample("alpha", Normal(loc, scale))
+        return pyro.sample("obs", Binomial(at_bats, logits=alpha), obs=hits)
 
 
 # ===================================

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import math
-import warnings
 from collections import OrderedDict
 
 import torch
@@ -95,14 +94,9 @@ class HMC(TraceKernel):
                  full_mass=False,
                  transforms=None,
                  max_plate_nesting=None,
-                 max_iarange_nesting=None,  # DEPRECATED
                  jit_compile=False,
                  ignore_jit_warnings=False):
         self.model = model
-        if max_iarange_nesting is not None:
-            warnings.warn("max_iarange_nesting is deprecated; use max_plate_nesting instead",
-                          DeprecationWarning)
-            max_plate_nesting = max_iarange_nesting
         self.max_plate_nesting = max_plate_nesting
         if trajectory_length is not None:
             self.trajectory_length = trajectory_length

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import warnings
 from collections import namedtuple
 
 import torch
@@ -106,14 +105,8 @@ class NUTS(HMC):
                  use_multinomial_sampling=True,
                  transforms=None,
                  max_plate_nesting=None,
-                 max_iarange_nesting=None,  # DEPRECATED
                  jit_compile=False,
                  ignore_jit_warnings=False):
-        if max_iarange_nesting is not None:
-            warnings.warn("max_iarange_nesting is deprecated; use max_plate_nesting instead",
-                          DeprecationWarning)
-            max_plate_nesting = max_iarange_nesting
-
         super(NUTS, self).__init__(model,
                                    step_size,
                                    adapt_step_size=adapt_step_size,
@@ -121,7 +114,6 @@ class NUTS(HMC):
                                    full_mass=full_mass,
                                    transforms=transforms,
                                    max_plate_nesting=max_plate_nesting,
-                                   max_iarange_nesting=max_iarange_nesting,
                                    jit_compile=jit_compile,
                                    ignore_jit_warnings=ignore_jit_warnings)
         self.use_multinomial_sampling = use_multinomial_sampling


### PR DESCRIPTION
 - Uses `pyro.plate` in baseball example
 - Removes `max_iarange_nesting` (deprecated) from the API completely - since this was not a part of the previous release of HMC.