### PR TITLE
Tiny attempt to overcome a jit error in GP

### DIFF
--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -102,9 +102,9 @@ class Sum(Combination):
     """
     def forward(self, X, Z=None, diag=False):
         if isinstance(self.kern1, Kernel):
-            return self.kern0(X, Z, diag) + self.kern1(X, Z, diag)
+            return self.kern0(X, Z, diag=diag) + self.kern1(X, Z, diag=diag)
         else:  # constant
-            return self.kern0(X, Z, diag) + self.kern1
+            return self.kern0(X, Z, diag=diag) + self.kern1
 
 
 class Product(Combination):
@@ -114,9 +114,9 @@ class Product(Combination):
     """
     def forward(self, X, Z=None, diag=False):
         if isinstance(self.kern1, Kernel):
-            return self.kern0(X, Z, diag) * self.kern1(X, Z, diag)
+            return self.kern0(X, Z, diag=diag) * self.kern1(X, Z, diag=diag)
         else:  # constant
-            return self.kern0(X, Z, diag) * self.kern1
+            return self.kern0(X, Z, diag=diag) * self.kern1
 
 
 class Transforming(Kernel):
@@ -139,7 +139,7 @@ class Exponent(Transforming):
         :math:`k_{new}(x, z) = \exp(k(x, z)).`
     """
     def forward(self, X, Z=None, diag=False):
-        return self.kern(X, Z, diag).exp()
+        return self.kern(X, Z, diag=diag).exp()
 
 
 class VerticalScaling(Transforming):
@@ -159,12 +159,12 @@ class VerticalScaling(Transforming):
 
     def forward(self, X, Z=None, diag=False):
         if diag:
-            return self.vscaling_fn(X) * self.kern(X, Z, diag) * self.vscaling_fn(X)
+            return self.vscaling_fn(X) * self.kern(X, Z, diag=diag) * self.vscaling_fn(X)
         elif Z is None:
             vscaled_X = self.vscaling_fn(X).unsqueeze(1)
-            return vscaled_X * self.kern(X, Z, diag) * vscaled_X.t()
+            return vscaled_X * self.kern(X, Z, diag=diag) * vscaled_X.t()
         else:
-            return (self.vscaling_fn(X).unsqueeze(1) * self.kern(X, Z, diag) *
+            return (self.vscaling_fn(X).unsqueeze(1) * self.kern(X, Z, diag=diag) *
                     self.vscaling_fn(Z).unsqueeze(0))
 
 
@@ -225,11 +225,11 @@ class Warping(Transforming):
 
     def forward(self, X, Z=None, diag=False):
         if self.iwarping_fn is None:
-            K_iwarp = self.kern(X, Z, diag)
+            K_iwarp = self.kern(X, Z, diag=diag)
         elif Z is None:
-            K_iwarp = self.kern(self.iwarping_fn(X), None, diag)
+            K_iwarp = self.kern(self.iwarping_fn(X), None, diag=diag)
         else:
-            K_iwarp = self.kern(self.iwarping_fn(X), self.iwarping_fn(Z), diag)
+            K_iwarp = self.kern(self.iwarping_fn(X), self.iwarping_fn(Z), diag=diag)
 
         if self.owarping_coef is None:
             return K_iwarp

--- a/pyro/contrib/gp/models/model.py
+++ b/pyro/contrib/gp/models/model.py
@@ -151,7 +151,7 @@ class GPModel(Parameterized):
             >>> likelihood = gp.likelihoods.Gaussian()
             >>> vsgp = gp.models.VariationalSparseGP(X, y, kernel, Xu, likelihood)
             >>> optimizer = torch.optim.Adam(vsgp.parameters(), lr=0.01)
-            >>> loss_fn = pyro.infer.Trace_ELBO().differentiable_loss
+            >>> loss_fn = pyro.infer.TraceMeanField_ELBO().differentiable_loss
             >>> batched_X, batched_y = X.split(split_size=10), y.split(split_size=10)
             >>> for Xi, yi in zip(batched_X, batched_y):
             ...     optimizer.zero_grad()


### PR DESCRIPTION
Though I have no intent to make Pyro GP jit-able (due to my lacking understanding of PyTorch jit), this is a quick fix for the error: "ValueError: Auto nesting doesn't know how to process an input object of type bool" when I tried to run svdkl with `--jit` option. It seems that the boolean value of the `arg` diag is not allowed for `jit.trace()`. We have to make it a `kwarg`.

Note that I am still not able to use `jit` with GP.