### PR TITLE
Expose target_accept_prob and max_tree_depth for HMC/NUTS

### DIFF
--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -26,7 +26,7 @@ class WarmupAdapter(object):
                  is_diag_mass=True):
         self.adapt_step_size = adapt_step_size
         self.adapt_mass_matrix = adapt_mass_matrix
-        self.target_accept_prob = 0.8 if target_accept_prob is None else target_accept_prob
+        self.target_accept_prob = target_accept_prob
         self.is_diag_mass = is_diag_mass
         self.step_size = 1 if step_size is None else step_size
         self._adaptation_disabled = not (adapt_step_size or adapt_mass_matrix)

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -26,9 +26,9 @@ class WarmupAdapter(object):
                  is_diag_mass=True):
         self.adapt_step_size = adapt_step_size
         self.adapt_mass_matrix = adapt_mass_matrix
-        self.target_accept_prob = target_accept_prob
+        self.target_accept_prob = target_accept_prob if target_accept_prob is None else target_accept_prob
         self.is_diag_mass = is_diag_mass
-        self.step_size = step_size if step_size is not None else 1
+        self.step_size = step_size if step_size is None else step_size
         self._adaptation_disabled = not (adapt_step_size or adapt_mass_matrix)
         if adapt_step_size:
             self._step_size_adapt_scheme = DualAveraging()

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -26,7 +26,7 @@ class WarmupAdapter(object):
                  is_diag_mass=True):
         self.adapt_step_size = adapt_step_size
         self.adapt_mass_matrix = adapt_mass_matrix
-        self.target_accept_prob = target_accept_prob if target_accept_prob is None else target_accept_prob
+        self.target_accept_prob = 0.8 if target_accept_prob is None else target_accept_prob
         self.is_diag_mass = is_diag_mass
         self.step_size = step_size if step_size is None else step_size
         self._adaptation_disabled = not (adapt_step_size or adapt_mass_matrix)

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -28,7 +28,7 @@ class WarmupAdapter(object):
         self.adapt_mass_matrix = adapt_mass_matrix
         self.target_accept_prob = 0.8 if target_accept_prob is None else target_accept_prob
         self.is_diag_mass = is_diag_mass
-        self.step_size = step_size if step_size is None else step_size
+        self.step_size = 1 if step_size is None else step_size
         self._adaptation_disabled = not (adapt_step_size or adapt_mass_matrix)
         if adapt_step_size:
             self._step_size_adapt_scheme = DualAveraging()

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -98,7 +98,7 @@ class HMC(TraceKernel):
                  max_plate_nesting=None,
                  jit_compile=False,
                  ignore_jit_warnings=False,
-                 target_accept_prob=None):
+                 target_accept_prob=0.8):
         self.model = model
         self.max_plate_nesting = max_plate_nesting
         if trajectory_length is not None:

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -59,6 +59,8 @@ class HMC(TraceKernel):
         optimized executable trace in the integrator.
     :param bool ignore_jit_warnings: Flag to ignore warnings from the JIT
         tracer when ``jit_compile=True``. Default is False.
+    :param float target_accept_prob: Increasing this value will lead to a smaller
+        step size, hence the sampling will be slower and more robust. Default to 0.8.
 
     .. note:: Internally, the mass matrix will be ordered according to the order
         of the names of latent variables, not the order of their appearance in
@@ -95,7 +97,8 @@ class HMC(TraceKernel):
                  transforms=None,
                  max_plate_nesting=None,
                  jit_compile=False,
-                 ignore_jit_warnings=False):
+                 ignore_jit_warnings=False,
+                 target_accept_prob=None):
         self.model = model
         self.max_plate_nesting = max_plate_nesting
         if trajectory_length is not None:
@@ -106,7 +109,6 @@ class HMC(TraceKernel):
             self.trajectory_length = 2 * math.pi  # from Stan
         self._jit_compile = jit_compile
         self._ignore_jit_warnings = ignore_jit_warnings
-        self._target_accept_prob = 0.8  # from Stan
         # The following parameter is used in find_reasonable_step_size method.
         # In NUTS paper, this threshold is set to a fixed log(0.5).
         # After https://github.com/stan-dev/stan/pull/356, it is set to a fixed log(0.8).
@@ -119,6 +121,7 @@ class HMC(TraceKernel):
         self._adapter = WarmupAdapter(step_size,
                                       adapt_step_size=adapt_step_size,
                                       adapt_mass_matrix=adapt_mass_matrix,
+                                      target_accept_prob=target_accept_prob,
                                       is_diag_mass=not full_mass)
         super(HMC, self).__init__()
 

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -244,7 +244,7 @@ class MCMC(TracePosterior):
         CUDA.
     :param bool disable_progbar: Disable progress bar and diagnostics update.
     """
-    def __init__(self, kernel, num_samples, warmup_steps=0,
+    def __init__(self, kernel, num_samples, warmup_steps=None,
                  num_chains=1, mp_context=None, disable_progbar=False):
         self.warmup_steps = warmup_steps if warmup_steps is not None else num_samples // 2  # Stan
         self.num_samples = num_samples
@@ -257,10 +257,10 @@ class MCMC(TracePosterior):
                               .format(num_chains, available_cpu))
                 num_chains = available_cpu
         if num_chains > 1:
-            self.sampler = _ParallelSampler(kernel, num_samples, warmup_steps,
+            self.sampler = _ParallelSampler(kernel, num_samples, self.warmup_steps,
                                             num_chains, mp_context, disable_progbar)
         else:
-            self.sampler = _SingleSampler(kernel, num_samples, warmup_steps, disable_progbar)
+            self.sampler = _SingleSampler(kernel, num_samples, self.warmup_steps, disable_progbar)
         super(MCMC, self).__init__(num_chains=num_chains)
 
     def _traces(self, *args, **kwargs):
@@ -276,11 +276,14 @@ class MCMCMarginals(Marginals):
         if self._diagnostics:
             return self._diagnostics
         for site in self.sites:
+            support = self.support()[site]
+            if self._trace_posterior.num_chains == 1:
+                support = support.unsqueeze(0)
             site_stats = OrderedDict()
             try:
-                site_stats["n_eff"] = stats.effective_sample_size(self.support()[site])
+                site_stats["n_eff"] = stats.effective_sample_size(support)
             except NotImplementedError:
                 site_stats["n_eff"] = torch.tensor(float('nan'))
-            site_stats["r_hat"] = stats.split_gelman_rubin(self.support()[site])
+            site_stats["r_hat"] = stats.split_gelman_rubin(support)
             self._diagnostics[site] = site_stats
         return self._diagnostics

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -75,6 +75,11 @@ class NUTS(HMC):
     :param bool jit_compile: Optional parameter denoting whether to use
         the PyTorch JIT to trace the log density computation, and use this
         optimized executable trace in the integrator.
+    :param float target_accept_prob: Target acceptance probability of step size
+        adaptation scheme. Increasing this value will lead to a smaller step size,
+        so the sampling will be slower but more robust. Default to 0.8.
+    :param int max_tree_depth: Max depth of the binary tree created during the doubling
+        scheme of NUTS sampler. Default to 10.
 
     Example:
 
@@ -106,7 +111,9 @@ class NUTS(HMC):
                  transforms=None,
                  max_plate_nesting=None,
                  jit_compile=False,
-                 ignore_jit_warnings=False):
+                 ignore_jit_warnings=False,
+                 target_accept_prob=None,
+                 max_tree_depth=None):
         super(NUTS, self).__init__(model,
                                    step_size,
                                    adapt_step_size=adapt_step_size,
@@ -115,9 +122,10 @@ class NUTS(HMC):
                                    transforms=transforms,
                                    max_plate_nesting=max_plate_nesting,
                                    jit_compile=jit_compile,
-                                   ignore_jit_warnings=ignore_jit_warnings)
+                                   ignore_jit_warnings=ignore_jit_warnings,
+                                   target_accept_prob=target_accept_prob)
         self.use_multinomial_sampling = use_multinomial_sampling
-        self._max_tree_depth = 10  # from Stan
+        self._max_tree_depth = 10 if max_tree_depth is None else max_tree_depth  # from Stan
         # There are three conditions to stop doubling process:
         #     + Tree is becoming too big.
         #     + The trajectory is making a U-turn.

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -112,8 +112,8 @@ class NUTS(HMC):
                  max_plate_nesting=None,
                  jit_compile=False,
                  ignore_jit_warnings=False,
-                 target_accept_prob=None,
-                 max_tree_depth=None):
+                 target_accept_prob=0.8,
+                 max_tree_depth=10):
         super(NUTS, self).__init__(model,
                                    step_size,
                                    adapt_step_size=adapt_step_size,
@@ -125,7 +125,7 @@ class NUTS(HMC):
                                    ignore_jit_warnings=ignore_jit_warnings,
                                    target_accept_prob=target_accept_prob)
         self.use_multinomial_sampling = use_multinomial_sampling
-        self._max_tree_depth = 10 if max_tree_depth is None else max_tree_depth  # from Stan
+        self._max_tree_depth = max_tree_depth
         # There are three conditions to stop doubling process:
         #     + Tree is becoming too big.
         #     + The trajectory is making a U-turn.


### PR DESCRIPTION
Address some minor issues at #1093: expose target_accept_prob and max_tree_depth

There are a few small silent bugs which are also fixed in this PR. I'll comment at them.
