### PR TITLE
Fix make doctest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ scrub: FORCE
 	find tutorial -name "*.ipynb" | xargs python tutorial/source/cleannb.py
 
 doctest: FORCE
-	pytest -p tests.doctest_fixtures --doctest-modules -o filterwarnings=ignore pyro
+	python -m pytest -p tests.doctest_fixtures --doctest-modules -o filterwarnings=ignore pyro
 
 format: FORCE
 	isort --recursive *.py pyro/ examples/ tests/ profiler/*.py docs/source/conf.py


### PR DESCRIPTION
It has been a while that I can't run doctest locally. Somehow we have to tell pytest to add current directory to PYTHONPATH to load plugin. Travis already did that at https://github.com/uber/pyro/blob/dev/.travis.yml#L7 so there is no error in Travis.