### PR TITLE
Support varying kwargs in jit, etc.

### DIFF
--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -7,7 +7,7 @@ from pyro.infer.enum import config_enumerate
 from pyro.infer.importance import Importance
 from pyro.infer.renyi_elbo import RenyiELBO
 from pyro.infer.svi import SVI
-from pyro.infer.trace_mean_field_elbo import TraceMeanField_ELBO
+from pyro.infer.trace_mean_field_elbo import JitTraceMeanField_ELBO, TraceMeanField_ELBO
 from pyro.infer.trace_elbo import JitTrace_ELBO, Trace_ELBO
 from pyro.infer.traceenum_elbo import JitTraceEnum_ELBO, TraceEnum_ELBO
 from pyro.infer.tracegraph_elbo import JitTraceGraph_ELBO, TraceGraph_ELBO
@@ -23,6 +23,7 @@ __all__ = [
     "Importance",
     "JitTraceEnum_ELBO",
     "JitTraceGraph_ELBO",
+    "JitTraceMeanField_ELBO",
     "JitTrace_ELBO",
     "RenyiELBO",
     "SVI",

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -244,7 +244,7 @@ class MCMC(TracePosterior):
             cpu_count = mp.cpu_count()
             if num_chains > cpu_count:
                 warnings.warn("`num_chains` is more than CPU count - {}. "
-                              "Resetting num_chains to CPU count.").format(cpu_count)
+                              "Resetting num_chains to CPU count.".format(cpu_count))
             self.sampler = _ParallelSampler(kernel, num_samples, warmup_steps,
                                             num_chains, mp_context)
         else:

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -150,19 +150,21 @@ class JitTrace_ELBO(Trace_ELBO):
     -   Models must not depend on any global data (except the param store).
     -   All model inputs that are tensors must be passed in via ``*args``.
     -   All model inputs that are *not* tensors must be passed in via
-        ``*kwargs``, and these will be fixed to their values on the first
-        call to :meth:`jit_loss_and_grads`.
-
-    .. warning:: Experimental. Interface subject to change.
+        ``**kwargs``, and compilation will be triggered once per unique
+        ``**kwargs``.
     """
 
     def loss_and_grads(self, model, guide, *args, **kwargs):
+        kwargs['_pyro_model_id'] = id(model)
+        kwargs['_pyro_guide_id'] = id(guide)
         if getattr(self, '_loss_and_surrogate_loss', None) is None:
             # build a closure for loss_and_surrogate_loss
             weakself = weakref.ref(self)
 
             @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings)
-            def loss_and_surrogate_loss(*args):
+            def loss_and_surrogate_loss(*args, **kwargs):
+                kwargs.pop('_pyro_model_id')
+                kwargs.pop('_pyro_guide_id')
                 self = weakself()
                 loss = 0.0
                 surrogate_loss = 0.0
@@ -200,7 +202,7 @@ class JitTrace_ELBO(Trace_ELBO):
             self._loss_and_surrogate_loss = loss_and_surrogate_loss
 
         # invoke _loss_and_surrogate_loss
-        loss, surrogate_loss = self._loss_and_surrogate_loss(*args)
+        loss, surrogate_loss = self._loss_and_surrogate_loss(*args, **kwargs)
         surrogate_loss.backward()
         loss = loss.item()
 

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -142,7 +142,7 @@ class JitTraceMeanField_ELBO(TraceMeanField_ELBO):
         ``**kwargs``, and compilation will be triggered once per unique
         ``**kwargs``.
     """
-    def loss_and_surrogate_loss(self, model, guide, *args, **kwargs):
+    def differentiable_loss(self, model, guide, *args, **kwargs):
         kwargs['_pyro_model_id'] = id(model)
         kwargs['_pyro_guide_id'] = id(guide)
         if getattr(self, '_loss_and_surrogate_loss', None) is None:
@@ -150,35 +150,24 @@ class JitTraceMeanField_ELBO(TraceMeanField_ELBO):
             weakself = weakref.ref(self)
 
             @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings)
-            def loss_and_surrogate_loss(*args, **kwargs):
+            def differentiable_loss(*args, **kwargs):
                 kwargs.pop('_pyro_model_id')
                 kwargs.pop('_pyro_guide_id')
                 self = weakself()
                 loss = 0.0
-                surrogate_loss = 0.0
                 for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
-                    loss_particle, surrogate_loss_particle = self._differentiable_loss_particle(
-                        model_trace, guide_trace)
-
+                    _, loss_particle = self._differentiable_loss_particle(model_trace, guide_trace)
                     loss = loss + loss_particle / self.num_particles
-                    surrogate_loss = surrogate_loss + surrogate_loss_particle / self.num_particles
+                return loss
 
-                return loss, surrogate_loss
+            self._differentiable_loss = differentiable_loss
 
-            self._loss_and_surrogate_loss = loss_and_surrogate_loss
-
-        return self._loss_and_surrogate_loss(*args, **kwargs)
-
-    def differentiable_loss(self, model, guide, *args, **kwargs):
-        loss, surrogate_loss = self.loss_and_surrogate_loss(model, guide, *args, **kwargs)
-
-        warn_if_nan(loss, "loss")
-        return surrogate_loss
+        return self._differentiable_loss(*args, **kwargs)
 
     def loss_and_grads(self, model, guide, *args, **kwargs):
-        loss, surrogate_loss = self.loss_and_surrogate_loss(model, guide, *args, **kwargs)
-        surrogate_loss.backward()
-        loss = loss.item()
+        loss = self.differentiable_loss(model, guide, *args, **kwargs)
+        loss.backward()
+        loss = torch_item(loss)
 
         warn_if_nan(loss, "loss")
         return loss

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -173,7 +173,7 @@ class JitTraceMeanField_ELBO(TraceMeanField_ELBO):
         loss, surrogate_loss = self.loss_and_surrogate_loss(model, guide, *args, **kwargs)
 
         warn_if_nan(loss, "loss")
-        return loss + (surrogate_loss - surrogate_loss.detach())
+        return surrogate_loss
 
     def loss_and_grads(self, model, guide, *args, **kwargs):
         loss, surrogate_loss = self.loss_and_surrogate_loss(model, guide, *args, **kwargs)

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -86,8 +86,8 @@ class TraceMeanField_ELBO(Trace_ELBO):
         """
         loss = 0.0
         for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
-            loss_particle = self._differentiable_loss_particle(model_trace, guide_trace)
-            loss += loss_particle / self.num_particles
+            loss_particle, _ = self._differentiable_loss_particle(model_trace, guide_trace)
+            loss = loss + loss_particle / self.num_particles
 
         warn_if_nan(loss, "loss")
         return loss

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -436,7 +436,7 @@ class JitTraceEnum_ELBO(TraceEnum_ELBO):
         ``**kwargs``, and compilation will be triggered once per unique
         ``**kwargs``.
     """
-    def loss_and_grads(self, model, guide, *args, **kwargs):
+    def differentiable_loss(self, model, guide, *args, **kwargs):
         kwargs['_model_id'] = id(model)
         kwargs['_guide_id'] = id(guide)
         if getattr(self, '_differentiable_loss', None) is None:
@@ -455,7 +455,10 @@ class JitTraceEnum_ELBO(TraceEnum_ELBO):
 
             self._differentiable_loss = differentiable_loss
 
-        differentiable_loss = self._differentiable_loss(*args, **kwargs)
+        return self._differentiable_loss(*args, **kwargs)
+
+    def loss_and_grads(self, model, guide, *args, **kwargs):
+        differentiable_loss = self.differentiable_loss(model, guide, *args, **kwargs)
         differentiable_loss.backward()  # this line triggers jit compilation
         loss = differentiable_loss.item()
 

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -433,19 +433,20 @@ class JitTraceEnum_ELBO(TraceEnum_ELBO):
     -   Models must not depend on any global data (except the param store).
     -   All model inputs that are tensors must be passed in via ``*args``.
     -   All model inputs that are *not* tensors must be passed in via
-        ``*kwargs``, and these will be fixed to their values on the first
-        call to :meth:`jit_loss_and_grads`.
-
-    .. warning:: Experimental. Interface subject to change.
+        ``**kwargs``, and compilation will be triggered once per unique
+        ``**kwargs``.
     """
-
     def loss_and_grads(self, model, guide, *args, **kwargs):
+        kwargs['_model_id'] = id(model)
+        kwargs['_guide_id'] = id(guide)
         if getattr(self, '_differentiable_loss', None) is None:
-
+            # build a closure for differentiable_loss
             weakself = weakref.ref(self)
 
             @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings)
-            def differentiable_loss(*args):
+            def differentiable_loss(*args, **kwargs):
+                kwargs.pop('_model_id')
+                kwargs.pop('_guide_id')
                 self = weakself()
                 elbo = 0.0
                 for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
@@ -454,7 +455,7 @@ class JitTraceEnum_ELBO(TraceEnum_ELBO):
 
             self._differentiable_loss = differentiable_loss
 
-        differentiable_loss = self._differentiable_loss(*args)
+        differentiable_loss = self._differentiable_loss(*args, **kwargs)
         differentiable_loss.backward()  # this line triggers jit compilation
         loss = differentiable_loss.item()
 

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -263,19 +263,21 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
     -   Models must not depend on any global data (except the param store).
     -   All model inputs that are tensors must be passed in via ``*args``.
     -   All model inputs that are *not* tensors must be passed in via
-        ``*kwargs``, and these will be fixed to their values on the first
-        call to :meth:`loss_and_grads`.
-
-    .. warning:: Experimental. Interface subject to change.
+        ``**kwargs``, and compilation will be triggered once per unique
+        ``**kwargs``.
     """
 
     def loss_and_grads(self, model, guide, *args, **kwargs):
+        kwargs['_pyro_model_id'] = id(model)
+        kwargs['_pyro_guide_id'] = id(guide)
         if getattr(self, '_loss_and_surrogate_loss', None) is None:
             # build a closure for loss_and_surrogate_loss
             weakself = weakref.ref(self)
 
             @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings)
-            def loss_and_surrogate_loss(*args):
+            def loss_and_surrogate_loss(*args, **kwargs):
+                kwargs.pop('_pyro_model_id')
+                kwargs.pop('_pyro_guide_id')
                 self = weakself()
                 loss = 0.0
                 surrogate_loss = 0.0
@@ -301,7 +303,7 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
 
             self._loss_and_surrogate_loss = loss_and_surrogate_loss
 
-        loss, surrogate_loss = self._loss_and_surrogate_loss(*args)
+        loss, surrogate_loss = self._loss_and_surrogate_loss(*args, **kwargs)
         surrogate_loss.backward()
         loss = loss.item()
 

--- a/pyro/ops/jit.py
+++ b/pyro/ops/jit.py
@@ -21,7 +21,7 @@ def _hash(value, allow_id):
         elif isinstance(value, dict):
             return tuple(sorted((_hash(x, allow_id), _hash(y, allow_id)) for x, y in value.items()))
         elif isinstance(value, set):
-            return frozenset(_hash(x) for x in value)
+            return frozenset(_hash(x, allow_id) for x in value)
         elif isinstance(value, argparse.Namespace):
             return str(value)
         elif allow_id:

--- a/pyro/ops/jit.py
+++ b/pyro/ops/jit.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import argparse
+import warnings
 import weakref
 
 import torch
@@ -7,6 +9,35 @@ import torch
 import pyro
 import pyro.poutine as poutine
 from pyro.util import ignore_jit_warnings, optional
+
+
+def _hash(value, allow_id):
+    try:
+        hash(value)
+        return value
+    except TypeError as e:
+        if isinstance(value, list):
+            return tuple(_hash(x, allow_id) for x in value)
+        elif isinstance(value, dict):
+            return tuple(sorted((_hash(x, allow_id), _hash(y, allow_id)) for x, y in value.items()))
+        elif isinstance(value, set):
+            return frozenset(_hash(x) for x in value)
+        elif isinstance(value, argparse.Namespace):
+            return str(value)
+        elif allow_id:
+            return id(value)
+        raise e
+
+
+def _hashable_args_kwargs(args, kwargs):
+    items = sorted(kwargs.items())
+    hashable_kwargs = tuple((key, _hash(value, False)) for key, value in items)
+    try:
+        hash(hashable_kwargs)
+    except TypeError:
+        warnings.warn("Failed to hash kwargs; attempting to hash by id.")
+        hashable_kwargs = tuple((key, _hash(value, True)) for key, value in items)
+    return len(args), hashable_kwargs
 
 
 class CompiledFunction(object):
@@ -26,10 +57,10 @@ class CompiledFunction(object):
         self._param_names = None
 
     def __call__(self, *args, **kwargs):
-        argc = len(args)
+        key = _hashable_args_kwargs(args, kwargs)
 
         # if first time
-        if argc not in self.compiled:
+        if key not in self.compiled:
             # param capture
             with poutine.block():
                 with poutine.trace(param_only=True) as first_param_capture:
@@ -53,7 +84,7 @@ class CompiledFunction(object):
                 return poutine.replay(self.fn, params=constrained_params)(*args, **kwargs)
 
             with pyro.validation_enabled(False), optional(ignore_jit_warnings(), self.ignore_warnings):
-                self.compiled[argc] = torch.jit.trace(compiled, params_and_args, check_trace=False)
+                self.compiled[key] = torch.jit.trace(compiled, params_and_args, check_trace=False)
         else:
             unconstrained_params = [pyro.param(name).unconstrained()
                                     for name in self._param_names]
@@ -61,7 +92,7 @@ class CompiledFunction(object):
 
         with poutine.block(hide=self._param_names):
             with poutine.trace(param_only=True) as param_capture:
-                ret = self.compiled[argc](*params_and_args)
+                ret = self.compiled[key](*params_and_args)
 
         for name in param_capture.trace.nodes.keys():
             if name not in self._param_names:

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -11,10 +11,10 @@ import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.distributions.testing import fakes
-from pyro.infer import (SVI, JitTrace_ELBO, JitTraceEnum_ELBO, JitTraceGraph_ELBO, Trace_ELBO, TraceEnum_ELBO,
-                        TraceGraph_ELBO, TraceMeanField_ELBO, config_enumerate)
+from pyro.infer import (SVI, JitTrace_ELBO, JitTraceEnum_ELBO, JitTraceGraph_ELBO, JitTraceMeanField_ELBO, Trace_ELBO,
+                        TraceEnum_ELBO, TraceGraph_ELBO, TraceMeanField_ELBO, config_enumerate)
 from pyro.optim import Adam
-from tests.common import assert_equal, xfail_param, xfail_if_not_implemented
+from tests.common import assert_equal, xfail_if_not_implemented, xfail_param
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +192,8 @@ def test_plate_elbo_vectorized_particles(Elbo, reparameterized):
     xfail_param(JitTraceGraph_ELBO,
                 reason="in broadcast_all: RuntimeError: expected int at position 0, but got: Tensor"),
     xfail_param(JitTraceEnum_ELBO,
+                reason="in broadcast_all: RuntimeError: expected int at position 0, but got: Tensor"),
+    xfail_param(JitTraceMeanField_ELBO,
                 reason="in broadcast_all: RuntimeError: expected int at position 0, but got: Tensor"),
 ])
 def test_subsample_gradient_sequential(Elbo, reparameterized, subsample):

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
 import os
 import warnings
-import logging
 
 import pytest
 import torch
@@ -13,8 +13,8 @@ import pyro
 import pyro.distributions as dist
 import pyro.ops.jit
 import pyro.poutine as poutine
-from pyro.infer import (SVI, JitTrace_ELBO, JitTraceEnum_ELBO, JitTraceGraph_ELBO, Trace_ELBO, TraceEnum_ELBO,
-                        TraceGraph_ELBO)
+from pyro.infer import (SVI, JitTrace_ELBO, JitTraceEnum_ELBO, JitTraceGraph_ELBO, JitTraceMeanField_ELBO, Trace_ELBO,
+                        TraceEnum_ELBO, TraceGraph_ELBO, TraceMeanField_ELBO)
 from pyro.optim import Adam
 from pyro.poutine.indep_messenger import CondIndepStackFrame
 from tests.common import assert_equal
@@ -234,6 +234,8 @@ def test_one_hot_categorical_enumerate(shape, expand):
     JitTraceGraph_ELBO,
     TraceEnum_ELBO,
     JitTraceEnum_ELBO,
+    TraceMeanField_ELBO,
+    JitTraceMeanField_ELBO,
 ])
 def test_svi(Elbo, num_particles):
     pyro.clear_param_store()
@@ -340,6 +342,8 @@ def test_beta_bernoulli(Elbo, vectorized):
     JitTraceGraph_ELBO,
     TraceEnum_ELBO,
     JitTraceEnum_ELBO,
+    TraceMeanField_ELBO,
+    JitTraceMeanField_ELBO,
 ])
 def test_svi_irregular_batch_size(Elbo):
     pyro.clear_param_store()

--- a/tests/ops/test_jit.py
+++ b/tests/ops/test_jit.py
@@ -1,14 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-import logging
-import warnings
-
 import torch
 
 import pyro.ops.jit
 from tests.common import assert_equal
-
-logger = logging.getLogger(__name__)
 
 
 def test_varying_len_args():
@@ -46,9 +41,4 @@ def test_varying_unhashable_kwargs():
     x = torch.tensor(1.)
     for scale in [-1., 0., 1., 10.]:
         config = {'scale': scale}
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            assert_equal(jit_fn(x, config=config), fn(x, config=config))
-            assert len(w), 'No warnings were raised'
-            for warning in w:
-                logger.info(warning)
+        assert_equal(jit_fn(x, config=config), fn(x, config=config))

--- a/tests/ops/test_jit.py
+++ b/tests/ops/test_jit.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import, division, print_function
+
+import logging
+import warnings
+
+import torch
+
+import pyro.ops.jit
+from tests.common import assert_equal
+
+logger = logging.getLogger(__name__)
+
+
+def test_varying_len_args():
+
+    def fn(*args):
+        return sum(args)
+
+    jit_fn = pyro.ops.jit.trace(fn)
+    examples = [
+        [torch.tensor(1.)],
+        [torch.tensor(2.), torch.tensor(3.)],
+        [torch.tensor(4.), torch.tensor(5.), torch.tensor(6.)],
+    ]
+    for args in examples:
+        assert_equal(jit_fn(*args), fn(*args))
+
+
+def test_varying_kwargs():
+
+    def fn(x, scale=1.):
+        return x * scale
+
+    jit_fn = pyro.ops.jit.trace(fn)
+    x = torch.tensor(1.)
+    for scale in [-1., 0., 1., 10.]:
+        assert_equal(jit_fn(x, scale=scale), fn(x, scale=scale))
+
+
+def test_varying_unhashable_kwargs():
+
+    def fn(x, config={}):
+        return x * config.get(scale, 1.)
+
+    jit_fn = pyro.ops.jit.trace(fn)
+    x = torch.tensor(1.)
+    for scale in [-1., 0., 1., 10.]:
+        config = {'scale': scale}
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert_equal(jit_fn(x, config=config), fn(x, config=config))
+            assert len(w), 'No warnings were raised'
+            for warning in w:
+                logger.info(warning)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -84,7 +84,7 @@ def xfail_jit(*args):
 
 JIT_EXAMPLES = [
     'air/main.py --num-steps=1 --jit',
-    xfail_jit('baseball.py --num-samples=200 --warmup-steps=100 --jit'),
+    'baseball.py --num-samples=200 --warmup-steps=100 --jit',
     'bayesian_regression.py --num-epochs=1 --jit',
     'contrib/autoname/mixture.py --num-epochs=1 --jit',
     xfail_jit('contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --jit'),


### PR DESCRIPTION
Resolves #1252 

1. This resurrects our support for jitting functions with non-fixed kwargs, allowing one compiled function per kwargs value. This is especially useful for semisupervised models.
2. Fixes our HMM example to be warning-free when run under the jit. @martinjankowiak this should be useful for your experiments.
3. Adds a `JitTraceMeanField_ELBO`
4. Adds `.differentiable_loss()` method to `Jit*_ELBO`s whose un-jitted versions have it also

## Tested

- added unit tests for `pyro.ops.jit.trace`
- unmarked baseball example xfail
- ran hmm example to verify absence of warning message