### PR TITLE
Supporting multi-chain mcmc with cuda tensors

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -247,8 +247,9 @@ def main(args):
     nuts_kernel = NUTS(fully_pooled)
     posterior_fully_pooled = MCMC(nuts_kernel,
                                   num_samples=args.num_samples,
-                                  warmup_steps=args.warmup_steps, mp_context="spawn",
-                                  num_chains=args.num_chains).run(at_bats, hits)
+                                  warmup_steps=args.warmup_steps,
+                                  num_chains=args.num_chains,
+                                  mp_context=args.mp_context).run(at_bats, hits)
     logging.info("\nModel: Fully Pooled")
     logging.info("===================")
     logging.info("\nphi:")
@@ -264,7 +265,8 @@ def main(args):
     posterior_not_pooled = MCMC(nuts_kernel,
                                 num_samples=args.num_samples,
                                 warmup_steps=args.warmup_steps,
-                                num_chains=args.num_chains).run(at_bats, hits)
+                                num_chains=args.num_chains,
+                                mp_context=args.mp_context).run(at_bats, hits)
     logging.info("\nModel: Not Pooled")
     logging.info("=================")
     logging.info("\nphi:")
@@ -282,7 +284,8 @@ def main(args):
         posterior_partially_pooled = MCMC(nuts_kernel,
                                           num_samples=args.num_samples,
                                           warmup_steps=args.warmup_steps,
-                                          num_chains=args.num_chains).run(at_bats, hits)
+                                          num_chains=args.num_chains,
+                                          mp_context=args.mp_context).run(at_bats, hits)
         logging.info("\nModel: Partially Pooled")
         logging.info("=======================")
         logging.info("\nphi:")
@@ -299,7 +302,8 @@ def main(args):
     posterior_partially_pooled_with_logit = MCMC(nuts_kernel,
                                                  num_samples=args.num_samples,
                                                  warmup_steps=args.warmup_steps,
-                                                 num_chains=args.num_chains).run(at_bats, hits)
+                                                 num_chains=args.num_chains,
+                                                 mp_context=args.mp_context).run(at_bats, hits)
     logging.info("\nModel: Partially Pooled with Logit")
     logging.info("==================================")
     logging.info("\nSigmoid(alpha):")
@@ -321,8 +325,14 @@ if __name__ == "__main__":
     parser.add_argument("--num-chains", nargs='?', default=4, type=int)
     parser.add_argument("--warmup-steps", nargs='?', default=100, type=int)
     parser.add_argument("--rng_seed", nargs='?', default=0, type=int)
-    parser.add_argument('--jit', action='store_true', default=False,
-                        help='use PyTorch jit')
+    parser.add_argument("--jit", action="store_true", default=False,
+                        help="use PyTorch jit")
+    parser.add_argument("--cuda", action="store_true", default=False,
+                        help="run this example in GPU")
     args = parser.parse_args()
-    torch.set_default_tensor_type(torch.cuda.FloatTensor)
+
+    args.mp_context = None  # use default multiprocessing context
+    if args.cuda:
+        torch.set_default_tensor_type(torch.cuda.FloatTensor)
+        args.mp_context = "spawn"
     main(args)

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -325,10 +325,10 @@ if __name__ == "__main__":
 
     # work around with the error "RuntimeError: received 0 items of ancdata"
     # see https://discuss.pytorch.org/t/received-0-items-of-ancdata-pytorch-0-4-0/19823
-    torch.multiprocessing.set_sharing_strategy('file_system')
+    torch.multiprocessing.set_sharing_strategy("file_system")
 
     if args.cuda:
         torch.set_default_tensor_type(torch.cuda.FloatTensor)
-        torch.multiprocessing.set_start_method("spawn")
+        torch.multiprocessing.set_start_method("spawn", force=True)
 
     main(args)

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import argparse
 import logging
 import math
-import os
 
 import pandas as pd
 import torch
@@ -163,11 +162,11 @@ def summary(trace_posterior, sites, player_names, transforms={}, diagnostics=Tru
         if site_name in transforms:
             marginal_site = transforms[site_name](marginal_site)
 
-        site_stats[site_name] = get_site_stats(marginal_site.numpy(), player_names)
+        site_stats[site_name] = get_site_stats(marginal_site.cpu().numpy(), player_names)
         if diagnostics and trace_posterior.num_chains > 1:
             diag = marginal.diagnostics()[site_name]
-            site_stats[site_name] = site_stats[site_name].assign(n_eff=diag["n_eff"].numpy(),
-                                                                 r_hat=diag["r_hat"].numpy())
+            site_stats[site_name] = site_stats[site_name].assign(n_eff=diag["n_eff"].cpu().numpy(),
+                                                                 r_hat=diag["r_hat"].cpu().numpy())
     return site_stats
 
 
@@ -176,8 +175,9 @@ def train_test_split(pd_dataframe):
     Training data - 45 initial at-bats and hits for each player.
     Validation data - Full season at-bats and hits for each player.
     """
-    train_data = torch.tensor(pd_dataframe[["At-Bats", "Hits"]].values, dtype=torch.float)
-    test_data = torch.tensor(pd_dataframe[["SeasonAt-Bats", "SeasonHits"]].values, dtype=torch.float)
+    device = torch.Tensor().device
+    train_data = torch.tensor(pd_dataframe[["At-Bats", "Hits"]].values, dtype=torch.float, device=device)
+    test_data = torch.tensor(pd_dataframe[["SeasonAt-Bats", "SeasonHits"]].values, dtype=torch.float, device=device)
     first_name = pd_dataframe["FirstName"].values
     last_name = pd_dataframe["LastName"].values
     player_names = [" ".join([first, last]) for first, last in zip(first_name, last_name)]
@@ -278,24 +278,22 @@ def main(args):
     evaluate_log_predictive_density(posterior_predictive, baseball_dataset)
 
     # (3) Partially Pooled Model
-    # TODO: remove once htps://github.com/uber/pyro/issues/1458 is resolved
-    if "CI" not in os.environ:
-        nuts_kernel = NUTS(partially_pooled)
-        posterior_partially_pooled = MCMC(nuts_kernel,
-                                          num_samples=args.num_samples,
-                                          warmup_steps=args.warmup_steps,
-                                          num_chains=args.num_chains,
-                                          mp_context=args.mp_context).run(at_bats, hits)
-        logging.info("\nModel: Partially Pooled")
-        logging.info("=======================")
-        logging.info("\nphi:")
-        logging.info(summary(posterior_partially_pooled, sites=["phi"],
-                             player_names=player_names)["phi"])
-        posterior_predictive = TracePredictive(partially_pooled,
-                                               posterior_partially_pooled,
-                                               num_samples=num_predictive_samples)
-        sample_posterior_predictive(posterior_predictive, baseball_dataset)
-        evaluate_log_predictive_density(posterior_predictive, baseball_dataset)
+    nuts_kernel = NUTS(partially_pooled)
+    posterior_partially_pooled = MCMC(nuts_kernel,
+                                      num_samples=args.num_samples,
+                                      warmup_steps=args.warmup_steps,
+                                      num_chains=args.num_chains,
+                                      mp_context=args.mp_context).run(at_bats, hits)
+    logging.info("\nModel: Partially Pooled")
+    logging.info("=======================")
+    logging.info("\nphi:")
+    logging.info(summary(posterior_partially_pooled, sites=["phi"],
+                         player_names=player_names)["phi"])
+    posterior_predictive = TracePredictive(partially_pooled,
+                                           posterior_partially_pooled,
+                                           num_samples=num_predictive_samples)
+    sample_posterior_predictive(posterior_predictive, baseball_dataset)
+    evaluate_log_predictive_density(posterior_predictive, baseball_dataset)
 
     # (4) Partially Pooled with Logit Model
     nuts_kernel = NUTS(partially_pooled_with_logit)

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -247,7 +247,7 @@ def main(args):
     nuts_kernel = NUTS(fully_pooled)
     posterior_fully_pooled = MCMC(nuts_kernel,
                                   num_samples=args.num_samples,
-                                  warmup_steps=args.warmup_steps,
+                                  warmup_steps=args.warmup_steps, mp_context="spawn",
                                   num_chains=args.num_chains).run(at_bats, hits)
     logging.info("\nModel: Fully Pooled")
     logging.info("===================")
@@ -324,4 +324,5 @@ if __name__ == "__main__":
     parser.add_argument('--jit', action='store_true', default=False,
                         help='use PyTorch jit')
     args = parser.parse_args()
+    torch.set_default_tensor_type(torch.cuda.FloatTensor)
     main(args)

--- a/pyro/infer/mcmc/__init__.py
+++ b/pyro/infer/mcmc/__init__.py
@@ -1,10 +1,12 @@
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.mcmc import MCMC, MCMCMarginals
+from pyro.infer.mcmc.mcmc1 import MCMC1
 from pyro.infer.mcmc.nuts import NUTS
 
 __all__ = [
     "HMC",
     "MCMC",
+    "MCMC1",
     "MCMCMarginals",
     "NUTS",
 ]

--- a/pyro/infer/mcmc/__init__.py
+++ b/pyro/infer/mcmc/__init__.py
@@ -1,12 +1,10 @@
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.mcmc import MCMC, MCMCMarginals
-from pyro.infer.mcmc.mcmc1 import MCMC1
 from pyro.infer.mcmc.nuts import NUTS
 
 __all__ = [
     "HMC",
     "MCMC",
-    "MCMC1",
     "MCMCMarginals",
     "NUTS",
 ]

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -408,7 +408,8 @@ class HMC(TraceKernel):
             accept_prob = delta_energy.new_tensor(0.0)
         else:
             accept_prob = (-delta_energy).exp().clamp(max=1.)
-        rand = pyro.sample("rand_t={}".format(self._t), dist.Uniform(torch.zeros(1), torch.ones(1)))
+        rand = pyro.sample("rand_t={}".format(self._t), dist.Uniform(accept_prob.new_tensor(0.),
+                                                                     accept_prob.new_tensor(1.)))
         if rand < accept_prob:
             self._accept_cnt += 1
             z = z_new

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -66,7 +66,7 @@ def logger_thread(log_queue, warmup_steps, num_samples, num_chains, disable_prog
 
 
 class _Worker(object):
-    def __init__(self, chain_id, result_queue, log_queue,
+    def __init__(self, chain_id, result_queue, log_queue, event,
                  kernel, num_samples, warmup_steps=0,
                  args=None, kwargs=None):
         self.chain_id = chain_id
@@ -78,6 +78,7 @@ class _Worker(object):
         self.log_queue = log_queue
         self.result_queue = result_queue
         self.default_tensor_type = torch.Tensor().type()
+        self.event = event
 
     def run(self, *args, **kwargs):
         pyro.set_rng_seed((self.chain_id + self.rng_seed) % MAX_SEED)
@@ -87,6 +88,8 @@ class _Worker(object):
         try:
             for sample in self.trace_gen._traces(*args, **kwargs):
                 self.result_queue.put_nowait((self.chain_id, sample))
+                self.event.wait()
+                self.event.clear()
             self.result_queue.put_nowait((self.chain_id, None))
         except Exception as e:
             self.trace_gen.logger.exception(e)
@@ -121,11 +124,12 @@ class _ParallelSampler(TracePosterior):
                                                  self.num_chains, disable_progbar))
         self.log_thread.daemon = True
         self.log_thread.start()
+        self.events = [self.ctx.Event() for i in range(num_chains)]
 
     def init_workers(self, *args, **kwargs):
         self.workers = []
         for i in range(self.num_chains):
-            worker = _Worker(i, self.result_queue, self.log_queue, self.kernel,
+            worker = _Worker(i, self.result_queue, self.log_queue, self.events[i], self.kernel,
                              self.num_samples, self.warmup_steps)
             worker.daemon = True
             self.workers.append(self.ctx.Process(name=str(i), target=worker.run,
@@ -153,13 +157,7 @@ class _ParallelSampler(TracePosterior):
             while active_workers:
                 try:
                     chain_id, val = self.result_queue.get(timeout=5)
-                # This can happen when the worker process has terminated.
-                # See https://github.com/pytorch/pytorch/pull/5380 for motivation.
-                except socket.error as e:
-                    if getattr(e, "errno", None) == errno.ENOENT:
-                        pass
-                    else:
-                        raise e
+                    self.events[chain_id].set()
                 except queue.Empty:
                     continue
                 if isinstance(val, Exception):

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -157,7 +157,7 @@ class _ParallelSampler(TracePosterior):
             while active_workers:
                 try:
                     chain_id, val = self.result_queue.get(timeout=5)
-                    self.events[i].set()
+                    self.events[chain_id].set()
                 # This can happen when the worker process has terminated.
                 # See https://github.com/pytorch/pytorch/pull/5380 for motivation.
                 except socket.error as e:

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-import errno
 import json
 import logging
 import signal
-import socket
 import sys
 import threading
 import warnings

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -88,6 +88,15 @@ class _Worker(object):
         kwargs["logger_id"] = "CHAIN:{}".format(self.chain_id)
         kwargs["log_queue"] = self.log_queue
         try:
+            # XXX to make MCMC work on GPU, we need to store generated samples in a list
+            # until this process is terminated or the main process sends a signal to clear
+            # the list.
+            # The following code will make MCMC work in GPU:
+            #
+            # samples = []
+            # for sample in self.trace_gen._traces(*args, **kwargs):
+            #     samples.append(sample)
+            # ...
             for sample in self.trace_gen._traces(*args, **kwargs):
                 self.result_queue.put_nowait((self.chain_id, sample))
                 self.event.wait()

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -66,7 +66,7 @@ def logger_thread(log_queue, warmup_steps, num_samples, num_chains, disable_prog
 
 
 class _Worker(object):
-    def __init__(self, chain_id, result_queue, log_queue,
+    def __init__(self, chain_id, result_queue, log_queue, event,
                  kernel, num_samples, warmup_steps=0,
                  args=None, kwargs=None):
         self.chain_id = chain_id
@@ -78,6 +78,7 @@ class _Worker(object):
         self.log_queue = log_queue
         self.result_queue = result_queue
         self.default_tensor_type = torch.Tensor().type()
+        self.event = event
 
     def run(self, *args, **kwargs):
         pyro.set_rng_seed((self.chain_id + self.rng_seed) % MAX_SEED)
@@ -87,6 +88,8 @@ class _Worker(object):
         try:
             for sample in self.trace_gen._traces(*args, **kwargs):
                 self.result_queue.put_nowait((self.chain_id, sample))
+                self.event.wait()
+                self.event.clear()
             self.result_queue.put_nowait((self.chain_id, None))
         except Exception as e:
             self.trace_gen.logger.exception(e)
@@ -121,11 +124,12 @@ class _ParallelSampler(TracePosterior):
                                                  self.num_chains, disable_progbar))
         self.log_thread.daemon = True
         self.log_thread.start()
+        self.events = [self.ctx.Event() for i in range(num_chains)]
 
     def init_workers(self, *args, **kwargs):
         self.workers = []
         for i in range(self.num_chains):
-            worker = _Worker(i, self.result_queue, self.log_queue, self.kernel,
+            worker = _Worker(i, self.result_queue, self.log_queue, self.events[i], self.kernel,
                              self.num_samples, self.warmup_steps)
             worker.daemon = True
             self.workers.append(self.ctx.Process(name=str(i), target=worker.run,
@@ -153,6 +157,7 @@ class _ParallelSampler(TracePosterior):
             while active_workers:
                 try:
                     chain_id, val = self.result_queue.get(timeout=5)
+                    self.events[i].set()
                 # This can happen when the worker process has terminated.
                 # See https://github.com/pytorch/pytorch/pull/5380 for motivation.
                 except socket.error as e:

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -317,7 +317,7 @@ class NUTS(HMC):
             tree_depth = 0
             while tree_depth < self._max_tree_depth:
                 direction = pyro.sample("direction_t={}_treedepth={}".format(self._t, tree_depth),
-                                        dist.Bernoulli(probs=torch.ones(1) * 0.5))
+                                        dist.Bernoulli(probs=tree_weight.new_tensor(0.5)))
                 direction = int(direction.item())
                 if direction == 1:  # go to the right, start from the right leaf of current tree
                     new_tree = self._build_tree(z_right, r_right, z_right_grads, log_slice,

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -63,7 +63,7 @@ def test_mcmc_diagnostics(num_chains):
     data = torch.tensor([2.0]).repeat(3)
     kernel = PriorKernel(normal_normal_model)
     mp_context = "spawn" if data.is_cuda else None
-    mcmc = MCMC(kernel=kernel, num_samples=5, num_chains=num_chains, mp_context=mp_context).run(data)
+    mcmc = MCMC(kernel=kernel, num_samples=10, num_chains=num_chains, mp_context=mp_context).run(data)
     diagnostics = mcmc.marginal(["y"]).diagnostics()
     assert diagnostics["y"]["n_eff"].shape == data.shape
     assert diagnostics["y"]["r_hat"].shape == data.shape

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -37,7 +37,7 @@ class PriorKernel(TraceKernel):
 
 
 def normal_normal_model(data):
-    x = pyro.param('loc', torch.tensor([0.0]))
+    x = torch.tensor([0.0])
     y = pyro.sample('y', dist.Normal(x, torch.tensor([1.0])))
     pyro.sample('obs', dist.Normal(y, torch.tensor([1.0])), obs=data)
     return y
@@ -57,8 +57,7 @@ def test_mcmc_interface():
 
 @pytest.mark.parametrize("num_chains", [
     1,
-    pytest.param(2, marks=[pytest.mark.skipif("CI" in os.environ, reason="CI only provides 1 CPU"),
-                           pytest.mark.skip(reason="https://github.com/uber/pyro/issues/1699")])
+    pytest.param(2, marks=[pytest.mark.skipif("CI" in os.environ, reason="CI only provides 1 CPU")])
 ])
 def test_mcmc_diagnostics(num_chains):
     data = torch.tensor([1.0])

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -38,7 +38,7 @@ class PriorKernel(TraceKernel):
 
 def normal_normal_model(data):
     x = torch.tensor([0.0])
-    y = pyro.sample('y', dist.Normal(x, torch.tensor([1.0])))
+    y = pyro.sample('y', dist.Normal(x, torch.ones(data.shape)))
     pyro.sample('obs', dist.Normal(y, torch.tensor([1.0])), obs=data)
     return y
 
@@ -60,12 +60,13 @@ def test_mcmc_interface():
     pytest.param(2, marks=[pytest.mark.skipif("CI" in os.environ, reason="CI only provides 1 CPU")])
 ])
 def test_mcmc_diagnostics(num_chains):
-    data = torch.tensor([1.0])
+    data = torch.tensor([2.0]).repeat(3)
     kernel = PriorKernel(normal_normal_model)
-    mcmc = MCMC(kernel=kernel, num_samples=10, num_chains=num_chains).run(data)
+    mp_context = "spawn" if data.is_cuda else None
+    mcmc = MCMC(kernel=kernel, num_samples=5, num_chains=num_chains, mp_context=mp_context).run(data)
     diagnostics = mcmc.marginal(["y"]).diagnostics()
-    assert diagnostics["y"]["n_eff"].shape == torch.Size([1])
-    assert diagnostics["y"]["r_hat"].shape == torch.Size([1])
+    assert diagnostics["y"]["n_eff"].shape == data.shape
+    assert diagnostics["y"]["r_hat"].shape == data.shape
 
 
 @pytest.mark.parametrize("num_chains, cpu_count", [

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -62,6 +62,7 @@ CPU_EXAMPLES = [
 CUDA_EXAMPLES = [
     'air/main.py --num-steps=1 --cuda',
     'bayesian_regression.py --num-epochs=1 --cuda',
+    'baseball.py --num-samples=200 --warmup-steps=100 --num-chains=2 --cuda',
     'contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --cuda',
     'dmm/dmm.py --num-epochs=1 --cuda',
     'dmm/dmm.py --num-epochs=1 --num-iafs=1 --cuda',


### PR DESCRIPTION
This PR is just used for discussion with @neerajprad .

Hi Neeraj, I added events to workers in ParallelSampler so we can solve the problem at https://discuss.pytorch.org/t/cuda-tensors-on-multiprocessing-queue/28626.

However, there is also another problem: [Invalid device pointer](https://discuss.pytorch.org/t/invalid-device-pointer-using-multiprocessing-with-cuda/28023).

After debugging, I noticed that if we clone `args` and `kwargs` in the returned `trace` of each mcmc step, then this error will go away. Of course, if we only put `z` (instead of trace) to the Queue (by returning `z` at the `sample()` method of HMC/NUTS), and get_trace from z retrieved from Queue, things will be fine (_note that because we cache (z, pe, grad), we don't need to use previous trace for the next sampling step_). However, it will add overhead to the workers: paused workers have to wait for get_trace from z of the current worker.

Maybe I am missing something so I make PR to discuss with you about solutions. :)