### PR TITLE
Add short tutorial on using the jit compiler

### DIFF
--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -362,7 +362,8 @@ class AutoContinuous(AutoGuide):
             unconstrained_value = latent[..., pos:pos + size].view(unconstrained_shape)
             yield site, unconstrained_value
             pos += size
-        assert pos == latent.size(-1)
+        if not torch._C._get_tracing_state():
+            assert pos == latent.size(-1)
 
     def __call__(self, *args, **kwargs):
         """

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -35,7 +35,7 @@ class Delta(TorchDistribution):
         event_shape = v.shape[batch_dim:]
         if isinstance(log_density, numbers.Number):
             log_density = v.new_empty(batch_shape).fill_(log_density)
-        elif log_density.shape != batch_shape:
+        elif validate_args and log_density.shape != batch_shape:
             raise ValueError('Expected log_density.shape = {}, actual {}'.format(
                 log_density.shape, batch_shape))
         self.v = v

--- a/tutorial/source/custom_objectives.ipynb
+++ b/tutorial/source/custom_objectives.ipynb
@@ -78,10 +78,10 @@
     "\n",
     "```python\n",
     "def my_custom_L2_regularizer(my_parameters):\n",
-    "   reg_loss = 0.0\n",
-    "   for param in my_parameters:\n",
-    "       reg_loss = reg_loss + param.pow(2.0).sum()\n",
-    "   return reg_loss  \n",
+    "    reg_loss = 0.0\n",
+    "    for param in my_parameters:\n",
+    "        reg_loss = reg_loss + param.pow(2.0).sum()\n",
+    "    return reg_loss  \n",
     "```\n",
     "\n",
     "Then the only change we need to make is:\n",
@@ -214,6 +214,13 @@
     "svi.step(other_args, annealing_factor=0.2, latents_to_anneal=[\"my_latent\"])\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -18,6 +18,7 @@ Welcome to Pyro Examples and Tutorials!
    tensor_shapes
    enumeration
    custom_objectives
+   jit
 
 .. toctree::
    :maxdepth: 2

--- a/tutorial/source/jit.ipynb
+++ b/tutorial/source/jit.ipynb
@@ -20,7 +20,8 @@
     "- Models should input all tensors as `*args` and all non-tensors as `**kwargs`.\n",
     "- Each different value of `**kwargs` triggers a separate compilation.\n",
     "- Use `**kwargs` to specify all variation in structure (e.g. time series length).\n",
-    "- To ignore jit warnings when it is safe to do so, use `with pyro.util.ignore_jit_warnings():`.\n",
+    "- To ignore jit warnings in safe code blocks, use `with pyro.util.ignore_jit_warnings():`.\n",
+    "- To ignore all jit warnings in `HMC` or `NUTS`, pass `ignore_jit_warnings=True`.\n",
     "\n",
     "#### Table of contents\n",
     "- [Introduction](#Introduction)\n",
@@ -57,17 +58,12 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "PyTorch 1.0 includes a [jit compiler](https://pytorch.org/docs/master/jit.html) to speed up models. You can think of this as a \"static mode\", where PyTorch usually operates in \"eager mode\".\n",
+    "PyTorch 1.0 includes a [jit compiler](https://pytorch.org/docs/master/jit.html) to speed up models. You can think of compilation as a \"static mode\", whereas PyTorch usually operates in \"eager mode\".\n",
     "\n",
     "Pyro supports the jit compiler in two ways. First you can use compiled functions inside Pyro models (but those functions cannot contain Pyro primitives). Second, you can use Pyro's jit inference algorithms to compile entire inference steps; in static models this can reduce the Python overhead of Pyro models and speed up inference.\n",
     "\n",
-    "The rest of this tutorial focuses on Pyro's jitted inference algorithms: [JitTrace_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.trace_elbo.JitTrace_ELBO), [JitTraceGraph_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.tracegraph_elbo.JitTraceGraph_ELBO), [JitTraceEnum_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.traceenum_elbo.JitTraceEnum_ELBO), [JitMeanField_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.trace_mean_field_elbo.JitTraceMeanField_ELBO), [HMC(jit_compile=True)](http://docs.pyro.ai/en/dev/mcmc.html#pyro.infer.mcmc.HMC), and [NUTS(jit_compile=True)](http://docs.pyro.ai/en/dev/mcmc.html#pyro.infer.mcmc.NUTS). For further reading, see the [examples/](https://github.com/uber/pyro/tree/dev/examples) directory, where most examples include a `--jit` option to run in compiled mode."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "The rest of this tutorial focuses on Pyro's jitted inference algorithms: [JitTrace_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.trace_elbo.JitTrace_ELBO), [JitTraceGraph_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.tracegraph_elbo.JitTraceGraph_ELBO), [JitTraceEnum_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.traceenum_elbo.JitTraceEnum_ELBO), [JitMeanField_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.trace_mean_field_elbo.JitTraceMeanField_ELBO), [HMC(jit_compile=True)](http://docs.pyro.ai/en/dev/mcmc.html#pyro.infer.mcmc.HMC), and [NUTS(jit_compile=True)](http://docs.pyro.ai/en/dev/mcmc.html#pyro.infer.mcmc.NUTS). For further reading, see the [examples/](https://github.com/uber/pyro/tree/dev/examples) directory, where most examples include a `--jit` option to run in compiled mode.\n",
+    "\n",
     "## A simple model\n",
     "\n",
     "Let's start with a simple Gaussian model and an [autoguide](http://docs.pyro.ai/en/dev/contrib.autoguide.html)."
@@ -106,8 +102,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.6 s, sys: 44.4 ms, total: 3.64 s\n",
-      "Wall time: 3.67 s\n"
+      "CPU times: user 3.15 s, sys: 26.6 ms, total: 3.18 s\n",
+      "Wall time: 3.18 s\n"
      ]
     }
    ],
@@ -141,8 +137,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.31 s, sys: 27.3 ms, total: 1.34 s\n",
-      "Wall time: 1.37 s\n"
+      "CPU times: user 1.19 s, sys: 19.4 ms, total: 1.21 s\n",
+      "Wall time: 1.22 s\n"
      ]
     }
    ],
@@ -162,13 +158,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that we have a more than 2x speedup for this small model."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "Notice that we have a more than 2x speedup for this small model.\n",
+    "\n",
     "## Varying structure\n",
     "\n",
     "Time series models often run on datasets of multiple time series with different lengths. To accomodate varying structure like this, Pyro requires models to separate all model inputs into tensors and non-tensors.\n",
@@ -185,7 +176,6 @@
    "outputs": [],
    "source": [
     "def model(sequence, num_sequences, length, state_dim=16):\n",
-    "\n",
     "    # This is a Gaussian HMM model.\n",
     "    with pyro.plate(\"states\", state_dim):\n",
     "        trans = pyro.sample(\"trans\", dist.Dirichlet(0.5 * torch.ones(state_dim)))\n",
@@ -205,7 +195,7 @@
     "guide = AutoDiagonalNormal(poutine.block(model, expose=[\"trans\", \"emit_scale\", \"emit_loc\"]))\n",
     "\n",
     "# This is fake data of different lengths.\n",
-    "lengths = [24] * 100 + [48] * 20 + [72] * 5\n",
+    "lengths = [24] * 50 + [48] * 20 + [72] * 5\n",
     "sequences = [torch.randn(length) for length in lengths]"
    ]
   },
@@ -225,8 +215,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1min 20s, sys: 428 ms, total: 1min 20s\n",
-      "Wall time: 1min 21s\n"
+      "CPU times: user 52.4 s, sys: 270 ms, total: 52.7 s\n",
+      "Wall time: 52.8 s\n"
      ]
     }
    ],
@@ -262,8 +252,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 30.8 s, sys: 255 ms, total: 31 s\n",
-      "Wall time: 31.1 s\n"
+      "CPU times: user 21.9 s, sys: 201 ms, total: 22.1 s\n",
+      "Wall time: 22.2 s\n"
      ]
     }
    ],

--- a/tutorial/source/jit.ipynb
+++ b/tutorial/source/jit.ipynb
@@ -1,0 +1,321 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using the PyTorch jit compiler with Pyro\n",
+    "\n",
+    "This tutorial shows how to use the PyTorch [jit compiler](https://pytorch.org/docs/master/jit.html) in Pyro models.\n",
+    "\n",
+    "#### Summary:\n",
+    "- You can use compiled functions in Pyro models.\n",
+    "- You cannot use pyro primitives inside compiled functions.\n",
+    "- If your model has static structure, you can use a `Jit*` version of an `ELBO` algorithm, e.g.\n",
+    "  ```diff\n",
+    "  - Trace_ELBO()\n",
+    "  + JitTrace_ELBO()\n",
+    "  ```\n",
+    "- The [HMC](http://docs.pyro.ai/en/dev/mcmc.html#pyro.infer.mcmc.HMC) and [NUTS](http://docs.pyro.ai/en/dev/mcmc.html#pyro.infer.mcmc.NUTS) classes accept `jit_compile=True` kwarg.\n",
+    "- Models should input all tensors as `*args` and all non-tensors as `**kwargs`.\n",
+    "- Each different value of `**kwargs` triggers a separate compilation.\n",
+    "- Use `**kwargs` to specify all variation in structure (e.g. time series length).\n",
+    "- To ignore jit warnings when it is safe to do so, use `with pyro.util.ignore_jit_warnings():`.\n",
+    "\n",
+    "#### Table of contents\n",
+    "- [Introduction](#Introduction)\n",
+    "- [A simple model](#A-simple-model)\n",
+    "- [Varying structure](#Varying structure)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import torch\n",
+    "import pyro\n",
+    "import pyro.distributions as dist\n",
+    "from torch.distributions import constraints\n",
+    "from pyro import poutine\n",
+    "from pyro.distributions.util import broadcast_shape\n",
+    "from pyro.infer import Trace_ELBO, JitTrace_ELBO, TraceEnum_ELBO, JitTraceEnum_ELBO, SVI\n",
+    "from pyro.contrib.autoguide import AutoDiagonalNormal\n",
+    "from pyro.optim import Adam\n",
+    "\n",
+    "smoke_test = ('CI' in os.environ)\n",
+    "assert pyro.__version__.startswith('0.3.0')\n",
+    "pyro.enable_validation(True)    # <---- This is always a good idea!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "PyTorch 1.0 includes a [jit compiler](https://pytorch.org/docs/master/jit.html) to speed up models. You can think of this as a \"static mode\", where PyTorch usually operates in \"eager mode\".\n",
+    "\n",
+    "Pyro supports the jit compiler in two ways. First you can use compiled functions inside Pyro models (but those functions cannot contain Pyro primitives). Second, you can use Pyro's jit inference algorithms to compile entire inference steps; in static models this can reduce the Python overhead of Pyro models and speed up inference.\n",
+    "\n",
+    "The rest of this tutorial focuses on Pyro's jitted inference algorithms: [JitTrace_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.trace_elbo.JitTrace_ELBO), [JitTraceGraph_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.tracegraph_elbo.JitTraceGraph_ELBO), [JitTraceEnum_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.traceenum_elbo.JitTraceEnum_ELBO), [JitMeanField_ELBO](http://docs.pyro.ai/en/dev/inference_algos.html#pyro.infer.trace_mean_field_elbo.JitTraceMeanField_ELBO), [HMC(jit_compile=True)](http://docs.pyro.ai/en/dev/mcmc.html#pyro.infer.mcmc.HMC), and [NUTS(jit_compile=True)](http://docs.pyro.ai/en/dev/mcmc.html#pyro.infer.mcmc.NUTS). For further reading, see the [examples/](https://github.com/uber/pyro/tree/dev/examples) directory, where most examples include a `--jit` option to run in compiled mode."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A simple model\n",
+    "\n",
+    "Let's start with a simple Gaussian model and an [autoguide](http://docs.pyro.ai/en/dev/contrib.autoguide.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def model(data):\n",
+    "    loc = pyro.sample(\"loc\", dist.Normal(0., 10.))\n",
+    "    scale = pyro.sample(\"scale\", dist.LogNormal(0., 3.))\n",
+    "    with pyro.plate(\"data\", data.size(0)):\n",
+    "        pyro.sample(\"obs\", dist.Normal(loc, scale), obs=data)\n",
+    "\n",
+    "guide = AutoDiagonalNormal(model)\n",
+    "\n",
+    "data = dist.Normal(0.5, 2.).sample((100,))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First let's run as usual with an SVI object and `Trace_ELBO`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3.6 s, sys: 44.4 ms, total: 3.64 s\n",
+      "Wall time: 3.67 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "pyro.clear_param_store()\n",
+    "elbo = Trace_ELBO()\n",
+    "svi = SVI(model, guide, Adam({'lr': 0.01}), elbo)\n",
+    "for i in range(2 if smoke_test else 1000):\n",
+    "    svi.step(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next to run with a jit compiled inference, we simply replace\n",
+    "```diff\n",
+    "- elbo = Trace_ELBO()\n",
+    "+ elbo = JitTrace_ELBO()\n",
+    "```\n",
+    "Also note that the `AutoDiagonalNormal` guide behaves a little differently on its first invocation (it runs the model to produce a prototype trace), and we don't want to record this warmup behavior when compiling. Thus we call the `guide(data)` once to initialize, then run the compiled SVI,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.31 s, sys: 27.3 ms, total: 1.34 s\n",
+      "Wall time: 1.37 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "pyro.clear_param_store()\n",
+    "\n",
+    "guide(data)  # Do any lazy initialization before compiling.\n",
+    "\n",
+    "elbo = JitTrace_ELBO()\n",
+    "svi = SVI(model, guide, Adam({'lr': 0.01}), elbo)\n",
+    "for i in range(2 if smoke_test else 1000):\n",
+    "    svi.step(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that we have a more than 2x speedup for this small model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Varying structure\n",
+    "\n",
+    "Time series models often run on datasets of multiple time series with different lengths. To accomodate varying structure like this, Pyro requires models to separate all model inputs into tensors and non-tensors.\n",
+    "- Non-tensor inputs should be passed as `**kwargs` to the model and guide. These can determine model structure, so that a model is compiled for each value of the passed `**kwargs`.\n",
+    "- Tensor inputs should be passed as `*args`. These must not determine model structure. However `len(args)` may determine model structure (as is used e.g. in semisupervised models).\n",
+    "\n",
+    "To illustrate this with a time series model, we will pass in a sequence of observations as a tensor `arg` and the sequence length as a non-tensor `kwarg`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def model(sequence, num_sequences, length, state_dim=16):\n",
+    "\n",
+    "    # This is a Gaussian HMM model.\n",
+    "    with pyro.plate(\"states\", state_dim):\n",
+    "        trans = pyro.sample(\"trans\", dist.Dirichlet(0.5 * torch.ones(state_dim)))\n",
+    "        emit_loc = pyro.sample(\"emit_loc\", dist.Normal(0., 10.))\n",
+    "    emit_scale = pyro.sample(\"emit_scale\", dist.LogNormal(0., 3.))\n",
+    "\n",
+    "    # We're doing manual data subsampling, so we need to scale to actual data size.\n",
+    "    with poutine.scale(scale=num_sequences):\n",
+    "        # We'll use enumeration inference over the hidden x.\n",
+    "        x = 0\n",
+    "        for t in pyro.markov(range(length)):\n",
+    "            x = pyro.sample(\"x_{}\".format(t), dist.Categorical(trans[x]),\n",
+    "                            infer={\"enumerate\": \"parallel\"})\n",
+    "            pyro.sample(\"y_{}\".format(t), dist.Normal(emit_loc[x], emit_scale),\n",
+    "                        obs=sequence[t])\n",
+    "\n",
+    "guide = AutoDiagonalNormal(poutine.block(model, expose=[\"trans\", \"emit_scale\", \"emit_loc\"]))\n",
+    "\n",
+    "# This is fake data of different lengths.\n",
+    "lengths = [24] * 100 + [48] * 20 + [72] * 5\n",
+    "sequences = [torch.randn(length) for length in lengths]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now lets' run SVI as usual."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1min 20s, sys: 428 ms, total: 1min 20s\n",
+      "Wall time: 1min 21s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "pyro.clear_param_store()\n",
+    "elbo = TraceEnum_ELBO(max_plate_nesting=1)\n",
+    "svi = SVI(model, guide, Adam({'lr': 0.01}), elbo)\n",
+    "for i in range(1 if smoke_test else 10):\n",
+    "    for sequence in sequences:\n",
+    "        svi.step(sequence,                                            # tensor args\n",
+    "                 num_sequences=len(sequences), length=len(sequence))  # non-tensor args"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again we'll simply swap in a `Jit*` implementation\n",
+    "```diff\n",
+    "- elbo = TraceEnum_ELBO(max_plate_nesting=1)\n",
+    "+ elbo = JitTraceEnum_ELBO(max_plate_nesting=1)\n",
+    "```\n",
+    "Note that we are manually specifying the `max_plate_nesting` arg. Usually Pyro can figure this out automatically by running the model once on the first invocation; however to avoid this extra work when we run the compiler on the first step, we pass this in manually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 30.8 s, sys: 255 ms, total: 31 s\n",
+      "Wall time: 31.1 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "pyro.clear_param_store()\n",
+    "\n",
+    "# Do any lazy initialization before compiling.\n",
+    "guide(sequences[0], num_sequences=len(sequences), length=len(sequences[0]))\n",
+    "\n",
+    "elbo = JitTraceEnum_ELBO(max_plate_nesting=1)\n",
+    "svi = SVI(model, guide, Adam({'lr': 0.01}), elbo)\n",
+    "for i in range(1 if smoke_test else 10):\n",
+    "    for sequence in sequences:\n",
+    "        svi.step(sequence,                                            # tensor args\n",
+    "                 num_sequences=len(sequences), length=len(sequence))  # non-tensor args"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again we see more than 2x speedup. Note that since there were three different sequence lengths, compilation was triggered three times."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorial/source/jit.ipynb
+++ b/tutorial/source/jit.ipynb
@@ -299,21 +299,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I had to modify `Delta` and `AutoContinuous` to suppress unnecessary compiler warnings.

This also fixes indentation in one cell in the custom_losses tutorial.