### PR TITLE
Fix infer_discrete to work under the PyTorch jit

### DIFF
--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -11,6 +11,7 @@ from pyro.ops.rings import MapRing, SampleRing
 from pyro.poutine.enumerate_messenger import EnumerateMessenger
 from pyro.poutine.replay_messenger import ReplayMessenger
 from pyro.poutine.util import prune_subsample_sites
+from pyro.util import jit_iter
 
 _RINGS = {0: MapRing, 1: SampleRing}
 
@@ -104,7 +105,7 @@ def _sample_posterior(model, first_available_dim, temperature, *args, **kwargs):
                 sample = log_prob._pyro_backward_result
                 if sample is not None:
                     new_value = packed.pack(node["value"], node["infer"]["_dim_to_symbol"])
-                    for index, dim in zip(sample, sample._pyro_sample_dims):
+                    for index, dim in zip(jit_iter(sample), sample._pyro_sample_dims):
                         if dim in new_value._pyro_dims:
                             index._pyro_dims = sample._pyro_dims[1:]
                             new_value = packed.gather(new_value, index, dim)

--- a/pyro/ops/einsum/adjoint.py
+++ b/pyro/ops/einsum/adjoint.py
@@ -101,7 +101,8 @@ def einsum_backward_sample(operands, sample1, sample2):
         sample._pyro_dims = parts[0]._pyro_dims
         sample._pyro_sample_dims = sample_dims
         assert sample.dim() == len(sample._pyro_dims)
-        assert sample.size(0) == len(sample._pyro_sample_dims)
+        if not torch._C._get_tracing_state():
+            assert sample.size(0) == len(sample._pyro_sample_dims)
 
     # Select sample dimensions to pass on to downstream sites.
     for x in operands:
@@ -123,7 +124,8 @@ def einsum_backward_sample(operands, sample1, sample2):
         x_sample._pyro_dims = sample._pyro_dims
         x_sample._pyro_sample_dims = x_sample_dims
         assert x_sample.dim() == len(x_sample._pyro_dims)
-        assert x_sample.size(0) == len(x_sample._pyro_sample_dims)
+        if not torch._C._get_tracing_state():
+            assert x_sample.size(0) == len(x_sample._pyro_sample_dims)
         yield x._pyro_backward, x_sample
 
 
@@ -143,5 +145,6 @@ def unflatten(flat_sample, output_dims, contract_dims, contract_shape):
     sample._pyro_dims = SAMPLE_SYMBOL + output_dims
     sample._pyro_sample_dims = contract_dims
     assert sample.dim() == len(sample._pyro_dims)
-    assert sample.size(0) == len(sample._pyro_sample_dims)
+    if not torch._C._get_tracing_state():
+        assert sample.size(0) == len(sample._pyro_sample_dims)
     return sample

--- a/pyro/ops/einsum/adjoint.py
+++ b/pyro/ops/einsum/adjoint.py
@@ -7,6 +7,7 @@ import torch
 from six import add_metaclass
 
 from pyro.ops import packed
+from pyro.util import jit_iter
 
 SAMPLE_SYMBOL = " "  # must be unique and precede alphanumeric characters
 
@@ -89,7 +90,7 @@ def einsum_backward_sample(operands, sample1, sample2):
         # Slice sample1 down based on choices in sample2.
         assert set(sample1._pyro_sample_dims).isdisjoint(sample2._pyro_sample_dims)
         sample_dims = sample1._pyro_sample_dims + sample2._pyro_sample_dims
-        for dim, index in zip(sample2._pyro_sample_dims, sample2):
+        for dim, index in zip(sample2._pyro_sample_dims, jit_iter(sample2)):
             if dim in sample1._pyro_dims:
                 index._pyro_dims = sample2._pyro_dims[1:]
                 sample1 = packed.gather(sample1, index, dim)

--- a/pyro/ops/einsum/torch_sample.py
+++ b/pyro/ops/einsum/torch_sample.py
@@ -9,6 +9,7 @@ import pyro.ops.einsum.torch_log
 from pyro.ops import packed
 from pyro.ops.einsum.adjoint import Backward, einsum_backward_sample, transpose, unflatten
 from pyro.ops.einsum.util import Tensordot
+from pyro.util import jit_iter
 
 
 class _EinsumBackward(Backward):
@@ -25,7 +26,7 @@ class _EinsumBackward(Backward):
         # Slice down operands before combining terms.
         sample2 = message
         if sample2 is not None:
-            for dim, index in zip(sample2._pyro_sample_dims, sample2):
+            for dim, index in zip(sample2._pyro_sample_dims, jit_iter(sample2)):
                 batch_dims = batch_dims.replace(dim, '')
                 for i, x in enumerate(operands):
                     if dim in x._pyro_dims:

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -348,6 +348,18 @@ def ignore_jit_warnings(filter=None):
         yield
 
 
+def jit_iter(tensor):
+    """
+    Iterate over a tensor, ignoring jit warnings.
+    """
+    # The "Iterating over a tensor" warning is erroneously a RuntimeWarning
+    # so we use a custom filter here.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "Iterating over a tensor")
+        warnings.filterwarnings("ignore", category=torch.jit.TracerWarning)
+        return list(tensor)
+
+
 @contextmanager
 def optional(context_manager, condition):
     """


### PR DESCRIPTION
This fixes a few jit warnings and patches `opt_einsum` (until https://github.com/dgasmith/opt_einsum/pull/77 is released) so that `infer_discrete` works with the PyTorch jit.

## Tested

- added an example of a jitted viterbi decoder