### PR TITLE
Resolve the slowness of HMC during init adaptation phase

### DIFF
--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -2,6 +2,7 @@ import math
 import torch
 from collections import namedtuple
 
+import pyro
 import pyro.distributions as dist
 from pyro.ops.dual_averaging import DualAveraging
 from pyro.ops.welford import WelfordCovariance
@@ -31,7 +32,6 @@ class WarmupAdapter(object):
         self._adaptation_disabled = not (adapt_step_size or adapt_mass_matrix)
         if adapt_step_size:
             self._step_size_adapt_scheme = DualAveraging()
-            self._reset_step_size_adaptation()
         if adapt_mass_matrix:
             self._mass_matrix_adapt_scheme = WelfordCovariance(diagonal=is_diag_mass)
 
@@ -86,7 +86,12 @@ class WarmupAdapter(object):
                                                 self._warmup_steps - 1))
         return adaptation_schedule
 
-    def _reset_step_size_adaptation(self):
+    def reset_step_size_adaptation(self):
+        r"""
+        Finds a reasonable step size and resets step size adaptation scheme.
+        """
+        with pyro.validation_enabled(False):
+            self.step_size = self._find_reasonable_step_size()
         self._step_size_adapt_scheme.prox_center = math.log(10 * self.step_size)
         self._step_size_adapt_scheme.reset()
 
@@ -122,6 +127,8 @@ class WarmupAdapter(object):
         self._warmup_steps = warmup_steps
         if initial_step_size is not None:
             self.step_size = initial_step_size
+        if find_reasonable_step_size_fn is not None:
+            self._find_reasonable_step_size = find_reasonable_step_size_fn
         if inv_mass_matrix is not None:
             self.inverse_mass_matrix = inv_mass_matrix
         if self.inverse_mass_matrix is None or self.step_size is None:
@@ -129,8 +136,6 @@ class WarmupAdapter(object):
                              "need to be initialized.")
         if not self._adaptation_disabled:
             self._adaptation_schedule = self._build_adaptation_schedule()
-        if find_reasonable_step_size_fn is not None:
-            self._find_reasonable_step_size_fn = find_reasonable_step_size_fn
 
     def step(self, t, z, accept_prob):
         r"""
@@ -165,10 +170,7 @@ class WarmupAdapter(object):
             if mass_matrix_adaptation_phase:
                 self.inverse_mass_matrix = self._mass_matrix_adapt_scheme.get_covariance()
                 if self.adapt_step_size:
-                    self.step_size = self._find_reasonable_step_size_fn(z)
-
-            if self.adapt_step_size:
-                self._reset_step_size_adaptation()
+                    self.reset_step_size_adaptation()
 
             self._current_window += 1
 

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -90,8 +90,9 @@ class WarmupAdapter(object):
         r"""
         Finds a reasonable step size and resets step size adaptation scheme.
         """
-        with pyro.validation_enabled(False):
-            self.step_size = self._find_reasonable_step_size()
+        if self._find_reasonable_step_size is not None:
+            with pyro.validation_enabled(False):
+                self.step_size = self._find_reasonable_step_size()
         self._step_size_adapt_scheme.prox_center = math.log(10 * self.step_size)
         self._step_size_adapt_scheme.reset()
 
@@ -123,6 +124,8 @@ class WarmupAdapter(object):
         :param warmup_steps: Number of warmup steps that the sampler is initialized with.
         :param initial_step_size: Step size to use to initialize the Dual Averaging scheme.
         :param inv_mass_matrix: Initial value of the inverse mass matrix.
+        :param find_reasonable_step_size_fn: A callable to find reasonable step size when
+            mass matrix is changed.
         """
         self._warmup_steps = warmup_steps
         if initial_step_size is not None:

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -387,7 +387,6 @@ class HMC(TraceKernel):
                                                                               z_grads=z_grads)
             # apply Metropolis correction.
             energy_proposal = self._kinetic_energy(r_new) + potential_energy_new
-
         delta_energy = energy_proposal - energy_current
         # Set accept prob to 0.0 if delta_energy is `NaN` which may be
         # the case for a diverging trajectory when using a large step size.
@@ -407,6 +406,7 @@ class HMC(TraceKernel):
         self._t += 1
 
         # get trace with the constrained values for `z`.
+        z = z.copy()
         for name, transform in self.transforms.items():
             z[name] = transform.inv(z[name])
         return self._get_trace(z)

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -104,10 +104,8 @@ class HMC(TraceKernel):
             self.trajectory_length = step_size * num_steps
         else:
             self.trajectory_length = 2 * math.pi  # from Stan
-        self.adapt_step_size = adapt_step_size
         self._jit_compile = jit_compile
         self._ignore_jit_warnings = ignore_jit_warnings
-        self.full_mass = full_mass
         self._target_accept_prob = 0.8  # from Stan
         # The following parameter is used in find_reasonable_step_size method.
         # In NUTS paper, this threshold is set to a fixed log(0.5).
@@ -142,15 +140,11 @@ class HMC(TraceKernel):
         return self._trace_prob_evaluator.log_prob(model_trace)
 
     def _kinetic_energy(self, r):
-        # TODO: revert to `torch.dot` in pytorch==1.0
-        # See: https://github.com/uber/pyro/issues/1458
         r_flat = torch.cat([r[site_name].reshape(-1) for site_name in sorted(r)])
-        if self.full_mass:
-            return 0.5 * (r_flat * (self.inverse_mass_matrix.matmul(r_flat))).sum()
+        if self.inverse_mass_matrix.dim() == 2:
+            return 0.5 * self.inverse_mass_matrix.matmul(r_flat).dot(r_flat)
         else:
-            k = 0.5 * (self.inverse_mass_matrix * (r_flat ** 2)).sum()
-            #print("kinetic energy", k)
-            return k
+            return 0.5 * self.inverse_mass_matrix.dot(r_flat ** 2)
 
     def _potential_energy(self, z):
         if self._jit_compile:
@@ -194,10 +188,7 @@ class HMC(TraceKernel):
         return self._compiled_potential_fn(*vals)
 
     def _energy(self, z, r):
-        k = self._kinetic_energy(r)
-        p = self._potential_energy(z)
-        #print("energy", k, p, k+p)
-        return k + p
+        return self._kinetic_energy(r) + self._potential_energy(z)
 
     def _reset(self):
         self._t = 0
@@ -210,21 +201,23 @@ class HMC(TraceKernel):
         self._initial_trace = None
         self._has_enumerable_sites = False
         self._trace_prob_evaluator = None
+        self._z_last = None
         self._potential_energy_last = None
         self._z_grads_last = None
         self._warmup_steps = None
 
-    def _find_reasonable_step_size(self, z):
+    def _find_reasonable_step_size(self):
         step_size = self.step_size
 
         # We are going to find a step_size which make accept_prob (Metropolis correction)
         # near the target_accept_prob. If accept_prob:=exp(-delta_energy) is small,
         # then we have to decrease step_size; otherwise, increase step_size.
+        z, potential_energy, z_grads = self._fetch_from_cache()
         r, _ = self._sample_r(name="r_presample_0")
-        energy_current = self._energy(z, r)
-        z_new, r_new, z_grads, potential_energy = velocity_verlet(
-            z, r, self._potential_energy, self.inverse_mass_matrix, step_size)
-        energy_new = potential_energy + self._kinetic_energy(r_new)
+        energy_current = self._kinetic_energy(r) + potential_energy
+        z_new, r_new, z_grads_new, potential_energy_new = velocity_verlet(
+            z, r, self._potential_energy, self.inverse_mass_matrix, step_size, z_grads=z_grads)
+        energy_new = self._kinetic_energy(r_new) + potential_energy_new
         delta_energy = energy_new - energy_current
         # direction=1 means keep increasing step_size, otherwise decreasing step_size.
         # Note that the direction is -1 if delta_energy is `NaN` which may be the
@@ -242,14 +235,11 @@ class HMC(TraceKernel):
             t += 1
             step_size = step_size_scale * step_size
             r, _ = self._sample_r(name="r_presample_{}".format(t))
-            #print("presample", t, r)
-            energy_current = self._energy(z, r)
-            z_new, r_new, z_grads, potential_energy = velocity_verlet(
-                z, r, self._potential_energy, self.inverse_mass_matrix, step_size)
-            energy_new = potential_energy + self._kinetic_energy(r_new)
+            energy_current = self._kinetic_energy(r) + potential_energy
+            z_new, r_new, z_grads_new, potential_energy_new = velocity_verlet(
+                z, r, self._potential_energy, self.inverse_mass_matrix, step_size, z_grads=z_grads)
+            energy_new = self._kinetic_energy(r_new) + potential_energy_new
             delta_energy = energy_new - energy_current
-            #print("delta_energy", delta_energy, energy_current)
-            #print("=" * 20)
             direction_new = 1 if self._direction_threshold < -delta_energy else -1
         return step_size
 
@@ -270,20 +260,6 @@ class HMC(TraceKernel):
                 for frame in site["cond_indep_stack"]
                 if frame.vectorized]
         self.max_plate_nesting = -min(dims) if dims else 0
-
-    def _configure_adaptation(self):
-        initial_step_size = None
-        if self.adapt_step_size:
-            z = {name: node["value"].detach() for name, node in self._iter_latent_nodes(self.initial_trace)}
-            #print("in configure", z)
-            for name, transform in self.transforms.items():
-                z[name] = transform(z[name])
-            with pyro.validation_enabled(False):
-                initial_step_size = self._find_reasonable_step_size(z)
-
-        self._adapter.configure(self._warmup_steps,
-                                initial_step_size,
-                                find_reasonable_step_size_fn=self._find_reasonable_step_size)
 
     def _sample_r(self, name):
         r_dist = self._adapter.r_dist
@@ -321,13 +297,10 @@ class HMC(TraceKernel):
         trace = poutine.trace(self.model).get_trace(*self._args, **self._kwargs)
         for i in range(self._max_tries_initial_trace):
             trace_log_prob_sum = self._compute_trace_log_prob(trace)
-            z = {name: node["value"].detach() for name, node in self._iter_latent_nodes(trace)}
-            #print("in configure", z)
-            #print(trace_log_prob_sum)
             if not torch_isnan(trace_log_prob_sum) and not torch_isinf(trace_log_prob_sum):
                 self._initial_trace = trace
                 return trace
-            trace = poutine.trace(self.model).get_trace(self._args, self._kwargs)
+            trace = poutine.trace(self.model).get_trace(*self._args, *self._kwargs)
         raise ValueError("Model specification seems incorrect - cannot find a valid trace.")
 
     @initial_trace.setter
@@ -360,38 +333,50 @@ class HMC(TraceKernel):
                                                           self._has_enumerable_sites,
                                                           self.max_plate_nesting)
         mass_matrix_size = sum(self._r_numels.values())
-        if self.full_mass:
-            initial_mass_matrix = eye_like(site_value, mass_matrix_size)
-        else:
+        if self._adapter.is_diag_mass:
             initial_mass_matrix = site_value.new_ones(mass_matrix_size)
-        self._adapter.inverse_mass_matrix = initial_mass_matrix
+        else:
+            initial_mass_matrix = eye_like(site_value, mass_matrix_size)
+        self._adapter.configure(self._warmup_steps,
+                                inv_mass_matrix=initial_mass_matrix,
+                                find_reasonable_step_size_fn=self._find_reasonable_step_size)
+
+    def _initialize_sampling(self, trace):
+        z = {name: node["value"].detach() for name, node in self._iter_latent_nodes(trace)}
+        # automatically transform `z` to unconstrained space, if needed.
+        for name, transform in self.transforms.items():
+            z[name] = transform(z[name])
+        potential_energy = self._potential_energy(z)
+        self._cache(z, potential_energy, None)
+        if self._adapter.adapt_step_size:
+            self._adapter.reset_step_size_adaptation()
 
     def setup(self, warmup_steps, *args, **kwargs):
         self._warmup_steps = warmup_steps
         self._args = args
         self._kwargs = kwargs
         self._initialize_model_properties()
-        self._configure_adaptation()
 
     def cleanup(self):
         self._reset()
 
-    def _cache(self, potential_energy, z_grads):
+    def _cache(self, z, potential_energy, z_grads):
+        self._z_last = z
         self._potential_energy_last = potential_energy
         self._z_grads_last = z_grads
 
     def _fetch_from_cache(self):
-        return self._potential_energy_last, self._z_grads_last
+        return self._z_last, self._potential_energy_last, self._z_grads_last
 
     def sample(self, trace):
-        z = {name: node["value"].detach() for name, node in self._iter_latent_nodes(trace)}
-        # automatically transform `z` to unconstrained space, if needed.
-        for name, transform in self.transforms.items():
-            z[name] = transform(z[name])
+        if self._t == 0:
+            # cache for initial trace and reset step size adaptation
+            self._initialize_sampling(trace)
 
+        z, potential_energy, z_grads = self._fetch_from_cache()
         r, _ = self._sample_r(name="r_t={}".format(self._t))
+        energy_current = self._kinetic_energy(r) + potential_energy
 
-        potential_energy, z_grads = self._fetch_from_cache()
         # Temporarily disable distributions args checking as
         # NaNs are expected during step size adaptation
         with optional(pyro.validation_enabled(False), self._t < self._warmup_steps):
@@ -402,8 +387,7 @@ class HMC(TraceKernel):
                                                                               z_grads=z_grads)
             # apply Metropolis correction.
             energy_proposal = self._kinetic_energy(r_new) + potential_energy_new
-            energy_current = self._kinetic_energy(r) + potential_energy if potential_energy is not None \
-                else self._energy(z, r)
+
         delta_energy = energy_proposal - energy_current
         # Set accept prob to 0.0 if delta_energy is `NaN` which may be
         # the case for a diverging trajectory when using a large step size.
@@ -415,7 +399,7 @@ class HMC(TraceKernel):
         if rand < accept_prob:
             self._accept_cnt += 1
             z = z_new
-            self._cache(potential_energy_new, z_grads_new)
+            self._cache(z, potential_energy_new, z_grads_new)
 
         if self._t < self._warmup_steps:
             self._adapter.step(self._t, z, accept_prob)

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -306,6 +306,8 @@ class HMC(TraceKernel):
     @initial_trace.setter
     def initial_trace(self, trace):
         self._initial_trace = trace
+        if self._warmup_steps is not None:  # if setup is already called
+            self._initialize_step_size()
 
     def _initialize_model_properties(self):
         if self.max_plate_nesting is None:

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -224,7 +224,7 @@ class HMC(TraceKernel):
         # case for a diverging trajectory (e.g. in the case of evaluating log prob
         # of a value simulated using a large step size for a constrained sample site).
         direction = 1 if self._direction_threshold < -delta_energy else -1
-        #print("aa", energy_current)
+
         # define scale for step_size: 2 for increasing, 1/2 for decreasing
         step_size_scale = 2 ** direction
         direction_new = direction
@@ -300,7 +300,7 @@ class HMC(TraceKernel):
             if not torch_isnan(trace_log_prob_sum) and not torch_isinf(trace_log_prob_sum):
                 self._initial_trace = trace
                 return trace
-            trace = poutine.trace(self.model).get_trace(*self._args, *self._kwargs)
+            trace = poutine.trace(self.model).get_trace(*self._args, **self._kwargs)
         raise ValueError("Model specification seems incorrect - cannot find a valid trace.")
 
     @initial_trace.setter

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -156,7 +156,6 @@ class NUTS(HMC):
         diverging = (sliced_energy > self._max_sliced_energy)
         delta_energy = energy_new - energy_current
         accept_prob = (-delta_energy).exp().clamp(max=1.0)
-        print("base", accept_prob.detach(), energy_new.detach(), energy_current.detach())
 
         if self.use_multinomial_sampling:
             tree_weight = -sliced_energy
@@ -366,6 +365,7 @@ class NUTS(HMC):
 
         self._t += 1
         # get trace with the constrained values for `z`.
+        z = z.copy()
         for name, transform in self.transforms.items():
             z[name] = transform.inv(z[name])
         return self._get_trace(z)

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -253,10 +253,6 @@ class NUTS(HMC):
                          sum_accept_probs, num_proposals)
 
     def sample(self, trace):
-        if self._t == 0:
-            # cache for initial trace and reset step size adaptation
-            self._initialize_sampling(trace)
-
         z, potential_energy, z_grads = self._fetch_from_cache()
         r, r_flat = self._sample_r(name="r_t={}".format(self._t))
         energy_current = self._kinetic_energy(r) + potential_energy
@@ -292,7 +288,7 @@ class NUTS(HMC):
         accepted = False
         r_sum = r_flat
         sum_accept_probs = 0.
-        num_proposals = 0.
+        num_proposals = 0
         if self.use_multinomial_sampling:
             tree_weight = energy_current.new_zeros(())
         else:
@@ -350,14 +346,10 @@ class NUTS(HMC):
                     else:
                         tree_weight = tree_weight + new_tree.weight
 
-        accept_prob = sum_accept_probs / num_proposals
         if self._t < self._warmup_steps:
+            accept_prob = sum_accept_probs / num_proposals
             self._adapter.step(self._t, z, accept_prob)
-        print("\n")
-        print(self.step_size, tree_depth, accept_prob.detach(),
-              self._potential_energy_last.detach())
-        print(self.inverse_mass_matrix)
-        print("------------------------")
+
         if accepted:
             self._accept_cnt += 1
 

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -174,6 +174,7 @@ class NUTS(HMC):
     def _build_tree(self, z, r, z_grads, log_slice, direction, tree_depth, energy_current):
         if tree_depth == 0:
             return self._build_basetree(z, r, z_grads, log_slice, direction, energy_current)
+
         # build the first half of tree
         half_tree = self._build_tree(z, r, z_grads, log_slice,
                                      direction, tree_depth-1, energy_current)

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -135,8 +135,8 @@ class NUTS(HMC):
         r_left_flat = torch.cat([r_left[site_name].reshape(-1) for site_name in sorted(r_left)])
         r_right_flat = torch.cat([r_right[site_name].reshape(-1) for site_name in sorted(r_right)])
         if self.inverse_mass_matrix.dim() == 2:
-            if (self.inverse_mass_matrix.matmul(r_left_flat).dot(r_sum - r_left_flat) and
-                    self.inverse_mass_matrix.matmul(r_right_flat).dot(r_sum - r_right_flat)):
+            if (self.inverse_mass_matrix.matmul(r_left_flat).dot(r_sum - r_left_flat) > 0 and
+                    self.inverse_mass_matrix.matmul(r_right_flat).dot(r_sum - r_right_flat) > 0):
                 return False
         else:
             if (self.inverse_mass_matrix.mul(r_left_flat).dot(r_sum - r_left_flat) > 0 and
@@ -253,9 +253,6 @@ class NUTS(HMC):
                          sum_accept_probs, num_proposals)
 
     def sample(self, trace):
-        print(self._t + 1)
-        print(self.step_size)
-        print(self.inverse_mass_matrix)
         if self._t == 0:
             # cache for initial trace and reset step size adaptation
             self._initialize_sampling(trace)
@@ -356,9 +353,6 @@ class NUTS(HMC):
         if self._t < self._warmup_steps:
             accept_prob = sum_accept_probs / num_proposals
             self._adapter.step(self._t, z, accept_prob)
-            print("accept_prob", accept_prob.item())
-        print("tree_depth", tree_depth)
-        print("-----------------------")
 
         if accepted:
             self._accept_cnt += 1

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -350,10 +350,14 @@ class NUTS(HMC):
                     else:
                         tree_weight = tree_weight + new_tree.weight
 
+        accept_prob = sum_accept_probs / num_proposals
         if self._t < self._warmup_steps:
-            accept_prob = sum_accept_probs / num_proposals
             self._adapter.step(self._t, z, accept_prob)
-
+        print("\n")
+        print(self.step_size, tree_depth, accept_prob.detach(),
+              self._potential_energy_last.detach())
+        print(self.inverse_mass_matrix)
+        print("------------------------")
         if accepted:
             self._accept_cnt += 1
 

--- a/pyro/ops/dual_averaging.py
+++ b/pyro/ops/dual_averaging.py
@@ -67,7 +67,6 @@ class DualAveraging(object):
         # weight for the new x_t
         weight_t = self._t ** (-self.kappa)
         self._x_avg = (1 - weight_t) * self._x_avg + weight_t * self._x_t
-        print("step", g, self._g_avg, self._x_t, self._x_avg)
 
     def get_state(self):
         r"""

--- a/pyro/ops/dual_averaging.py
+++ b/pyro/ops/dual_averaging.py
@@ -67,6 +67,7 @@ class DualAveraging(object):
         # weight for the new x_t
         weight_t = self._t ** (-self.kappa)
         self._x_avg = (1 - weight_t) * self._x_avg + weight_t * self._x_t
+        print("step", g, self._g_avg, self._x_t, self._x_avg)
 
     def get_state(self):
         r"""

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -272,7 +272,7 @@ def test_initial_trace(monkeypatch):
     true_coefs = torch.arange(1., dim + 1.)
     labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
     # mock values to replay - from right to left
-    trace_log_prob_replay = [-5, float('NaN'), float('Inf')]
+    trace_log_prob_replay = [-5, -5, float('NaN'), float('Inf')]
 
     def model(data):
         coefs_mean = torch.zeros(dim)


### PR DESCRIPTION
This PR tries to resolve #1673 by setting a high prox_center value during the first window_adaptation. 

In addition, this also fixes some bugs:

- Missing cache for HMC. Not sure why HMC tests passed previously.
- Better definition of tree_depth (for debugging)
- Feed python float into DualAveraging scheme. Previously it is a mixed of float and tensor_scalar, which in turns forces `step_size` be a tensor_scalar, not float.

More details are in comments.

Todo:

- [x] Clean the PR (lots of printing are added for debugging)