### PR TITLE
Fix bug in initial trace setter in HMC

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -310,7 +310,7 @@ class HMC(TraceKernel):
             if not torch_isnan(trace_log_prob_sum) and not torch_isinf(trace_log_prob_sum):
                 self._initial_trace = trace
                 return trace
-            trace = poutine.trace(self.model).get_trace(self._args, self._kwargs)
+            trace = poutine.trace(self.model).get_trace(*self._args, **self._kwargs)
         raise ValueError("Model specification seems incorrect - cannot find a valid trace.")
 
     @initial_trace.setter

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -23,6 +23,9 @@ import pyro.ops.stats as stats
 from pyro.util import optional
 
 
+MAX_SEED = 2**32 - 1
+
+
 def logger_thread(log_queue, warmup_steps, num_samples, num_chains, disable_progbar=False):
     """
     Logging thread that asynchronously consumes logging events from `log_queue`,
@@ -77,7 +80,7 @@ class _Worker(object):
         self.default_tensor_type = torch.Tensor().type()
 
     def run(self, *args, **kwargs):
-        pyro.set_rng_seed(self.chain_id + self.rng_seed)
+        pyro.set_rng_seed((self.chain_id + self.rng_seed) % MAX_SEED)
         torch.set_default_tensor_type(self.default_tensor_type)
         kwargs["logger_id"] = "CHAIN:{}".format(self.chain_id)
         kwargs["log_queue"] = self.log_queue


### PR DESCRIPTION
 - Fixes a bug in HMC initial trace setting loop. We didn't hit upon this bug because none of our tests / examples gave an initial trace with NaN/Inf values and hence this wasn't tested. Added a small test by mocking the log prob computation so that this code path is exercised.
 - Also, fixes an issue with multiprocessing so that the rng seed is restricted to the interval [0, 2**32-1] which is required in numpy.