### PR TITLE
Enable test_jit.py under CUDA, which now passes

### DIFF
--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-import os
 import warnings
 
 import pytest
@@ -28,8 +27,6 @@ def constant(*args, **kwargs):
 
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.skipif('CUDA_TEST' in os.environ,
-                                reason='https://github.com/uber/pyro/issues/1419')
 
 
 def test_simple():


### PR DESCRIPTION
Resolves #1419

These tests must have been fixed by recent jit fixes in Pyro and PyTorch.

## Tested

- ran locally with PyTorch nightly, cuda 9.0