### PR TITLE
Switch config_enumerate default from sequential to parallel

### DIFF
--- a/examples/contrib/autoname/scoping_mixture.py
+++ b/examples/contrib/autoname/scoping_mixture.py
@@ -49,7 +49,7 @@ def main(args):
 
     data = torch.tensor([0.0, 1.0, 2.0, 20.0, 30.0, 40.0])
     optim = pyro.optim.Adam({'lr': 0.1})
-    inference = SVI(model, config_enumerate(guide, 'parallel'), optim,
+    inference = SVI(model, config_enumerate(guide), optim,
                     loss=TraceEnum_ELBO(max_plate_nesting=1))
 
     print('Step\tLoss')

--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -664,7 +664,7 @@ class AutoDiscreteParallel(AutoGuide):
     """
     def _setup_prototype(self, *args, **kwargs):
         # run the model so we can inspect its structure
-        model = config_enumerate(self.model, default="parallel")
+        model = config_enumerate(self.model)
         self.prototype_trace = poutine.block(poutine.trace(model).get_trace)(*args, **kwargs)
         self.prototype_trace = prune_subsample_sites(self.prototype_trace)
         if self.master is not None:

--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -127,7 +127,7 @@ def infer_discrete(fn=None, first_available_dim=None, temperature=1):
     Example::
 
         @infer_discrete(first_available_dim=-1, temperature=0)
-        @config_enumerate(hmm, default="parallel")
+        @config_enumerate
         def viterbi_decoder(data, hidden_dim=10):
             transition = 0.3 / hidden_dim + 0.7 * torch.eye(hidden_dim)
             means = torch.arange(float(hidden_dim))

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -102,7 +102,7 @@ def _config_enumerate(default, expand, num_samples):
     return config_fn
 
 
-def config_enumerate(guide=None, default="sequential", expand=False, num_samples=None):
+def config_enumerate(guide=None, default="parallel", expand=False, num_samples=None):
     """
     Configures enumeration for all relevant sites in a guide. This is mainly
     used in conjunction with :class:`~pyro.infer.traceenum_elbo.TraceEnum_ELBO`.
@@ -124,14 +124,14 @@ def config_enumerate(guide=None, default="sequential", expand=False, num_samples
         def guide1(*args, **kwargs):
             ...
 
-        @config_enumerate(default="parallel", expand=True)
+        @config_enumerate(default="sequential", expand=True)
         def guide2(*args, **kwargs):
             ...
 
     :param callable guide: a pyro model that will be used as a guide in
         :class:`~pyro.infer.svi.SVI`.
     :param str default: Which enumerate strategy to use, one of
-        "sequential", "parallel", or None.
+        "sequential", "parallel", or None. Defaults to "parallel".
     :param bool expand: Whether to expand enumerated sample values. See
         :meth:`~pyro.distributions.Distribution.enumerate_support` for details.
         This only applies to exhaustive enumeration, where ``num_samples=None``.

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -322,7 +322,7 @@ class HMC(TraceKernel):
             self._guess_max_plate_nesting()
         # Wrap model in `poutine.enum` to enumerate over discrete latent sites.
         # No-op if model does not have any discrete latents.
-        self.model = poutine.enum(config_enumerate(self.model, default="parallel"),
+        self.model = poutine.enum(config_enumerate(self.model),
                                   first_available_dim=-1 - self.max_plate_nesting)
         if self._automatic_transform_enabled:
             self.transforms = {}

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -82,7 +82,7 @@ def test_model_error_enum_dim_clash(kernel, kwargs):
 
 def test_log_prob_eval_iterates_in_correct_order():
     @poutine.enum(first_available_dim=-5)
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.condition(data={"p": torch.tensor(0.4)})
     def model():
         outer = pyro.plate("outer", 3, dim=-1)
@@ -124,7 +124,7 @@ def test_all_discrete_sites_log_prob(Eval):
     p = 0.3
 
     @poutine.enum(first_available_dim=-4)
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         d = dist.Bernoulli(p)
         context1 = pyro.plate("outer", 2, dim=-1)
@@ -149,7 +149,7 @@ def test_all_discrete_sites_log_prob(Eval):
                                   xfail_param(TraceEinsumEvaluator, reason="TODO: Debug this failure case.")])
 def test_enumeration_in_tree(Eval):
     @poutine.enum(first_available_dim=-5)
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.condition(data={"sample1": torch.tensor(0.),
                              "sample2": torch.tensor(1.),
                              "sample3": torch.tensor(2.)})
@@ -187,7 +187,7 @@ def test_enumeration_in_dag(Eval):
     p = 0.3
 
     @poutine.enum(first_available_dim=-3)
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.condition(data={"b": torch.tensor(0.4), "c": torch.tensor(0.4)})
     def model():
         d = dist.Bernoulli(p)
@@ -218,7 +218,7 @@ def test_enumeration_in_dag(Eval):
 def test_enum_log_prob_continuous_observed(data, expected_log_prob, Eval):
 
     @poutine.enum(first_available_dim=-2)
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.condition(data={"p": torch.tensor(0.4)})
     def model(data):
         p = pyro.sample("p", dist.Uniform(0., 1.))
@@ -247,7 +247,7 @@ def test_enum_log_prob_continuous_observed(data, expected_log_prob, Eval):
 def test_enum_log_prob_continuous_sampled(data, expected_log_prob, Eval):
 
     @poutine.enum(first_available_dim=-2)
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.condition(data={"p": torch.tensor(0.4),
                              "n": torch.tensor([[1.], [-1.]])})
     def model(data):
@@ -275,7 +275,7 @@ def test_enum_log_prob_continuous_sampled(data, expected_log_prob, Eval):
 def test_enum_log_prob_discrete_observed(data, expected_log_prob, Eval):
 
     @poutine.enum(first_available_dim=-2)
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.condition(data={"p": torch.tensor(0.4)})
     def model(data):
         p = pyro.sample("p", dist.Uniform(0., 1.))
@@ -301,7 +301,7 @@ def test_enum_log_prob_discrete_observed(data, expected_log_prob, Eval):
 def test_enum_log_prob_multiple_plate(data, expected_log_prob, Eval):
 
     @poutine.enum(first_available_dim=-2)
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.condition(data={"p": torch.tensor(0.4)})
     def model(data):
         p = pyro.sample("p", dist.Beta(1.1, 1.1))
@@ -330,7 +330,7 @@ def test_enum_log_prob_multiple_plate(data, expected_log_prob, Eval):
 def test_enum_log_prob_nested_plate(data, expected_log_prob, Eval):
 
     @poutine.enum(first_available_dim=-3)
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.condition(data={"p": torch.tensor(0.4)})
     def model(data):
         p = pyro.sample("p", dist.Uniform(0., 1.))

--- a/tests/infer/test_discrete.py
+++ b/tests/infer/test_discrete.py
@@ -42,7 +42,7 @@ def test_distribution_1(temperature):
     num_particles = 10000
     data = torch.tensor([1., 2., 3.])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model(num_particles=1, z=None):
         p = pyro.param("p", torch.tensor(0.25))
         with pyro.plate("num_particles", num_particles, dim=-2):
@@ -78,7 +78,7 @@ def test_distribution_2(temperature):
     num_particles = 10000
     data = torch.tensor([[-1., -1., 0.], [-1., 1., 1.]])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model(num_particles=1, z1=None, z2=None):
         p = pyro.param("p", torch.tensor([[0.25, 0.75], [0.1, 0.9]]))
         loc = pyro.param("loc", torch.tensor([-1., 1.]))
@@ -124,7 +124,7 @@ def test_distribution_3(temperature):
     num_particles = 10000
     data = [torch.tensor([-1., -1., 0.]), torch.tensor([-1., 1.])]
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model(num_particles=1, z1=None, z2=None):
         p = pyro.param("p", torch.tensor([0.25, 0.75]))
         loc = pyro.param("loc", torch.tensor([-1., 1.]))
@@ -182,7 +182,7 @@ def test_hmm_smoke(temperature, length):
     assert len(data) == length
     assert len(true_states) == 1 + len(data)
 
-    decoder = infer_discrete(config_enumerate(hmm, default="parallel"),
+    decoder = infer_discrete(config_enumerate(hmm),
                              first_available_dim=-1, temperature=temperature)
     inferred_states, _ = decoder(data)
     assert len(inferred_states) == len(true_states)
@@ -201,7 +201,7 @@ def test_prob(nderivs):
     data = torch.tensor([0.5, 1., 1.5])
     p = pyro.param("p", torch.tensor(0.25))
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model(num_particles):
         p = pyro.param("p")
         with pyro.plate("num_particles", num_particles, dim=-2):

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -42,7 +42,7 @@ def _skip_cuda(*args):
 @pytest.mark.parametrize("graph_type", ["flat", "dense"])
 def test_iter_discrete_traces_order(depth, graph_type):
 
-    @config_enumerate
+    @config_enumerate(deafult="sequential")
     def model(depth):
         for i in range(depth):
             pyro.sample("x{}".format(i), dist.Bernoulli(0.5))
@@ -59,7 +59,7 @@ def test_iter_discrete_traces_order(depth, graph_type):
 def test_iter_discrete_traces_scalar(graph_type):
     pyro.clear_param_store()
 
-    @config_enumerate
+    @config_enumerate(deafult="sequential")
     def model():
         p = pyro.param("p", torch.tensor(0.05))
         probs = pyro.param("probs", torch.tensor([0.1, 0.2, 0.3, 0.4]))
@@ -1207,7 +1207,7 @@ def test_elbo_hmm_in_guide(enumerate1, num_steps, expand):
 def test_hmm_enumerate_model(num_steps):
     data = dist.Categorical(torch.tensor([0.5, 0.5])).sample((num_steps,))
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model(data):
         transition_probs = pyro.param("transition_probs",
                                       torch.tensor([[0.75, 0.25], [0.25, 0.75]]),
@@ -1308,7 +1308,7 @@ def test_elbo_enumerate_1(scale):
         pyro.sample("x", dist.Categorical(probs_x))
         pyro.sample("z", dist.Categorical(probs_z), obs=torch.tensor(0))
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def guide():
         probs_x = pyro.param("guide_probs_x")
@@ -1354,7 +1354,7 @@ def test_elbo_enumerate_2(scale):
         x = pyro.sample("x", dist.Categorical(probs_x))
         pyro.sample("z", dist.Categorical(probs_yz[x]), obs=torch.tensor(0))
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def guide():
         probs_x = pyro.param("guide_probs_x")
@@ -1400,7 +1400,7 @@ def test_elbo_enumerate_3(scale):
         with poutine.scale(scale=scale):
             pyro.sample("z", dist.Categorical(probs_yz[x]), obs=torch.tensor(0))
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def guide():
         probs_x = pyro.param("guide_probs_x")
         pyro.sample("x", dist.Categorical(probs_x))
@@ -1460,7 +1460,7 @@ def test_elbo_enumerate_plate_1(num_samples, num_masked, scale):
             for i in pyro.plate("data", num_masked):
                 pyro.sample("z_{}".format(i), dist.Categorical(probs_z[y]), obs=data[i])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def guide(data):
         probs_x = pyro.param("guide_probs_x")
         pyro.sample("x", dist.Categorical(probs_x))
@@ -1523,7 +1523,7 @@ def test_elbo_enumerate_plate_2(num_samples, num_masked, scale):
                                 infer={"enumerate": "parallel"})
                 pyro.sample("z_{}".format(i), dist.Categorical(probs_z[y]), obs=data[i])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def guide(data):
         probs_x = pyro.param("guide_probs_x")
         pyro.sample("x", dist.Categorical(probs_x))
@@ -1577,7 +1577,7 @@ def test_elbo_enumerate_plate_3(num_samples, num_masked, scale):
                     pyro.sample("z", dist.Categorical(probs_z[y]), obs=data)
 
     @poutine.scale(scale=scale)
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def auto_guide(data):
         probs_x = pyro.param("guide_probs_x")
         with pyro.plate("data", len(data)):
@@ -1599,7 +1599,7 @@ def test_elbo_enumerate_plate_3(num_samples, num_masked, scale):
             pyro.sample("z_{}".format(i), dist.Categorical(probs_z[y]), obs=data[i])
 
     @poutine.scale(scale=scale)
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def hand_guide(data):
         probs_x = pyro.param("guide_probs_x")
         for i in pyro.plate("data", num_masked):
@@ -1699,7 +1699,7 @@ def test_elbo_enumerate_plate_5():
     data = torch.tensor([1, 2])
     c_ind = torch.arange(3, dtype=torch.long)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model_plate():
         probs_a = pyro.param("model_probs_a")
         probs_b = pyro.param("model_probs_b")
@@ -1711,13 +1711,13 @@ def test_elbo_enumerate_plate_5():
                         dist.Categorical(probs_c[a.unsqueeze(-1), b.unsqueeze(-1), c_ind]),
                         obs=data)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def guide_plate():
         probs_b = pyro.param("guide_probs_b")
         with pyro.plate("b_axis", 2):
             pyro.sample("b", dist.Categorical(probs_b))
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model_iplate():
         probs_a = pyro.param("model_probs_a")
         probs_b = pyro.param("model_probs_b")
@@ -1729,7 +1729,7 @@ def test_elbo_enumerate_plate_5():
                         dist.Categorical(probs_c[a.unsqueeze(-1), b.unsqueeze(-1), c_ind]),
                         obs=data[i])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def guide_iplate():
         probs_b = pyro.param("guide_probs_b")
         for i in pyro.plate("b_axis", 2):
@@ -1769,7 +1769,7 @@ def test_elbo_enumerate_plate_6(enumerate1):
     data = torch.tensor([1, 2])
     c_ind = torch.arange(3, dtype=torch.long)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model_plate():
         probs_a = pyro.param("model_probs_a")
         probs_b = pyro.param("model_probs_b")
@@ -1781,7 +1781,7 @@ def test_elbo_enumerate_plate_6(enumerate1):
                         dist.Categorical(probs_c[a.unsqueeze(-1), b.unsqueeze(-1), c_ind]),
                         obs=data)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model_iplate():
         probs_a = pyro.param("model_probs_a")
         probs_b = pyro.param("model_probs_b")
@@ -1923,7 +1923,7 @@ def test_elbo_enumerate_plates_1(scale):
     b_data = torch.tensor([0, 1])
     d_data = torch.tensor([0, 0, 1])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def auto_model():
         probs_a = pyro.param("probs_a")
@@ -1937,7 +1937,7 @@ def test_elbo_enumerate_plates_1(scale):
             c = pyro.sample("c", dist.Categorical(probs_c))
             pyro.sample("d", dist.Categorical(probs_d[c]), obs=d_data)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def hand_model():
         probs_a = pyro.param("probs_a")
@@ -1980,7 +1980,7 @@ def test_elbo_enumerate_plates_2(scale):
     b_data = torch.tensor([0, 1])
     c_data = torch.tensor([0, 0, 1])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def auto_model():
         probs_a = pyro.param("probs_a")
@@ -1994,7 +1994,7 @@ def test_elbo_enumerate_plates_2(scale):
             pyro.sample("c", dist.Categorical(probs_c[a]),
                         obs=c_data)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def hand_model():
         probs_a = pyro.param("probs_a")
@@ -2036,7 +2036,7 @@ def test_elbo_enumerate_plates_3(scale):
                constraint=constraints.simplex)
     data = torch.tensor([[0, 1], [0, 0]])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def auto_model():
         probs_a = pyro.param("probs_a")
@@ -2047,7 +2047,7 @@ def test_elbo_enumerate_plates_3(scale):
                 pyro.sample("b", dist.Categorical(probs_b[a]),
                             obs=data)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def hand_model():
         probs_a = pyro.param("probs_a")
@@ -2087,7 +2087,7 @@ def test_elbo_enumerate_plates_4(scale):
                torch.tensor([[0.4, 0.6], [0.3, 0.7]]),
                constraint=constraints.simplex)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def auto_model(data):
         probs_a = pyro.param("probs_a")
@@ -2099,7 +2099,7 @@ def test_elbo_enumerate_plates_4(scale):
             with pyro.plate("inner", 2):
                 pyro.sample("c", dist.Categorical(probs_c[b]), obs=data)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def hand_model(data):
         probs_a = pyro.param("probs_a")
@@ -2147,7 +2147,7 @@ def test_elbo_enumerate_plates_5(scale):
     data = torch.tensor([[0, 1], [0, 0]])
     c_ind = torch.arange(2, dtype=torch.long)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def auto_model():
         probs_a = pyro.param("probs_a")
@@ -2161,7 +2161,7 @@ def test_elbo_enumerate_plates_5(scale):
                             dist.Categorical(probs_c[a.unsqueeze(-1), b.unsqueeze(-1), c_ind]),
                             obs=data)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def hand_model():
         probs_a = pyro.param("probs_a")
@@ -2214,7 +2214,7 @@ def test_elbo_enumerate_plates_6(scale):
                constraint=constraints.simplex)
     d_ind = torch.arange(2, dtype=torch.long)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def model_iplate_iplate(data):
         probs_a = pyro.param("probs_a")
@@ -2232,7 +2232,7 @@ def test_elbo_enumerate_plates_6(scale):
                             dist.Categorical(probs_d[b[i].unsqueeze(-1), c[j].unsqueeze(-1), d_ind]),
                             obs=data[i, j])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def model_iplate_plate(data):
         probs_a = pyro.param("probs_a")
@@ -2251,7 +2251,7 @@ def test_elbo_enumerate_plates_6(scale):
                             dist.Categorical(probs_d[b[i].unsqueeze(-1), c.unsqueeze(-1), d_ind]),
                             obs=data[i])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def model_plate_iplate(data):
         probs_a = pyro.param("probs_a")
@@ -2270,7 +2270,7 @@ def test_elbo_enumerate_plates_6(scale):
                             dist.Categorical(probs_d[b.unsqueeze(-1), c[j].unsqueeze(-1), d_ind]),
                             obs=data[:, j])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def model_plate_plate(data):
         probs_a = pyro.param("probs_a")
@@ -2339,7 +2339,7 @@ def test_elbo_enumerate_plates_7(scale):
                torch.tensor([[0.4, 0.6], [0.3, 0.7]]),
                constraint=constraints.simplex)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def model_iplate_iplate(data):
         probs_a = pyro.param("probs_a")
@@ -2359,7 +2359,7 @@ def test_elbo_enumerate_plates_7(scale):
                 pyro.sample("e_{}_{}".format(i, j), dist.Categorical(probs_e[c[j]]),
                             obs=data[i, j])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def model_iplate_plate(data):
         probs_a = pyro.param("probs_a")
@@ -2380,7 +2380,7 @@ def test_elbo_enumerate_plates_7(scale):
                 pyro.sample("e_{}".format(i), dist.Categorical(probs_e[c]),
                             obs=data[i])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def model_plate_iplate(data):
         probs_a = pyro.param("probs_a")
@@ -2401,7 +2401,7 @@ def test_elbo_enumerate_plates_7(scale):
                 pyro.sample("e_{}".format(j), dist.Categorical(probs_e[c[j]]),
                             obs=data[:, j])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=scale)
     def model_plate_plate(data):
         probs_a = pyro.param("probs_a")
@@ -2467,7 +2467,7 @@ def test_elbo_enumerate_plates_8(model_scale, guide_scale, inner_vectorized, out
     data = torch.tensor([[0, 1], [0, 2]])
     c_ind = torch.arange(3, dtype=torch.long)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=model_scale)
     def model_plate_plate():
         probs_a = pyro.param("model_probs_a")
@@ -2481,7 +2481,7 @@ def test_elbo_enumerate_plates_8(model_scale, guide_scale, inner_vectorized, out
                             dist.Categorical(probs_c[a.unsqueeze(-1), b.unsqueeze(-1), c_ind]),
                             obs=data)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=model_scale)
     def model_iplate_plate():
         probs_a = pyro.param("model_probs_a")
@@ -2496,7 +2496,7 @@ def test_elbo_enumerate_plates_8(model_scale, guide_scale, inner_vectorized, out
                             dist.Categorical(probs_c[a.unsqueeze(-1), b.unsqueeze(-1), c_ind]),
                             obs=data[:, i])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=model_scale)
     def model_plate_iplate():
         probs_a = pyro.param("model_probs_a")
@@ -2510,7 +2510,7 @@ def test_elbo_enumerate_plates_8(model_scale, guide_scale, inner_vectorized, out
                             dist.Categorical(probs_c[a.unsqueeze(-1), b.unsqueeze(-1), c_ind]),
                             obs=data[j])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=model_scale)
     def model_iplate_iplate():
         probs_a = pyro.param("model_probs_a")
@@ -2525,14 +2525,14 @@ def test_elbo_enumerate_plates_8(model_scale, guide_scale, inner_vectorized, out
                             dist.Categorical(probs_c[a.unsqueeze(-1), b.unsqueeze(-1), c_ind]),
                             obs=data[j, i])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=guide_scale)
     def guide_plate():
         probs_b = pyro.param("guide_probs_b")
         with pyro.plate("outer", 2):
             pyro.sample("b", dist.Categorical(probs_b))
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     @poutine.scale(scale=guide_scale)
     def guide_iplate():
         probs_b = pyro.param("guide_probs_b")
@@ -2616,7 +2616,7 @@ def test_elbo_hmm_growth():
             x = pyro.sample("x_{}".format(i), dist.Categorical(probs))
             pyro.sample("y_{}".format(i), dist.Categorical(emission_probs[x]), obs=y)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def guide(data):
         transition_probs = pyro.param("transition_probs",
                                       torch.tensor([[0.75, 0.25], [0.25, 0.75]]),
@@ -2671,7 +2671,7 @@ def test_elbo_dbn_growth():
             y = pyro.sample("y_{}".format(i), dist.Categorical(uniform))
             pyro.sample("z_{}".format(i), dist.Categorical(probs_z[y]), obs=z)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def guide(data):
         probs_x = pyro.param("probs_x",
                              torch.tensor([[0.75, 0.25], [0.25, 0.75]]),
@@ -2944,7 +2944,7 @@ def test_compute_marginals_single(Dist, prior):
     prior = torch.tensor(prior)
     data = torch.tensor([0., 0.1, 0.2, 0.9, 1.0, 1.1])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         locs = torch.tensor([-1., 0., 1., 2.])
         x = pyro.sample("x", Dist(prior))
@@ -2970,7 +2970,7 @@ def test_compute_marginals_single(Dist, prior):
     # and ensure that they are exact, or at least locally optimal.
     pyro.param("probs", probs)
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def exact_guide():
         probs = pyro.param("probs")
         pyro.sample("x", Dist(probs))
@@ -2988,7 +2988,7 @@ def test_compute_marginals_single(Dist, prior):
 ])
 def test_compute_marginals_restrictions(ok, enumerate_guide, num_particles, vectorize_particles):
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         w = pyro.sample("w", dist.Bernoulli(0.1))
         x = pyro.sample("x", dist.Bernoulli(0.2))
@@ -3019,7 +3019,7 @@ def test_compute_marginals_restrictions(ok, enumerate_guide, num_particles, vect
 @pytest.mark.parametrize('size', [1, 2, 3, 4, 10, 20, _skip_cuda(30)])
 def test_compute_marginals_hmm(size):
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model(data):
         transition_probs = torch.tensor([[0.75, 0.25], [0.25, 0.75]])
         emission_probs = torch.tensor([[0.75, 0.25], [0.25, 0.75]])
@@ -3060,7 +3060,7 @@ def test_compute_marginals_hmm(size):
 ])
 def test_backwardsample_posterior_smoke(data):
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model(data):
         xs = list(data)
         zs = []
@@ -3096,7 +3096,7 @@ def test_backwardsample_posterior_smoke(data):
 def test_backwardsample_posterior_2():
     num_particles = 10000
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model(data):
         with pyro.plate("particles", num_particles):
             p_z = torch.tensor([0.1, 0.9])
@@ -3117,7 +3117,7 @@ def test_backwardsample_posterior_2():
 def test_backwardsample_posterior_3():
     num_particles = 10000
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model(data):
         with pyro.plate("particles", num_particles):
             p_z = torch.tensor([[0.9, 0.1], [0.1, 0.9]])
@@ -3151,7 +3151,7 @@ def test_backwardsample_posterior_3():
 ])
 def test_backwardsample_posterior_restrictions(ok, enumerate_guide, num_particles, vectorize_particles):
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         w = pyro.sample("w", dist.Bernoulli(0.1))
         x = pyro.sample("x", dist.Bernoulli(0.2))

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -42,7 +42,7 @@ def _skip_cuda(*args):
 @pytest.mark.parametrize("graph_type", ["flat", "dense"])
 def test_iter_discrete_traces_order(depth, graph_type):
 
-    @config_enumerate(deafult="sequential")
+    @config_enumerate(default="sequential")
     def model(depth):
         for i in range(depth):
             pyro.sample("x{}".format(i), dist.Bernoulli(0.5))
@@ -59,7 +59,7 @@ def test_iter_discrete_traces_order(depth, graph_type):
 def test_iter_discrete_traces_scalar(graph_type):
     pyro.clear_param_store()
 
-    @config_enumerate(deafult="sequential")
+    @config_enumerate(default="sequential")
     def model():
         p = pyro.param("p", torch.tensor(0.05))
         probs = pyro.param("probs", torch.tensor([0.1, 0.2, 0.3, 0.4]))
@@ -78,7 +78,7 @@ def test_iter_discrete_traces_scalar(graph_type):
 def test_iter_discrete_traces_vector(expand, graph_type):
     pyro.clear_param_store()
 
-    @config_enumerate(expand=expand)
+    @config_enumerate(default="sequential", expand=expand)
     def model():
         p = pyro.param("p", torch.tensor([0.05, 0.15]))
         probs = pyro.param("probs", torch.tensor([[0.1, 0.2, 0.3, 0.4],
@@ -170,7 +170,7 @@ def gmm_guide(data, verbose=False):
 def test_gmm_iter_discrete_traces(data_size, graph_type, model):
     pyro.clear_param_store()
     data = torch.arange(0., float(data_size))
-    model = config_enumerate(model)
+    model = config_enumerate(model, "sequential")
     traces = list(iter_discrete_traces(graph_type, model, data=data, verbose=True))
     # This non-vectorized version is exponential in data_size:
     assert len(traces) == 2**data_size

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -205,7 +205,7 @@ def gmm_batch_guide(data):
 def test_gmm_batch_iter_discrete_traces(model, data_size, graph_type):
     pyro.clear_param_store()
     data = torch.arange(0., float(data_size))
-    model = config_enumerate(model)
+    model = config_enumerate(model, "sequential")
     traces = list(iter_discrete_traces(graph_type, model, data=data))
     # This vectorized version is independent of data_size:
     assert len(traces) == 2

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -60,7 +60,7 @@ def test_subsample_gradient(Elbo, reparameterized, subsample, local_samples, sca
 
     num_particles = 50000
     if local_samples:
-        guide = config_enumerate(guide, default="parallel", num_samples=num_particles)
+        guide = config_enumerate(guide, num_samples=num_particles)
         num_particles = 1
 
     optim = Adam({"lr": 0.1})

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -643,7 +643,7 @@ def test_plate_enum_discrete_no_discrete_vars_warning(strict_enumeration_warning
         with pyro.plate("plate", 10, 5) as ind:
             pyro.sample("x", dist.Normal(loc, scale).expand_by([len(ind)]))
 
-    @config_enumerate
+    @config_enumerate(deafult="sequential")
     def guide():
         loc = pyro.param("loc", torch.tensor(1.0, requires_grad=True))
         scale = pyro.param("scale", torch.tensor(2.0, requires_grad=True))
@@ -1109,7 +1109,7 @@ def test_enum_sequential_in_model_error():
 
 def test_enum_in_model_plate_reuse_ok():
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         p = pyro.param("p", torch.tensor([0.2, 0.8]))
         a = pyro.sample("a", dist.Bernoulli(0.3)).long()
@@ -1127,7 +1127,7 @@ def test_enum_in_model_plate_reuse_ok():
 
 def test_enum_in_model_multi_scale_error():
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         p = pyro.param("p", torch.tensor([0.2, 0.8]))
         x = pyro.sample("x", dist.Bernoulli(0.3)).long()
@@ -1144,7 +1144,7 @@ def test_enum_in_model_multi_scale_error():
 def test_enum_in_model_diamond_error():
     data = torch.tensor([[0, 1], [0, 0]])
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         pyro.param("probs_a", torch.tensor([0.45, 0.55]))
         pyro.param("probs_b", torch.tensor([[0.6, 0.4], [0.4, 0.6]]))
@@ -1284,7 +1284,7 @@ def test_enum_discrete_vectorized_num_particles(enumerate_, expand, num_samples,
 
 def test_enum_recycling_chain():
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         p = pyro.param("p", torch.tensor([[0.2, 0.8], [0.1, 0.9]]))
 
@@ -1306,7 +1306,7 @@ def test_enum_recycling_dbn(markov):
     #  \ |   \ |   \ |
     #    z     z     z  obs
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         p = pyro.param("p", torch.ones(3, 3))
         q = pyro.param("q", torch.ones(2))
@@ -1355,7 +1355,7 @@ def test_enum_recycling_nested():
     # z21: x y1 y2 z20
     # z22: x y1 y2 z21
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         p = pyro.param("p", torch.ones(3, 3))
         x = pyro.sample("x", dist.Categorical(p[0]))
@@ -1381,7 +1381,7 @@ def test_enum_recycling_grid():
     #  |   |   |   |
     #  x---x--(x)--x <-- what can this depend on?
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         p = pyro.param("p_leaf", torch.ones(2, 2, 2))
         ind = torch.arange(2, dtype=torch.long)
@@ -1511,7 +1511,7 @@ def test_enum_recycling_interleave():
 
 def test_enum_recycling_plate():
 
-    @config_enumerate(default="parallel")
+    @config_enumerate
     def model():
         p = pyro.param("p", torch.ones(3, 3))
         q = pyro.param("q", torch.tensor([0.5, 0.5]))

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -643,7 +643,7 @@ def test_plate_enum_discrete_no_discrete_vars_warning(strict_enumeration_warning
         with pyro.plate("plate", 10, 5) as ind:
             pyro.sample("x", dist.Normal(loc, scale).expand_by([len(ind)]))
 
-    @config_enumerate(deafult="sequential")
+    @config_enumerate(default="sequential")
     def guide():
         loc = pyro.param("loc", torch.tensor(1.0, requires_grad=True))
         scale = pyro.param("scale", torch.tensor(2.0, requires_grad=True))
@@ -980,7 +980,7 @@ def test_dim_allocation_ok(Elbo, expand):
             assert z.shape == (5, 7, 6)
             assert q.shape == (8, 5, 7, 6)
 
-    guide = config_enumerate(model, expand=expand) if enumerate_ else model
+    guide = config_enumerate(model, "sequential", expand=expand) if enumerate_ else model
     assert_ok(model, guide, Elbo(max_plate_nesting=4))
 
 

--- a/tutorial/source/enumeration.ipynb
+++ b/tutorial/source/enumeration.ipynb
@@ -187,7 +187,7 @@
     }
    ],
    "source": [
-    "@config_enumerate(default=\"parallel\")\n",
+    "@config_enumerate\n",
     "def model():\n",
     "    p = pyro.param(\"p\", torch.randn(3, 3).exp(), constraint=constraints.simplex)\n",
     "    x = pyro.sample(\"x\", dist.Categorical(p[0]))\n",
@@ -279,7 +279,7 @@
     }
    ],
    "source": [
-    "@config_enumerate(default=\"parallel\")\n",
+    "@config_enumerate\n",
     "def model(data, num_components=3):\n",
     "    print('Running model with {} data points'.format(len(data)))\n",
     "    p = pyro.sample(\"p\", dist.Dirichlet(0.5 * torch.ones(3)))\n",
@@ -326,7 +326,7 @@
     "#### Restriction 2: no downstream coupling\n",
     "No variable outside of a vectorized plate can depend on an enumerated variable inside of that plate. This would violate Pyro's exponential speedup assumption. For example the following model is invalid:\n",
     "```py\n",
-    "@config_enumerate(default=\"parallel\")\n",
+    "@config_enumerate\n",
     "def invalid_model(data):\n",
     "    with pyro.plate(\"plate\", 10):  # <--- invalid vectorized plate\n",
     "        x = pyro.sample(\"x\", dist.Bernoulli(0.5))\n",
@@ -335,7 +335,7 @@
     "```\n",
     " To work around this restriction, you can convert the vectorized plate to a sequential plate:\n",
     "```py\n",
-    "@config_enumerate(default=\"parallel\")\n",
+    "@config_enumerate\n",
     "def valid_model(data):\n",
     "    x = []\n",
     "    for i in pyro.plate(\"plate\", 10):  # <--- valid sequential plate\n",
@@ -351,7 +351,7 @@
     "\n",
     "This requirement only applies when there are at least two plates and at least three variables in different plate contexts. The simplest counterexample is a Boltzmann machine\n",
     "```py\n",
-    "@config_enumerate(default=\"parallel\")\n",
+    "@config_enumerate\n",
     "def invalid_model(data):\n",
     "    plate_1 = pyro.plate(\"plate_1\", 10, dim=-1)  # vectorized\n",
     "    plate_2 = pyro.plate(\"plate_2\", 10, dim=-2)  # vectorized\n",
@@ -367,7 +367,7 @@
     "\n",
     "To work around this restriction, you can convert one of the plates to a sequential plate:\n",
     "```py\n",
-    "@config_enumerate(default=\"parallel\")\n",
+    "@config_enumerate\n",
     "def valid_model(data):\n",
     "    plate_1 = pyro.plate(\"plate_1\", 10, dim=-1)  # vectorized\n",
     "    plate_2 = pyro.plate(\"plate_2\", 10)          # sequential\n",

--- a/tutorial/source/gmm.ipynb
+++ b/tutorial/source/gmm.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "K = 2  # Fixed number of components.\n",
     "\n",
-    "@config_enumerate(default='parallel')\n",
+    "@config_enumerate\n",
     "def model(data):\n",
     "    # Global variables.\n",
     "    weights = pyro.sample('weights', dist.Dirichlet(0.5 * torch.ones(K)))\n",
@@ -327,7 +327,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@config_enumerate(default=\"parallel\")\n",
+    "@config_enumerate\n",
     "def full_guide(data):\n",
     "    # Global variables.\n",
     "    with poutine.block(hide_types=[\"param\"]):  # Keep our learned values of global parameters.\n",

--- a/tutorial/source/tensor_shapes.ipynb
+++ b/tutorial/source/tensor_shapes.ipynb
@@ -464,7 +464,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@config_enumerate(default=\"parallel\")\n",
+    "@config_enumerate\n",
     "def model3():\n",
     "    p = pyro.param(\"p\", torch.arange(6.) / 6)\n",
     "    locs = pyro.param(\"locs\", torch.tensor([-1., 1.]))\n",
@@ -713,7 +713,7 @@
     "    def model():\n",
     "        fun(observe=True, sample_fn=sample_fn)\n",
     "\n",
-    "    @config_enumerate(default=\"parallel\")\n",
+    "    @config_enumerate\n",
     "    def guide():\n",
     "        fun(observe=False, sample_fn=sample_fn)\n",
     "\n",


### PR DESCRIPTION
Now that "parallel" is used much more commonly than "sequential", we can simplify in many places:
```diff
- @config_enumerate(default="parallel")
+ @config_enumerate
```