### PR TITLE
bump rtd to pytorch 1.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -205,8 +205,4 @@ def setup(app):
 
 # @jpchen's hack to get rtd builder to install latest pytorch
 if 'READTHEDOCS' in os.environ:
-    os.system('pip install http://download.pytorch.org/whl/cpu/torch-0.4.1-cp27-cp27mu-linux_x86_64.whl')
-    # for pytorch 1.0 (currently fails with OOM
-    # https://readthedocs.org/projects/pyro-ppl/builds/8159615/
-#     os.system('pip install torch_nightly==1.0.0.dev20181127 -f '
-#               'https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html')
+    os.system('pip install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp27-cp27mu-linux_x86_64.whl')

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -1,12 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-import os
-
 import torch
 
-if 'READTHEDOCS' not in os.environ:
-    # RTD is running 0.4.1 due to a memory issue with pytorch 1.0
-    assert torch.__version__.startswith('1.')
+assert torch.__version__.startswith('1.')
 
 
 def patch_dependency(target, root_module=torch):


### PR DESCRIPTION
memory issue is resolved so bumping the pytorch version running on rtd.

resolves (this issue)[https://github.com/uber/pyro/pull/1713#discussion_r249939136]