### PR TITLE
Minor fixes to tqdm progress bars used for MCMC logging

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -411,6 +411,6 @@ class HMC(TraceKernel):
 
     def diagnostics(self):
         return OrderedDict([
-            ("Step size", self.step_size),
-            ("Acceptance rate", self._accept_cnt / self._t)
+            ("step size", "{:.2e}".format(self.step_size)),
+            ("acc. rate", "{:.3f}".format(self._accept_cnt / self._t))
         ])

--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -6,6 +6,12 @@ from collections import OrderedDict
 
 from tqdm.auto import tqdm
 
+try:
+    get_ipython
+    ipython_env = True
+except NameError:
+    ipython_env = False
+
 # Identifiers to distinguish between diagnostic messages for progress bars
 # vs. logging output. Useful when using QueueHandler in multiprocessing.
 LOG_MSG = "LOG"
@@ -168,8 +174,12 @@ def initialize_progbar(warmup_steps, num_samples, min_width=80, max_width=120, p
     # Disable progress bar in "CI"
     # (see https://github.com/travis-ci/travis-ci/issues/1337).
     disable = "CI" in os.environ or "PYTEST_XDIST_WORKER" in os.environ
-    progress_bar = tqdm(total=total_steps, desc=description,
+    bar_format = None
+    if not ipython_env:
+        bar_format = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}, {rate_fmt}{postfix}]"
+    progress_bar = tqdm(total=total_steps, desc=description, bar_format=bar_format,
                         position=pos, file=sys.stderr, disable=disable)
+    progress_bar._ipython_env = ipython_env
 
     if getattr(progress_bar, "ncols", None) is not None:
         progress_bar.ncols = max(min_width, progress_bar.ncols)

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -56,8 +56,9 @@ def logger_thread(log_queue, warmup_steps, num_samples, num_chains):
     finally:
         for pbar in progress_bars:
             pbar.close()
-        # Required to not overwrite multiple progress bars on exit.
-        sys.stderr.write("\n" * num_chains)
+            # Required to not overwrite multiple progress bars on exit.
+            if not pbar._ipython_env:
+                sys.stderr.write("\n")
 
 
 class _Worker(object):


### PR DESCRIPTION
Addresses #1520. 

I have shelved my current effort to reimplement progress bars in the `progbar` branch, and tried to get around some of tqdm's limitations instead (https://github.com/tqdm/tqdm/issues/630, https://github.com/tqdm/tqdm/issues/649). This was because while I was able to solve some of these limitations, I was introducing new ones which tqdm handles well like synchronizing logging output with progress bar updates.
 - Remove remaining time counter which isn't that useful specially during the warmup phase because step size is being constantly tuned. Also reduces the width of the description, making it a bit more unlikely to bump into issues like in https://github.com/tqdm/tqdm/issues/630. 
 - Diagnostics are formatted with fixed width so as to reduce jumpy behavior.
 - Slightly different configuration between jupyter notebook environment and otherwise, inc. cleaning up and bar formatting.