### PR TITLE
Refactor polyphonic data loader to load other music datasets

### DIFF
--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -271,7 +271,7 @@ def main(args):
     log = get_logger(args.log)
     log(args)
 
-    data = poly.load_data()
+    data = poly.load_data(poly.JSB_CHORALES)
     training_seq_lengths = data['train']['sequence_lengths']
     training_data_sequences = data['train']['sequences']
     test_seq_lengths = data['test']['sequence_lengths']

--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -279,12 +279,12 @@ def main(args):
     val_seq_lengths = data['valid']['sequence_lengths']
     val_data_sequences = data['valid']['sequences']
     N_train_data = len(training_seq_lengths)
-    N_train_time_slices = float(np.sum(training_seq_lengths))
+    N_train_time_slices = float(torch.sum(training_seq_lengths))
     N_mini_batches = int(N_train_data / args.mini_batch_size +
                          int(N_train_data % args.mini_batch_size > 0))
 
     log("N_train_data: %d     avg. training seq. length: %.2f    N_mini_batches: %d" %
-        (N_train_data, np.mean(training_seq_lengths), N_mini_batches))
+        (N_train_data, training_seq_lengths.float().mean(), N_mini_batches))
 
     # how often we do validation/test evaluation during training
     val_test_frequency = 50
@@ -294,17 +294,19 @@ def main(args):
     # package repeated copies of val/test data for faster evaluation
     # (i.e. set us up for vectorization)
     def rep(x):
-        y = np.repeat(x, n_eval_samples, axis=0)
-        return y
+        rep_shape = torch.Size([x.size(0) * n_eval_samples]) + x.size()[1:]
+        repeat_dims = [1] * len(x.size())
+        repeat_dims[0] = n_eval_samples
+        return x.repeat(repeat_dims).reshape(n_eval_samples, -1).transpose(1, 0).reshape(rep_shape)
 
     # get the validation/test data ready for the dmm: pack into sequences, etc.
     val_seq_lengths = rep(val_seq_lengths)
     test_seq_lengths = rep(test_seq_lengths)
     val_batch, val_batch_reversed, val_batch_mask, val_seq_lengths = poly.get_mini_batch(
-        np.arange(n_eval_samples * val_data_sequences.shape[0]), rep(val_data_sequences),
+        torch.arange(n_eval_samples * val_data_sequences.shape[0]), rep(val_data_sequences),
         val_seq_lengths, cuda=args.cuda)
     test_batch, test_batch_reversed, test_batch_mask, test_seq_lengths = poly.get_mini_batch(
-        np.arange(n_eval_samples * test_data_sequences.shape[0]), rep(test_data_sequences),
+        torch.arange(n_eval_samples * test_data_sequences.shape[0]), rep(test_data_sequences),
         test_seq_lengths, cuda=args.cuda)
 
     # instantiate the dmm
@@ -374,9 +376,9 @@ def main(args):
 
         # compute the validation and test loss n_samples many times
         val_nll = svi.evaluate_loss(val_batch, val_batch_reversed, val_batch_mask,
-                                    val_seq_lengths) / np.sum(val_seq_lengths)
+                                    val_seq_lengths) / torch.sum(val_seq_lengths)
         test_nll = svi.evaluate_loss(test_batch, test_batch_reversed, test_batch_mask,
-                                     test_seq_lengths) / np.sum(test_seq_lengths)
+                                     test_seq_lengths) / torch.sum(test_seq_lengths)
 
         # put the RNN back into training mode (i.e. turn on drop-out if applicable)
         dmm.rnn.train()
@@ -398,8 +400,7 @@ def main(args):
         # accumulator for our estimate of the negative log likelihood (or rather -elbo) for this epoch
         epoch_nll = 0.0
         # prepare mini-batch subsampling indices for this epoch
-        shuffled_indices = np.arange(N_train_data)
-        np.random.shuffle(shuffled_indices)
+        shuffled_indices = torch.randperm(N_train_data)
 
         # process each mini-batch; this is where we take gradient steps
         for which_mini_batch in range(N_mini_batches):

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -149,7 +149,7 @@ def get_mini_batch(mini_batch_indices, sequences, seq_lengths, cuda=False):
     # this is the sorted mini-batch
     mini_batch = sequences[sorted_mini_batch_indices, 0:T_max, :]
     # this is the sorted mini-batch in reverse temporal order
-    mini_batch_reversed = reverse_sequences_torch(mini_batch, sorted_seq_lengths)
+    mini_batch_reversed = reverse_sequences(mini_batch, sorted_seq_lengths)
     # get mask for mini-batch
     mini_batch_mask = get_mini_batch_mask(mini_batch, sorted_seq_lengths)
 

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -16,7 +16,7 @@ und Kognitive Systeme at Universitaet Karlsruhe.
 import os
 import urllib
 from collections import namedtuple
-from urllib.request import urlopen
+from six.moves.urllib.request import urlopen
 
 import numpy as np
 import six.moves.cPickle as pickle

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -102,10 +102,8 @@ def load_data(dataset):
 
 
 # this function takes a torch mini-batch and reverses each sequence
-# (w.r.t. the temporal axis, i.e. axis=1)
-# in contrast to `reverse_sequences_numpy`, this function plays
-# nice with torch autograd
-def reverse_sequences_torch(mini_batch, seq_lengths):
+# (w.r.t. the temporal axis, i.e. axis=1).
+def reverse_sequences(mini_batch, seq_lengths):
     reversed_mini_batch = mini_batch.new_zeros(mini_batch.size())
     for b in range(mini_batch.size(0)):
         T = seq_lengths[b]
@@ -119,7 +117,7 @@ def reverse_sequences_torch(mini_batch, seq_lengths):
 # unpacks it it; it also reverses each sequence temporally
 def pad_and_reverse(rnn_output, seq_lengths):
     rnn_output, _ = nn.utils.rnn.pad_packed_sequence(rnn_output, batch_first=True)
-    reversed_output = reverse_sequences_torch(rnn_output, seq_lengths)
+    reversed_output = reverse_sequences(rnn_output, seq_lengths)
     return reversed_output
 
 

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -14,7 +14,6 @@ und Kognitive Systeme at Universitaet Karlsruhe.
 """
 
 import os
-import urllib
 from collections import namedtuple
 from six.moves.urllib.request import urlopen
 
@@ -58,10 +57,7 @@ def process_data(base_path, dataset, min_note=21, note_range=88):
             os.remove(output)
 
     print("processing raw data - {} ...".format(dataset.name))
-    try:
-        data = pickle.load(urlopen(dataset.url))
-    except urllib.HTTPError as e:
-        print(e.fp.read())
+    data = pickle.load(urlopen(dataset.url))
     processed_dataset = {}
     for split, data_split in data.items():
         processed_dataset[split] = {}
@@ -86,12 +82,12 @@ def process_data(base_path, dataset, min_note=21, note_range=88):
 base_path = get_data_directory(__file__)
 if not os.path.exists(base_path):
     os.mkdir(base_path)
-for dset in (JSB_CHORALES, MUSE_DATA, PIANO_MIDI, NOTTINGHAM):
-    process_data(base_path, dset)
 
 
 # ingest training/validation/test data from disk
 def load_data(dataset):
+    # download and process dataset if it does not exist
+    process_data(base_path, dataset)
     file_loc = os.path.join(base_path, dataset.filename)
     with open(file_loc, "rb") as f:
         dset = pickle.load(f)

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -18,41 +18,35 @@ import urllib
 from collections import namedtuple
 from six.moves.urllib.request import urlopen
 
-import numpy as np
 import six.moves.cPickle as pickle
 import torch
 import torch.nn as nn
+from torch.nn.utils.rnn import pad_sequence
 
 from pyro.contrib.examples.util import get_data_directory
 
 
-dset = namedtuple("dset", ["name", "url", "filename", "t_max"])
+dset = namedtuple("dset", ["name", "url", "filename"])
 
 JSB_CHORALES = dset("jsb_chorales",
                     "https://d2fefpcigoriu7.cloudfront.net/datasets/polyphonic/jsb_chorales.pickle",
-                    "jsb_chorales.pkl",
-                    160)
+                    "jsb_chorales.pkl")
 
 PIANO_MIDI = dset("piano_midi",
                   "https://d2fefpcigoriu7.cloudfront.net/datasets/polyphonic/piano_midi.pickle",
-                  "piano_midi.pkl",
-                  3857)
+                  "piano_midi.pkl")
 
-# FIXME: t_max is too large for pickle.dump
 MUSE_DATA = dset("muse_data",
                  "https://d2fefpcigoriu7.cloudfront.net/datasets/polyphonic/muse_data.pickle",
-                 "muse_data.pkl",
-                 4273)
+                 "muse_data.pkl")
 
 NOTTINGHAM = dset("nottingham",
                   "https://d2fefpcigoriu7.cloudfront.net/datasets/polyphonic/nottingham.pickle",
-                  "nottingham.pkl",
-                  1793)
+                  "nottingham.pkl")
 
 
 # this function processes the raw data; in particular it unsparsifies it
 def process_data(base_path, dataset, min_note=21, note_range=88):
-    t_max = dataset.t_max
     output = os.path.join(base_path, dataset.filename)
     if os.path.exists(output):
         try:
@@ -72,16 +66,18 @@ def process_data(base_path, dataset, min_note=21, note_range=88):
     for split, data_split in data.items():
         processed_dataset[split] = {}
         n_seqs = len(data_split)
-        processed_dataset[split]['sequence_lengths'] = np.zeros((n_seqs), dtype=np.int32)
-        processed_dataset[split]['sequences'] = np.zeros((n_seqs, t_max, note_range))
+        processed_dataset[split]['sequence_lengths'] = torch.zeros(n_seqs, dtype=torch.long)
+        processed_dataset[split]['sequences'] = []
         for seq in range(n_seqs):
             seq_length = len(data_split[seq])
             processed_dataset[split]['sequence_lengths'][seq] = seq_length
+            processed_sequence = torch.zeros((seq_length, note_range))
             for t in range(seq_length):
-                note_slice = np.array(list(data_split[seq][t])) - min_note
+                note_slice = torch.tensor(list(data_split[seq][t])) - min_note
                 slice_length = len(note_slice)
                 if slice_length > 0:
-                    processed_dataset[split]['sequences'][seq, t, note_slice] = np.ones((slice_length))
+                    processed_sequence[t, note_slice] = torch.ones(slice_length)
+            processed_dataset[split]['sequences'].append(processed_sequence)
     pickle.dump(processed_dataset, open(output, "wb"), pickle.HIGHEST_PROTOCOL)
     print("dumped processed data to %s" % output)
 
@@ -90,7 +86,7 @@ def process_data(base_path, dataset, min_note=21, note_range=88):
 base_path = get_data_directory(__file__)
 if not os.path.exists(base_path):
     os.mkdir(base_path)
-for dset in (JSB_CHORALES, PIANO_MIDI, NOTTINGHAM):
+for dset in (JSB_CHORALES, MUSE_DATA, PIANO_MIDI, NOTTINGHAM):
     process_data(base_path, dset)
 
 
@@ -98,17 +94,11 @@ for dset in (JSB_CHORALES, PIANO_MIDI, NOTTINGHAM):
 def load_data(dataset):
     file_loc = os.path.join(base_path, dataset.filename)
     with open(file_loc, "rb") as f:
-        return pickle.load(f)
-
-
-# this function takes a numpy mini-batch and reverses each sequence
-# (w.r.t. the temporal axis, i.e. axis=1)
-def reverse_sequences_numpy(mini_batch, seq_lengths):
-    reversed_mini_batch = mini_batch.copy()
-    for b in range(mini_batch.shape[0]):
-        T = seq_lengths[b]
-        reversed_mini_batch[b, 0:T, :] = mini_batch[b, (T - 1)::-1, :]
-    return reversed_mini_batch
+        dset = pickle.load(f)
+        for k, v in dset.items():
+            sequences = v["sequences"]
+            dset[k]["sequences"] = pad_sequence(sequences, batch_first=True).type(torch.Tensor)
+    return dset
 
 
 # this function takes a torch mini-batch and reverses each sequence
@@ -119,9 +109,7 @@ def reverse_sequences_torch(mini_batch, seq_lengths):
     reversed_mini_batch = mini_batch.new_zeros(mini_batch.size())
     for b in range(mini_batch.size(0)):
         T = seq_lengths[b]
-        time_slice = np.arange(T - 1, -1, -1)
-        time_slice = torch.cuda.LongTensor(time_slice) if 'cuda' in mini_batch.data.type() \
-            else torch.LongTensor(time_slice)
+        time_slice = torch.arange(T - 1, -1, -1, device=mini_batch.device)
         reversed_sequence = torch.index_select(mini_batch[b, :, :], 0, time_slice)
         reversed_mini_batch[b, 0:T, :] = reversed_sequence
     return reversed_mini_batch
@@ -138,9 +126,9 @@ def pad_and_reverse(rnn_output, seq_lengths):
 # this function returns a 0/1 mask that can be used to mask out a mini-batch
 # composed of sequences of length `seq_lengths`
 def get_mini_batch_mask(mini_batch, seq_lengths):
-    mask = np.zeros(mini_batch.shape[0:2])
+    mask = torch.zeros(mini_batch.shape[0:2])
     for b in range(mini_batch.shape[0]):
-        mask[b, 0:seq_lengths[b]] = np.ones(seq_lengths[b])
+        mask[b, 0:seq_lengths[b]] = torch.ones(seq_lengths[b])
     return mask
 
 
@@ -153,23 +141,19 @@ def get_mini_batch(mini_batch_indices, sequences, seq_lengths, cuda=False):
     # get the sequence lengths of the mini-batch
     seq_lengths = seq_lengths[mini_batch_indices]
     # sort the sequence lengths
-    sorted_seq_length_indices = np.argsort(seq_lengths)[::-1]
+    _, sorted_seq_length_indices = torch.sort(seq_lengths)
+    sorted_seq_length_indices = sorted_seq_length_indices.flip(0)
     sorted_seq_lengths = seq_lengths[sorted_seq_length_indices]
     sorted_mini_batch_indices = mini_batch_indices[sorted_seq_length_indices]
 
     # compute the length of the longest sequence in the mini-batch
-    T_max = np.max(seq_lengths)
+    T_max = torch.max(seq_lengths)
     # this is the sorted mini-batch
     mini_batch = sequences[sorted_mini_batch_indices, 0:T_max, :]
     # this is the sorted mini-batch in reverse temporal order
-    mini_batch_reversed = reverse_sequences_numpy(mini_batch, sorted_seq_lengths)
+    mini_batch_reversed = reverse_sequences_torch(mini_batch, sorted_seq_lengths)
     # get mask for mini-batch
     mini_batch_mask = get_mini_batch_mask(mini_batch, sorted_seq_lengths)
-
-    # wrap in PyTorch Tensors, using default tensor type
-    mini_batch = torch.tensor(mini_batch).type(torch.Tensor)
-    mini_batch_reversed = torch.tensor(mini_batch_reversed).type(torch.Tensor)
-    mini_batch_mask = torch.tensor(mini_batch_mask).type(torch.Tensor)
 
     # cuda() here because need to cuda() before packing
     if cuda:

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -414,7 +414,7 @@ def main(args):
         torch.set_default_tensor_type('torch.cuda.FloatTensor')
 
     logging.info('Loading data')
-    data = poly.load_data()
+    data = poly.load_data(poly.JSB_CHORALES)
 
     logging.info('-' * 40)
     model = models[args.model]

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -414,14 +414,14 @@ def main(args):
         torch.set_default_tensor_type('torch.cuda.FloatTensor')
 
     logging.info('Loading data')
-    data = poly.load_data(poly.JSB_CHORALES)
+    data = poly.load_data(poly.MUSE_DATA)
 
     logging.info('-' * 40)
     model = models[args.model]
     logging.info('Training {} on {} sequences'.format(
         model.__name__, len(data['train']['sequences'])))
-    sequences = torch.tensor(data['train']['sequences'], dtype=torch.float32)
-    lengths = torch.tensor(data['train']['sequence_lengths'], dtype=torch.long)
+    sequences = data['train']['sequences']
+    lengths = data['train']['sequence_lengths']
 
     # find all the notes that are present at least once in the training set
     present_notes = ((sequences == 1).sum(0).sum(0) > 0)
@@ -475,8 +475,8 @@ def main(args):
     # Finally we evaluate on the test dataset.
     logging.info('-' * 40)
     logging.info('Evaluating on {} test sequences'.format(len(data['test']['sequences'])))
-    sequences = torch.tensor(data['test']['sequences'], dtype=torch.float32)[..., present_notes]
-    lengths = torch.tensor(data['test']['sequence_lengths'], dtype=torch.long)
+    sequences = data['test']['sequences'][..., present_notes]
+    lengths = data['test']['sequence_lengths']
     if args.truncate:
         lengths.clamp_(max=args.truncate)
     num_observations = float(lengths.sum())

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -414,7 +414,7 @@ def main(args):
         torch.set_default_tensor_type('torch.cuda.FloatTensor')
 
     logging.info('Loading data')
-    data = poly.load_data(poly.MUSE_DATA)
+    data = poly.load_data(poly.JSB_CHORALES)
 
     logging.info('-' * 40)
     model = models[args.model]


### PR DESCRIPTION
Tasks:
 - [x] Ensure that muse data can be pickled efficiently. Currently pickling the entire numpy array consumes more than 4GB and breaks. Resolved - dumping the sequences and constructing the full dense representation on load.
 - [x] Check that DMM, HMM examples run giving similar / same results as earlier.
 - [x] Test examples on CUDA to ensure that refactoring has not broken CUDA compatibility.
