### PR TITLE
Bump opt_einsum to 2.3.2, remove patch

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,5 @@ cloudpickle>=0.3.1
 graphviz>=0.8
 networkx>=2.2
 observations>=0.1.4
-opt_einsum>=2.3.0
+opt_einsum>=2.3.2
 tqdm>=4.25

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-import opt_einsum
 import torch
 
 if 'READTHEDOCS' not in os.environ:
@@ -83,24 +82,6 @@ def _einsum(equation, *operands):
         return (x.unsqueeze(1) * y).sum(0).transpose(0, 1)
 
     return _einsum._pyro_unpatched(equation, *operands)
-
-
-# This can be removed after https://github.com/dgasmith/opt_einsum/pull/77 is released.
-@patch_dependency('opt_einsum.helpers.compute_size_by_dict', opt_einsum)
-def _compute_size_by_dict(indices, idx_dict):
-    if torch._C._get_tracing_state():
-        # If running under the jit, convert all sizes from tensors to ints, the
-        # first time each idx_dict is seen.
-        last_idx_dict = getattr(_compute_size_by_dict, '_last_idx_dict', None)
-        if idx_dict is not last_idx_dict:
-            _compute_size_by_dict._last_idx_dict = idx_dict
-            for key, value in idx_dict.items():
-                idx_dict[key] = int(value)
-
-    ret = 1
-    for i in indices:
-        ret *= idx_dict[i]
-    return ret
 
 
 __all__ = []

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'graphviz>=0.8',
         'networkx>=2.2',
         'numpy>=1.7',
-        'opt_einsum>=2.3.0',
+        'opt_einsum>=2.3.2',
         'six>=1.10.0',
         'torch>=1.0.0',
         'tqdm>=4.28',


### PR DESCRIPTION
This removes the patch for https://github.com/dgasmith/opt_einsum/pull/77 needed to jit einsum contractions.