### PR TITLE
Provide arg in MCMC to turn off progress bar and diagnostics

### DIFF
--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -177,7 +177,8 @@ class MetadataFilter(logging.Filter):
         return True
 
 
-def initialize_progbar(warmup_steps, num_samples, min_width=80, max_width=120, pos=None):
+def initialize_progbar(warmup_steps, num_samples, min_width=80, max_width=120, pos=None,
+                       disable=False):
     """
     Initialize progress bar using :class:`~tqdm.tqdm`.
 
@@ -187,12 +188,13 @@ def initialize_progbar(warmup_steps, num_samples, min_width=80, max_width=120, p
     :param int max_width: Maximum column width of the bar.
     :param int pos: Position of the bar (e.g. in the case of
         multiple parallel samplers).
+    :param bool disable: Disable progress bar.
     """
     description = "Warmup" if pos is None else "Warmup [{}]".format(pos + 1)
     total_steps = warmup_steps + num_samples
     # Disable progress bar in "CI"
     # (see https://github.com/travis-ci/travis-ci/issues/1337).
-    disable = "CI" in os.environ or "PYTEST_XDIST_WORKER" in os.environ
+    disable = disable or "CI" in os.environ or "PYTEST_XDIST_WORKER" in os.environ
     bar_format = None
     if not ipython_env:
         bar_format = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}, {rate_fmt}{postfix}]"

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -66,7 +66,8 @@ class _Worker(object):
                  kernel, num_samples, warmup_steps=0,
                  args=None, kwargs=None):
         self.chain_id = chain_id
-        self.trace_gen = _SingleSampler(kernel, num_samples=num_samples, warmup_steps=warmup_steps)
+        self.trace_gen = _SingleSampler(kernel, num_samples=num_samples, warmup_steps=warmup_steps,
+                                        disable_progbar=True)
         self.args = args if args is not None else []
         self.kwargs = kwargs if kwargs is not None else {}
         self.rng_seed = torch.initial_seed()

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -186,7 +186,7 @@ def test_logistic_regression(step_size, trajectory_length, num_steps,
 
     hmc_kernel = HMC(model, step_size, trajectory_length, num_steps,
                      adapt_step_size, adapt_mass_matrix, full_mass)
-    mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
+    mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100, disable_progbar=True).run(data)
     beta_posterior = mcmc_run.marginal(['beta']).empirical['beta']
     assert_equal(rmse(true_coefs, beta_posterior.mean).item(), 0.0, prec=0.1)
 


### PR DESCRIPTION
There might be situations (for instance, when logging to a file) when users may not want progress bar / diagnostics update when running HMC. This provides an option to turn off these updates from the MCMC class itself. The only API change in this PR is providing a `disable_progbar=False` kwarg in MCMC.

Ideally, under this scenario, we should log text updates via the logger and the user could use a NullHandler to silence this logging. This aspect of logging can be improved at a future date - I did not want to tackle it yet because we need to decide how to do this clearly for parallel chains.