### PR TITLE
Enable all slow hmc jit tests

### DIFF
--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -191,9 +191,7 @@ def test_logistic_regression(step_size, trajectory_length, num_steps,
     assert_equal(rmse(true_coefs, beta_posterior.mean).item(), 0.0, prec=0.1)
 
 
-@pytest.mark.parametrize("jit", [False, mark_jit(True, marks=[
-    pytest.mark.skip(reason="https://github.com/uber/pyro/issues/1487")])],
-                         ids=jit_idfn)
+@pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
 def test_dirichlet_categorical(jit):
     def model(data):
         concentration = torch.tensor([1.0, 1.0, 1.0])
@@ -228,9 +226,7 @@ def test_beta_bernoulli(jit):
     assert_equal(posterior.mean, true_probs, prec=0.05)
 
 
-@pytest.mark.parametrize("jit", [False, mark_jit(True, marks=[
-    pytest.mark.skip(reason="https://github.com/uber/pyro/issues/1487")])],
-                         ids=jit_idfn)
+@pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
 def test_gamma_normal(jit):
     def model(data):
         rate = torch.tensor([1.0, 1.0])

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -180,8 +180,7 @@ def test_beta_bernoulli(step_size, adapt_step_size, adapt_mass_matrix, full_mass
     assert_equal(posterior.mean, true_probs, prec=0.02)
 
 
-@pytest.mark.parametrize("jit", [False, mark_jit(True, marks=[pytest.mark.skip("Doesn't finish")])],
-                         ids=jit_idfn)
+@pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
 @pytest.mark.parametrize("use_multinomial_sampling", [True, False])
 def test_gamma_normal(jit, use_multinomial_sampling):
     def model(data):
@@ -235,10 +234,7 @@ def test_gamma_beta(jit):
     assert_equal(posterior['beta'].mean, true_beta, prec=0.05)
 
 
-@pytest.mark.parametrize("jit", [False,
-                                 mark_jit(True, marks=[pytest.mark.skip(
-                                     "https://github.com/uber/pyro/issues/1487")])],
-                         ids=jit_idfn)
+@pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
 def test_gaussian_mixture_model(jit):
     K, N = 3, 1000
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -80,7 +80,7 @@ CUDA_EXAMPLES = [
 
 def xfail_jit(*args):
     return pytest.param(*args, marks=[pytest.mark.xfail(reason="not jittable"),
-                                      pytest.mark.skipif('CI' in os.eniron, reason='slow test')])
+                                      pytest.mark.skipif('CI' in os.environ, reason='slow test')])
 
 
 JIT_EXAMPLES = [

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -80,7 +80,7 @@ CUDA_EXAMPLES = [
 
 def xfail_jit(*args):
     return pytest.param(*args, marks=[pytest.mark.xfail(reason="not jittable"),
-                                      pytest.mark.skipif('CI' in os.environ, reason='slow test')])
+                                      pytest.mark.skipif('CI' in os.eniron, reason='slow test')])
 
 
 JIT_EXAMPLES = [
@@ -91,8 +91,7 @@ JIT_EXAMPLES = [
     xfail_jit('contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --jit'),
     xfail_jit('dmm/dmm.py --num-epochs=1 --jit'),
     xfail_jit('dmm/dmm.py --num-epochs=1 --num-iafs=1 --jit'),
-    skipif_param('eight_schools/mcmc.py --num-samples=500 --warmup-steps=100 --jit',
-                 condition=True, reason='very slow test'),
+    'eight_schools/mcmc.py --num-samples=500 --warmup-steps=100 --jit',
     'eight_schools/svi.py --num-epochs=1 --jit',
     'hmm.py --num-steps=1 --truncate=10 --model=1 --jit',
     'hmm.py --num-steps=1 --truncate=10 --model=2 --jit',


### PR DESCRIPTION
Fixes #1487. 

The issue https://github.com/pytorch/pytorch/issues/13669 has been fixed in pytorch release. Now we can enable many failed jit tests of hmc/nuts.

Thanks @apaszke !