### PR TITLE
Fix initial trace get NaN energy

### DIFF
--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -146,7 +146,7 @@ class Trace(networkx.DiGraph):
                     if is_validation_enabled():
                         warn_if_nan(log_p, "log_prob_sum at site '{}'".format(name))
                         warn_if_inf(log_p, "log_prob_sum at site '{}'".format(name), allow_neginf=True)
-                result += log_p
+                result = result + log_p
         return result
 
     def compute_log_prob(self, site_filter=lambda name, site: True):


### PR DESCRIPTION
In initial_trace method, we only check for NaN of log_prob_sum in constrained space. Sometimes, after transformed to unconstrained space, latent variables will get NaN values, which in turn makes initial_trace's potential energy get NaN value.

This PR prevents that case by only selecting traces with non-NaN potential energy.

I also want to take this chance to incorporate the fix of @eb8680 for #1685.