### PR TITLE
 Use consistent marginal implementation for all TracePosterior subclasses

### DIFF
--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -14,19 +14,18 @@ from pyro.ops.stats import waic
 
 class EmpiricalMarginal(Empirical):
     """
-    Marginal distribution, that wraps over a ``TracePosterior`` object to provide a
-    a marginal over one or more sites from the ``TracePosterior``'s model.
+    Marginal distribution over a single site (or multiple, provided they have the same
+    shape) from the ``TracePosterior``'s model.
 
     ..note:: If multiple sites are specified, they must have the same tensor shape.
-    To hold the marginal distribution of sites having different shapes, use
-    :class:`~pyro.infer.abstract_infer.Marginals` instead.
+        Samples from each site will be stacked and stored within a single tensor. See
+        :class:`~pyro.distributions.Empirical`. To hold the marginal distribution of sites
+        having different shapes, use :class:`~pyro.infer.abstract_infer.Marginals` instead.
 
     :param TracePosterior trace_posterior: a ``TracePosterior`` instance representing
         a Monte Carlo posterior.
     :param list sites: optional list of sites for which we need to generate
-        the marginal distribution. Note that for multiple sites, the shape
-        for the site values must match (needed by the underlying ``Empirical``
-        class).
+        the marginal distribution.
     """
 
     def __init__(self, trace_posterior, sites=None, validate_args=None):

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -16,8 +16,11 @@ class EmpiricalMarginal(Empirical):
     """
     Marginal distribution, that wraps over a TracePosterior object to provide a
     a marginal over one or more latent sites or the return values of the
-    TracePosterior's model. If multiple sites are specified, they must have the
-    same tensor shape.
+    TracePosterior's model.
+
+    ..note:: If multiple sites are specified, they must have the same tensor shape.
+    To hold the marginal distribution of sites having different shapes, use
+    :class:`~pyro.infer.abstract_infer.Marginals` instead.
 
     :param TracePosterior trace_posterior: a TracePosterior instance representing
         a Monte Carlo posterior.
@@ -97,6 +100,50 @@ class EmpiricalMarginal(Empirical):
             self._add_sample(value, log_weight=log_weight, chain_id=chain_id)
 
 
+class Marginals(object):
+    """
+    Holds the marginal distribution over one or more latent sites as well
+    as the return values of the TracePosterior's model.
+
+    :param TracePosterior trace_posterior: a TracePosterior instance representing
+        a Monte Carlo posterior.
+    :param list sites: optional list of sites for which we need to generate
+        the marginal distribution.
+    """
+    def __init__(self, trace_posterior, sites=None, validate_args=None):
+        assert isinstance(trace_posterior, TracePosterior), \
+            "trace_dist must be trace posterior distribution object"
+        if sites is None:
+            sites = ["_RETURN"]
+        elif isinstance(sites, str):
+            sites = [sites]
+        else:
+            assert isinstance(sites, list)
+        self.sites = sites
+        self._marginals = OrderedDict()
+        self._diagnostics = OrderedDict()
+        self._trace_posterior = trace_posterior
+        self._populate_traces(trace_posterior, validate_args)
+
+    def _populate_traces(self, trace_posterior, validate):
+        self._marginals = {site: EmpiricalMarginal(trace_posterior, site, validate)
+                           for site in self.sites}
+
+    def support(self, flatten=False):
+        support = OrderedDict([(site, value.enumerate_support())
+                               for site, value in self._marginals.items()])
+        if self._trace_posterior.num_chains > 1 and flatten:
+            for site, samples in support.items():
+                shape = samples.size()
+                flattened_shape = torch.Size((shape[0] * shape[1],)) + shape[2:]
+                support[site] = samples.reshape(flattened_shape)
+        return support
+
+    @property
+    def empirical(self):
+        return self._marginals
+
+
 @add_metaclass(ABCMeta)
 class TracePosterior(object):
     """
@@ -117,7 +164,7 @@ class TracePosterior(object):
         self._categorical = None
 
     def marginal(self, sites=None):
-        return EmpiricalMarginal(self, sites)
+        return Marginals(self, sites)
 
     @abstractmethod
     def _traces(self, *args, **kwargs):

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -14,15 +14,14 @@ from pyro.ops.stats import waic
 
 class EmpiricalMarginal(Empirical):
     """
-    Marginal distribution, that wraps over a TracePosterior object to provide a
-    a marginal over one or more latent sites or the return values of the
-    TracePosterior's model.
+    Marginal distribution, that wraps over a ``TracePosterior`` object to provide a
+    a marginal over one or more sites from the ``TracePosterior``'s model.
 
     ..note:: If multiple sites are specified, they must have the same tensor shape.
     To hold the marginal distribution of sites having different shapes, use
     :class:`~pyro.infer.abstract_infer.Marginals` instead.
 
-    :param TracePosterior trace_posterior: a TracePosterior instance representing
+    :param TracePosterior trace_posterior: a ``TracePosterior`` instance representing
         a Monte Carlo posterior.
     :param list sites: optional list of sites for which we need to generate
         the marginal distribution. Note that for multiple sites, the shape
@@ -102,8 +101,9 @@ class EmpiricalMarginal(Empirical):
 
 class Marginals(object):
     """
-    Holds the marginal distribution over one or more latent sites as well
-    as the return values of the TracePosterior's model.
+    Holds the marginal distribution over one or more sites from the ``TracePosterior``'s
+    model. This is a convenience container class, which can be extended by ``TracePosterior``
+    subclasses. e.g. for implementing diagnostics.
 
     :param TracePosterior trace_posterior: a TracePosterior instance representing
         a Monte Carlo posterior.

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -16,7 +16,8 @@ import torch
 import torch.multiprocessing as mp
 
 import pyro
-from pyro.infer import TracePosterior, EmpiricalMarginal
+from pyro.infer import TracePosterior
+from pyro.infer.abstract_infer import Marginals
 from pyro.infer.mcmc.logger import initialize_logger, initialize_progbar, DIAGNOSTIC_MSG, TqdmHandler
 import pyro.ops.stats as stats
 from pyro.util import optional
@@ -260,52 +261,10 @@ class MCMC(TracePosterior):
             yield sample
 
     def marginal(self, sites=None):
-        return _Marginal(self, sites)
+        return MCMCMarginals(self, sites)
 
 
-class _Marginal(object):
-    """
-    Marginal distribution for MCMC that provides a a marginal over one or more
-    latent sites as well as the return values of the TracePosterior's model.
-
-    :param TracePosterior trace_posterior: a TracePosterior instance representing
-        a Monte Carlo posterior.
-    :param list sites: optional list of sites for which we need to generate
-        the marginal distribution.
-    """
-    def __init__(self, trace_posterior, sites=None, validate_args=None):
-        assert isinstance(trace_posterior, TracePosterior), \
-            "trace_dist must be trace posterior distribution object"
-        if sites is None:
-            sites = ["_RETURN"]
-        elif isinstance(sites, str):
-            sites = [sites]
-        else:
-            assert isinstance(sites, list)
-        self.sites = sites
-        self._marginals = OrderedDict()
-        self._diagnostics = OrderedDict()
-        self._trace_posterior = trace_posterior
-        self._populate_traces(trace_posterior, validate_args)
-
-    def _populate_traces(self, trace_posterior, validate):
-        self._marginals = {site: EmpiricalMarginal(trace_posterior, site, validate)
-                           for site in self.sites}
-
-    def support(self, flatten=False):
-        support = OrderedDict([(site, value.enumerate_support())
-                               for site, value in self._marginals.items()])
-        if self._trace_posterior.num_chains > 1 and flatten:
-            for site, samples in support.items():
-                shape = samples.size()
-                flattened_shape = torch.Size((shape[0] * shape[1],)) + shape[2:]
-                support[site] = samples.reshape(flattened_shape)
-        return support
-
-    @property
-    def empirical(self):
-        return self._marginals
-
+class MCMCMarginals(Marginals):
     def diagnostics(self):
         if self._diagnostics:
             return self._diagnostics


### PR DESCRIPTION
Refer to #1630. This shouldn't affect any existing code, but merely provides a consistent behavior when we call `.marginal(..)` on a TracePosterior instance. 

Currently calling `.marginal()` for HMC would return a container class that can accommodate latents of different shape and implements some chain level diagnostics, whereas calling this for SVI would throw an error.