### PR TITLE
Add check for pyro.markov history size

### DIFF
--- a/pyro/util.py
+++ b/pyro/util.py
@@ -261,7 +261,13 @@ def check_site_shape(site, max_plate_nesting):
                 '- .to_event(...) the distribution being sampled',
                 '- .permute() data dimensions']))
 
-    # TODO Check parallel dimensions on the left of max_plate_nesting.
+    # Check parallel dimensions on the left of max_plate_nesting.
+    enum_dim = site["infer"].get("_enumerate_dim")
+    if enum_dim is not None:
+        if len(site["fn"].batch_shape) >= -enum_dim and site["fn"].batch_shape[enum_dim] != 1:
+            raise ValueError('\n  '.join([
+                'Enumeration dim conflict at site "{}"'.format(site["name"]),
+                'Try increasing pyro.markov history size']))
 
 
 def _are_independent(counters1, counters2):

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -1556,6 +1556,30 @@ def test_enum_recycling_plate():
     assert_ok(model, guide, TraceEnum_ELBO(max_plate_nesting=2))
 
 
+@pytest.mark.parametrize('history', [0, 1, 2, 3])
+def test_markov_history(history):
+
+    @config_enumerate
+    def model():
+        p = pyro.param("p", 0.25 * torch.ones(2, 2))
+        q = pyro.param("q", 0.25 * torch.ones(2))
+        x_prev = torch.tensor(0)
+        x_curr = torch.tensor(0)
+        for t in pyro.markov(range(10), history=history):
+            probs = p[x_prev, x_curr]
+            x_prev, x_curr = x_curr, pyro.sample("x_{}".format(t), dist.Bernoulli(probs)).long()
+            pyro.sample("y_{}".format(t), dist.Bernoulli(q[x_curr]),
+                        obs=torch.tensor(0.))
+
+    def guide():
+        pass
+
+    if history < 2:
+        assert_error(model, guide, TraceEnum_ELBO(max_plate_nesting=0))
+    else:
+        assert_ok(model, guide, TraceEnum_ELBO(max_plate_nesting=0))
+
+
 def test_mean_field_ok():
 
     def model():

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -1575,7 +1575,8 @@ def test_markov_history(history):
         pass
 
     if history < 2:
-        assert_error(model, guide, TraceEnum_ELBO(max_plate_nesting=0))
+        assert_error(model, guide, TraceEnum_ELBO(max_plate_nesting=0),
+                     match="Enumeration dim conflict")
     else:
         assert_ok(model, guide, TraceEnum_ELBO(max_plate_nesting=0))
 


### PR DESCRIPTION
Resolves #1700 

This checks for conflict between the enumeration dim at any enumerated sample site and previous enumeration dims that may have leaked into this sample site's distribution's parameters. Conflict can happen when a user declares independence using `pyro.markov` (which is used to determine when an enum dim is safe to recycle) but the user does not respect that independence, and writes python code between sample statements whereby an enumerated sample site depends on a site it shouldn't (according to `pyro.markov`). We can detect conflict by comparing `site['infer']['_enumerate_dim']` with `site['fn'].batch_shape`.

In practice, dim conflict was observed to happen in practice when implementing a higher-order HMM without setting `pyro.markov(..., history=n)` for some `n>1`.

## Tested

- added a regression test to test_valid_models.py