### PR TITLE
Add argument jit_optimize for hmc/nuts

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -59,6 +59,8 @@ class HMC(TraceKernel):
         optimized executable trace in the integrator.
     :param bool ignore_jit_warnings: Flag to ignore warnings from the JIT
         tracer when ``jit_compile=True``. Default is False.
+    :param bool jit_optimize: Optional parameter denoting whether to enable
+        ``optimize`` flag for PyTorch JIT. Defaults to True.
     :param float target_accept_prob: Increasing this value will lead to a smaller
         step size, hence the sampling will be slower and more robust. Default to 0.8.
 
@@ -98,6 +100,7 @@ class HMC(TraceKernel):
                  max_plate_nesting=None,
                  jit_compile=False,
                  ignore_jit_warnings=False,
+                 jit_optimize=True,
                  target_accept_prob=0.8):
         self.model = model
         self.max_plate_nesting = max_plate_nesting
@@ -109,6 +112,7 @@ class HMC(TraceKernel):
             self.trajectory_length = 2 * math.pi  # from Stan
         self._jit_compile = jit_compile
         self._ignore_jit_warnings = ignore_jit_warnings
+        self._jit_optimize = jit_optimize
         # The following parameter is used in find_reasonable_step_size method.
         # In NUTS paper, this threshold is set to a fixed log(0.5).
         # After https://github.com/stan-dev/stan/pull/356, it is set to a fixed log(0.8).
@@ -187,7 +191,8 @@ class HMC(TraceKernel):
             return potential_energy
 
         with pyro.validation_enabled(False), optional(ignore_jit_warnings(), self._ignore_jit_warnings):
-            self._compiled_potential_fn = torch.jit.trace(compiled, vals, check_trace=False)
+            self._compiled_potential_fn = torch.jit.trace(compiled, vals, check_trace=False,
+                                                          optimize=self._jit_optimize)
         return self._compiled_potential_fn(*vals)
 
     def _energy(self, z, r):

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -75,6 +75,8 @@ class NUTS(HMC):
     :param bool jit_compile: Optional parameter denoting whether to use
         the PyTorch JIT to trace the log density computation, and use this
         optimized executable trace in the integrator.
+    :param bool jit_optimize: Optional parameter denoting whether to enable
+        ``optimize`` flag for PyTorch JIT. Defaults to True.
     :param float target_accept_prob: Target acceptance probability of step size
         adaptation scheme. Increasing this value will lead to a smaller step size,
         so the sampling will be slower but more robust. Default to 0.8.
@@ -112,6 +114,7 @@ class NUTS(HMC):
                  max_plate_nesting=None,
                  jit_compile=False,
                  ignore_jit_warnings=False,
+                 jit_optimize=True,
                  target_accept_prob=0.8,
                  max_tree_depth=10):
         super(NUTS, self).__init__(model,
@@ -123,6 +126,7 @@ class NUTS(HMC):
                                    max_plate_nesting=max_plate_nesting,
                                    jit_compile=jit_compile,
                                    ignore_jit_warnings=ignore_jit_warnings,
+                                   jit_optimize=jit_optimize,
                                    target_accept_prob=target_accept_prob)
         self.use_multinomial_sampling = use_multinomial_sampling
         self._max_tree_depth = max_tree_depth


### PR DESCRIPTION
This PR adds an optional `jit_optimize` flag to get a deterministic behaviour for using JIT in GPU. (refer #1696 for a context)